### PR TITLE
Fix submodule URLs to use absolute paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/avatar2"]
 	path = deps/avatar2
-	url = ../halucinator_avatar2
+	url = https://github.com/halucinator/avatar2.git
 [submodule "deps/avatar-qemu"]
 	path = deps/avatar-qemu
-	url = ../halucinator_avatar-qemu
+	url = https://github.com/halucinator/avatar-qemu.git


### PR DESCRIPTION
The relative submodule paths were failing because the dependent repository names have changed:

- halucinator_avatar2 → avatar2
- halucinator_avatar-qemu → avatar-qemu

This PR updates .gitmodules to use absolute GitHub URLs for these submodules, ensuring they clone correctly.

Please let me know if I made any mistake in the update.

