### PR TITLE
Update halucinator repo for avatar2 and avatar-qemu PR (upstream merge, ppc64, mips)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN pip install -e src
 RUN mkdir -p deps/build-qemu/arm-softmmu
 RUN mkdir -p deps/build-qemu/aarch64-softmmu
 RUN mkdir -p deps/build-qemu/ppc-softmmu
+RUN mkdir -p deps/build-qemu/ppc64-softmmu
+RUN mkdir -p deps/build-qemu/mips-softmmu
 # RUN pip install meson
 
 WORKDIR /root/halucinator/deps/build-qemu/arm-softmmu
@@ -53,6 +55,13 @@ WORKDIR /root/halucinator/deps/build-qemu/ppc-softmmu
 RUN /root/halucinator/deps/avatar-qemu/configure --target-list=ppc-softmmu
 RUN make all -j`nproc`
 
+WORKDIR /root/halucinator/deps/build-qemu/mips-softmmu
+RUN /root/halucinator/deps/avatar-qemu/configure --target-list=mips-softmmu
+RUN make all -j`nproc`
+
+WORKDIR /root/halucinator/deps/build-qemu/ppc64-softmmu
+RUN /root/halucinator/deps/avatar-qemu/configure --target-list=ppc64-softmmu
+RUN make all -j`nproc`
 
 WORKDIR  /root/halucinator
 RUN ln -s -T /usr/bin/gdb-multiarch /usr/bin/arm-none-eabi-gdb

--- a/build_qemu.sh
+++ b/build_qemu.sh
@@ -4,7 +4,7 @@
 set -o errexit
 
 if [ "$1" == "" ] ; then
-    TARGET_LIST=("ppc-softmmu" "arm-softmmu" "aarch64-softmmu")
+    TARGET_LIST=("ppc-softmmu" "arm-softmmu" "aarch64-softmmu" "mips-softmmu" "ppc64-softmmu")
 else
     TARGET_LIST=$@
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 # . /etc/bash_completion
 
 if [ "$1" == "" ] ; then
-    TARGET_LIST=("ppc-softmmu" "arm-softmmu" "aarch64-softmmu")
+    TARGET_LIST=("ppc-softmmu" "arm-softmmu" "aarch64-softmmu" "mips-softmmu" "ppc64-softmmu")
 else
     TARGET_LIST=$@
 fi

--- a/src/halucinator/bp_handlers/atmel_asf_v3/ext_interrupt.py
+++ b/src/halucinator/bp_handlers/atmel_asf_v3/ext_interrupt.py
@@ -31,7 +31,7 @@ class EXT_Int(BPHandler, AvatarPeripheral):
     def get_mmio_info(self):
         return self.name, self.address, self.size, 'rw-'
 
-    def hw_read(self, offset, size, pc):
+    def hw_read(self, offset, size, pc, **kwargs):
         value = 0
         if offset == 0x10:  # Set interrupt
             for channel, isr_name in list(self.channel_map.items()):
@@ -42,7 +42,7 @@ class EXT_Int(BPHandler, AvatarPeripheral):
                  (self.address + offset, size, value, hex(pc)))
         return value
 
-    def hw_write(self, offset, size, value, pc):
+    def hw_write(self, offset, size, value, pc, **kwargs):
         log.info("Write to addr, 0x%08x size: %i value: 0x%0x pc:%s" %
                  (self.address + offset, size, value, hex(pc)))
         if offset == 8:  # Clear interrupt

--- a/src/halucinator/bp_handlers/atmel_asf_v3/timers.py
+++ b/src/halucinator/bp_handlers/atmel_asf_v3/timers.py
@@ -40,7 +40,7 @@ class Timers(BPHandler, AvatarPeripheral):
     def get_mmio_info(self):
         return self.name, self.address, self.size, 'rw-'
 
-    def hw_read(self, offset, size, pc):
+    def hw_read(self, offset, size, pc, **kwargs):
         value = 0
 
         if offset == 0x0c0e:  # TC3 INT Reg
@@ -50,7 +50,7 @@ class Timers(BPHandler, AvatarPeripheral):
             self.address + offset, offset, size, value, hex(pc)))
         return value
 
-    def hw_write(self, offset, size, value, pc):
+    def hw_write(self, offset, size, value, pc, **kwargs):
         log.info("Write to addr, 0x%08x size: %i value: 0x%0x, pc: %s" %
                  (self.address + offset, size, value, hex(pc)))
         return True

--- a/src/halucinator/peripheral_models/generic.py
+++ b/src/halucinator/peripheral_models/generic.py
@@ -17,7 +17,7 @@ hal_stats.stats['MMIO_addr_pc'] = set()
 class GenericPeripheral(AvatarPeripheral):
     read_addresses = set()
 
-    def hw_read(self, offset, size, pc=0xBAADBAAD):
+    def hw_read(self, offset, size, pc=0xBAADBAAD, **kwargs):
         log.info("%s: Read from addr, 0x%08x size %i, pc: %s" %
                  (self.name, self.address + offset, size, hex(pc)))
         addr = self.address + offset
@@ -29,7 +29,7 @@ class GenericPeripheral(AvatarPeripheral):
         ret = 0
         return ret
 
-    def hw_write(self, offset, size, value, pc=0xBAADBAAD):
+    def hw_write(self, offset, size, value, pc=0xBAADBAAD, **kwargs):
         log.info("%s: Write to addr: 0x%08x, size: %i, value: 0x%08x, pc %s" % (
             self.name, self.address + offset, size, value, hex(pc)))
         addr = self.address + offset
@@ -53,7 +53,7 @@ class HaltPeripheral(AvatarPeripheral):
         Just halts on first address read/written
     '''
 
-    def hw_read(self, offset, size, pc=0xBAADBAAD):
+    def hw_read(self, offset, size, pc=0xBAADBAAD, **kwargs):
         addr = self.address + offset
         log.info("%s: Read from addr, 0x%08x size %i, pc: %s" %
                  (self.name, addr, size, hex(pc)))
@@ -64,7 +64,7 @@ class HaltPeripheral(AvatarPeripheral):
         while 1:
             pass
 
-    def hw_write(self, offset, size, value, pc=0xBAADBAAD):
+    def hw_write(self, offset, size, value, pc=0xBAADBAAD, **kwargs):
         addr = self.address + offset
         log.info("%s: Write to addr: 0x%08x, size: %i, value: 0x%08x, pc %s" % (
             self.name, addr, size, value, hex(pc)))


### PR DESCRIPTION
# Update HALucinator: Add MIPS & PPC64 QEMU Targets, Harmonize Handler Signatures

## Overview

This update brings the following improvements to the HALucinator repository:

1. **Support for additional QEMU targets**  
   - `mips-softmmu`  
   - `ppc64-softmmu`  
   These are now included in the default build lists and Docker build steps alongside existing ARM, AArch64, and PPC (32-bit) targets.

2. **Unified peripheral handler method signatures**  
   All `hw_read` and `hw_write` methods in:
   - Atmel ASF v3 handlers (`ext_interrupt.py`, `timers.py`)
   - Generic peripheral model (`generic.py`)
   - HaltPeripheral  
   have been updated to accept arbitrary keyword arguments (`**kwargs`), allowing for future context parameters without breaking existing APIs.

---

## Changelog

### `build_qemu.sh` & `setup.sh`

```bash
# Before
TARGET_LIST=("ppc-softmmu" "arm-softmmu" "aarch64-softmmu")

# After
TARGET_LIST=("ppc-softmmu" "arm-softmmu" "aarch64-softmmu" \
             "mips-softmmu" "ppc64-softmmu")
```

### Atmel ASF v3: `ext_interrupt.py` & `timers.py`

```diff
- def hw_read(self, offset, size, pc):
+ def hw_read(self, offset, size, pc, **kwargs):
...
- def hw_write(self, offset, size, value, pc):
+ def hw_write(self, offset, size, value, pc, **kwargs):
```

### Generic Peripheral: `generic.py`

```diff
- def hw_read(self, offset, size, pc=0xBAADBAAD):
+ def hw_read(self, offset, size, pc=0xBAADBAAD, **kwargs):

- def hw_write(self, offset, size, value, pc=0xBAADBAAD):
+ def hw_write(self, offset, size, value, pc=0xBAADBAAD, **kwargs):
```

### Dockerfile

```dockerfile
# Create new build directories
RUN mkdir -p deps/build-qemu/ppc64-softmmu
RUN mkdir -p deps/build-qemu/mips-softmmu

WORKDIR /root/halucinator/deps/build-qemu/mips-softmmu
RUN /root/halucinator/deps/avatar-qemu/configure --target-list=mips-softmmu
RUN make all -j`nproc`

WORKDIR /root/halucinator/deps/build-qemu/ppc64-softmmu
RUN /root/halucinator/deps/avatar-qemu/configure --target-list=ppc64-softmmu
RUN make all -j`nproc`
```
