### PR TITLE
ARM/VxWorks PLC re-host: AT91 peripherals, socket bridge, diagnostics + example

### DIFF
--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -290,6 +290,16 @@ class UnicornBackend(ARMHalMixin, HalBackend):
         self._recover_bad_calls = (
             _os.environ.get("HAL_RECOVER_BAD_CALLS") == "1")
         self._bad_call_recover: Dict[int, int] = {}
+        # MMU flat-fallback (opt-in HAL_MMU_FLAT_FALLBACK=1): on an ARM data/
+        # prefetch abort whose faulting address IS backed in physical memory
+        # (uc.mem_read succeeds — i.e. the MMU translation failed but the page
+        # is present), emulate the faulting load/store flat (VA==PA) and step
+        # past it. Lets MMU-library code that walks page tables not yet mapped
+        # in the active context proceed, where unicorn's CP15/TTBR handling
+        # would otherwise data-abort-loop forever. See _mmu_flat_complete.
+        self._mmu_flat_fallback = (
+            _os.environ.get("HAL_MMU_FLAT_FALLBACK") == "1")
+        self._mmu_flat_count: Dict[int, int] = {}
         self._bp_callbacks: Dict[int, Callable] = {}  # bp_id → callback
         # Pending IRQ injected from another thread (peripheral_server zmq
         # handler). cont() drains the queue before re-entering emu_start
@@ -626,6 +636,123 @@ class UnicornBackend(ARMHalMixin, HalBackend):
                     self._last_movpc_pc = addr & ~1
             self._uc.hook_add(unicorn.UC_HOOK_CODE, _indirect_trace)
 
+        # HAL_PIN_REGS="0xADDR=0xVALUE[,0xADDR=0xVALUE...]": model read-only
+        # hardware/boot-ROM latch registers that live in RAM space but the
+        # firmware never writes (e.g. an RTOS kernel "system-ready" flag
+        # in RAM, many readers, no writer). A boot seed gets clobbered by
+        # the firmware's .bss-clearing memset; this hook re-pins the value on
+        # every read so the load always returns it, exactly like a HW control
+        # register. (Unicorn's read hook fires before the load samples memory,
+        # so writing here makes the subsequent load return the pinned value.)
+        _pin = _os.environ.get("HAL_PIN_REGS")
+        if _pin and arch_str == "arm":
+            pins = {}
+            for tok in _pin.split(","):
+                tok = tok.strip()
+                if not tok or "=" not in tok:
+                    continue
+                a_s, v_s = tok.split("=", 1)
+                try:
+                    pins[int(a_s, 0)] = int(v_s, 0)
+                except ValueError:
+                    log.warning("HAL_PIN_REGS: bad token %r", tok)
+            if pins:
+                lo = min(pins); hi = max(pins) + 4
+                log.info("HAL_PIN_REGS: pinning %d register(s): %s",
+                         len(pins), ", ".join("0x%08x=0x%08x" % (a, v)
+                                              for a, v in pins.items()))
+                # Optional PC gate: HAL_PIN_PC_LO/HI restrict pinning to reads
+                # whose PC is in [LO,HI). Needed for phase-dependent flags that
+                # must be FALSE during init and TRUE only at a specific point
+                # (e.g. the multitasking-start dispatch) -- pinning globally
+                # corrupts the init logic that expects the flag clear.
+                _pc_lo = _os.environ.get("HAL_PIN_PC_LO")
+                _pc_hi = _os.environ.get("HAL_PIN_PC_HI")
+                pc_lo = int(_pc_lo, 0) if _pc_lo else None
+                pc_hi = int(_pc_hi, 0) if _pc_hi else None
+                pc_reg = self._reg_map.get("pc")
+                # HAL_PIN_ARM_PC=0xADDR: latch the pins ON the first time this PC
+                # executes, and keep them on thereafter. Models a boot-ROM/HW
+                # flag that transitions to "ready" at a single point (the
+                # scheduler-start entry) and stays set -- cleaner than a PC
+                # range for a flag that must be false through ALL of init and
+                # true through ALL of multitasking.
+                _arm = _os.environ.get("HAL_PIN_ARM_PC")
+                arm_pc = int(_arm, 0) if _arm else None
+                pin_state = {"armed": arm_pc is None}
+                self._pin_arm_pc = arm_pc
+                self._pin_state = pin_state
+                if arm_pc is not None:
+                    # Armed from _code_hook (fires per-instruction) -- a tight
+                    # begin/end UC_HOOK_CODE doesn't reliably fire.
+                    def _arm_hook(uc, addr, size, ud):
+                        if (addr & ~1) == arm_pc and not pin_state["armed"]:
+                            pin_state["armed"] = True
+                            log.info("HAL_PIN_REGS: armed at 0x%08x", addr)
+                    self._uc.hook_add(unicorn.UC_HOOK_CODE, _arm_hook)
+                def _pin_read(uc, access, addr, size, value, ud):
+                    if not pin_state["armed"]:
+                        return
+                    if pc_lo is not None:
+                        try:
+                            pc = uc.reg_read(pc_reg)
+                        except Exception:
+                            return
+                        if not (pc_lo <= pc < pc_hi):
+                            return
+                    for pa, pv in pins.items():
+                        if addr <= pa < addr + size or pa <= addr < pa + 4:
+                            try:
+                                uc.mem_write(pa, pv.to_bytes(4, "little"))
+                            except Exception:
+                                pass
+                self._uc.hook_add(unicorn.UC_HOOK_MEM_READ, _pin_read,
+                                  begin=lo, end=hi - 1)
+
+        # Diagnostic: HAL_WATCH_WRITE="0xADDR[,0xADDR...]" logs PC + value on every
+        # write to those addresses ("who writes this field?"). For finding skipped
+        # object-init writes (e.g. a TCB OBJ_CORE self-ptr never set).
+        _ww = _os.environ.get("HAL_WATCH_WRITE")
+        if _ww and arch_str == "arm":
+            _waddrs = set(int(x, 0) for x in _ww.split(",") if x.strip())
+            _wlo = min(_waddrs); _whi = max(_waddrs) + 4
+            _wpc = self._reg_map.get("pc")
+            def _watch_write(uc, access, addr, size, value, ud):
+                if any(a <= addr < a + size or addr <= a < addr + 4 for a in _waddrs):
+                    try:
+                        pc = uc.reg_read(_wpc)
+                    except Exception:
+                        pc = 0
+                    log.error("WATCH-WRITE: [0x%08x]<=0x%08x (size %d) PC=0x%08x",
+                              addr, value, size, pc)
+            self._uc.hook_add(unicorn.UC_HOOK_MEM_WRITE, _watch_write,
+                              begin=_wlo, end=_whi - 1)
+
+        # Diagnostic: HAL_STEP_TRACE="0xLO-0xHI[:path]" single-step-logs every
+        # instruction whose PC is in [LO,HI): PC | sp | r0-r3 | sl | ip | lr.
+        # For pinning frame/register state to the exact instruction (e.g. a
+        # context-switch TCB load or a trap-style ldm epilogue).
+        _st = _os.environ.get("HAL_STEP_TRACE")
+        if _st and arch_str == "arm":
+            _spec = _st.split(":", 1)
+            _lo, _hi = (int(x, 0) for x in _spec[0].split("-"))
+            _stf = open(_spec[1] if len(_spec) > 1 else "/tmp/hal_step_trace.txt", "w")
+            _st_n = {"n": 0}
+            _rmap = self._reg_map
+            def _step_trace(uc, addr, size, ud):
+                if not (_lo <= addr < _hi) or _st_n["n"] >= 200000:
+                    return
+                _st_n["n"] += 1
+                try:
+                    vals = tuple(uc.reg_read(_rmap.get(r)) for r in
+                                 ("sp", "r0", "r1", "r2", "r3", "r10", "r12", "lr"))
+                    _stf.write("0x%08x sp=0x%08x r0=0x%08x r1=0x%08x r2=0x%08x r3=0x%08x "
+                               "sl=0x%08x ip=0x%08x lr=0x%08x\n" % ((addr,) + vals))
+                    _stf.flush()
+                except Exception:
+                    pass
+            self._uc.hook_add(unicorn.UC_HOOK_CODE, _step_trace)
+
     def dump_pc_sample(self, top: int = 10) -> None:
         hist = getattr(self, "_pc_hist", None)
         if not hist:
@@ -692,9 +819,151 @@ class UnicornBackend(ARMHalMixin, HalBackend):
                          "return lr=0x%08x", intno, pc, lr)
                 self.write_register("pc", lr)
                 return
+        # Opt-in MMU flat-fallback (HAL_MMU_FLAT_FALLBACK=1): on the first ARM
+        # data/prefetch abort, DISABLE the MMU (clear SCTLR.M) so the rest of
+        # the run is flat (VA==PA). unicorn's CP15/TTBR handling is unreliable
+        # for this firmware (TTBR0 reads 0), translation-faulting on pages that
+        # are physically present; since the firmware's mappings are identity,
+        # running flat is equivalent and avoids both data- and prefetch-abort
+        # loops. We do this LATE (on the fault, after usrMmuInit/vmLib is up),
+        # not by skipping usrMmuInit, so vmLib stays initialised. Falls back to
+        # per-instruction flat-completion of the load/store if SCTLR can't be
+        # cleared on this unicorn build.
+        if (self._mmu_flat_fallback and self.arch_name == "arm"
+                and intno in (3, 4) and pc not in (-1, 0)):
+            if self._mmu_disable(uc):
+                return  # MMU now off -> faulting instr re-executes flat
+            if intno == 4 and self._mmu_flat_complete(uc, pc):
+                return
         log.error("UnicornBackend: CPU exception/interrupt %d at pc=0x%x",
                   intno, pc)
         uc.emu_stop()
+
+    def _mmu_disable(self, uc) -> bool:
+        """Clear SCTLR.M (and TLB-relevant bits) to turn off ARM MMU
+        translation so execution proceeds flat (VA==PA). Idempotent: once
+        done, returns True on subsequent calls without re-touching CP15.
+        Returns False if CP15 SCTLR isn't accessible on this unicorn build."""
+        if getattr(self, "_mmu_off", False):
+            return True
+        from unicorn import arm_const
+        # CP15 SCTLR = coproc 15, crn=c1, crm=c0, opc1=0, opc2=0.
+        spec = (15, 0, 0, 1, 0, 0, 0)
+        try:
+            sctlr = uc.reg_read(arm_const.UC_ARM_REG_CP_REG, spec)
+        except Exception:  # noqa: BLE001
+            return False
+        if not (sctlr & 0x1):
+            # MMU already off — nothing to do, but a fault still happened, so
+            # this isn't our case; let the caller try other handlers.
+            return False
+        try:
+            uc.reg_write(arm_const.UC_ARM_REG_CP_REG, spec + (sctlr & ~0x1,))
+        except Exception:  # noqa: BLE001
+            return False
+        # Verify it took.
+        try:
+            if uc.reg_read(arm_const.UC_ARM_REG_CP_REG, spec) & 0x1:
+                return False
+        except Exception:  # noqa: BLE001
+            return False
+        self._mmu_off = True
+        log.info("UnicornBackend: MMU flat-fallback -> disabled MMU "
+                 "(SCTLR.M cleared 0x%x -> 0x%x); running flat from here",
+                 sctlr, sctlr & ~0x1)
+        return True
+
+    # capstone ARM register name -> unicorn UC_ARM_REG_* id
+    @staticmethod
+    def _arm_reg_id(name: str):
+        from unicorn import arm_const
+        alias = {"sb": "r9", "sl": "r10", "fp": "r11", "ip": "r12",
+                 "r13": "sp", "r14": "lr", "r15": "pc"}
+        n = alias.get(name.lower(), name.lower())
+        return getattr(arm_const, "UC_ARM_REG_" + n.upper(), None)
+
+    def _mmu_flat_complete(self, uc, pc: int) -> bool:
+        """Emulate a single faulting ARM load/store flat (VA==PA) and advance
+        PC by 4. Returns True if it handled the instruction. Only acts when the
+        faulting address is backed in physical memory (uc.mem_read works), which
+        is the 'MMU translation missing but page present' case. Unhandled forms
+        (LDM/STM, etc.) return False so the caller aborts as before."""
+        try:
+            import capstone
+            import capstone.arm as cs_arm
+        except ImportError:
+            return False
+        cs = getattr(self, "_cs_arm", None)
+        if cs is None:
+            cs = capstone.Cs(capstone.CS_ARCH_ARM, capstone.CS_MODE_ARM)
+            cs.detail = True
+            self._cs_arm = cs
+        try:
+            ins = next(cs.disasm(bytes(uc.mem_read(pc, 4)), pc), None)
+        except Exception:  # noqa: BLE001
+            return False
+        if ins is None:
+            return False
+        # Map the instruction to (access size, is_load, signed).
+        I = cs_arm
+        sizes = {
+            I.ARM_INS_LDR: (4, True, False), I.ARM_INS_STR: (4, False, False),
+            I.ARM_INS_LDRB: (1, True, False), I.ARM_INS_STRB: (1, False, False),
+            I.ARM_INS_LDRH: (2, True, False), I.ARM_INS_STRH: (2, False, False),
+            I.ARM_INS_LDRSB: (1, True, True), I.ARM_INS_LDRSH: (2, True, True),
+        }
+        if ins.id not in sizes:
+            return False
+        size, is_load, signed = sizes[ins.id]
+        # Operands: a register operand (dest for load / src for store) and a
+        # memory operand {base, index, lshift, disp}.
+        reg_op = None
+        mem_op = None
+        for o in ins.operands:
+            if o.type == I.ARM_OP_REG and reg_op is None:
+                reg_op = o
+            elif o.type == I.ARM_OP_MEM:
+                mem_op = o
+        if reg_op is None or mem_op is None:
+            return False
+        m = mem_op.mem
+        base_id = self._arm_reg_id(cs.reg_name(m.base)) if m.base else None
+        if base_id is None:
+            return False
+        addr = uc.reg_read(base_id) & 0xFFFFFFFF
+        if m.index:
+            idx_id = self._arm_reg_id(cs.reg_name(m.index))
+            if idx_id is None:
+                return False
+            idxval = uc.reg_read(idx_id) & 0xFFFFFFFF
+            addr += (idxval << m.lshift) if m.lshift else idxval
+        addr = (addr + m.disp) & 0xFFFFFFFF
+        # Only act if the physical page is present (translation-missing case).
+        try:
+            data = bytes(uc.mem_read(addr, size))
+        except Exception:  # noqa: BLE001
+            return False  # genuinely unmapped -> real fault
+        rid = self._arm_reg_id(cs.reg_name(reg_op.reg))
+        if rid is None:
+            return False
+        if is_load:
+            val = int.from_bytes(data, "little")
+            if signed and (val & (1 << (size * 8 - 1))):
+                val -= 1 << (size * 8)
+            uc.reg_write(rid, val & 0xFFFFFFFF)
+        else:
+            val = uc.reg_read(rid) & ((1 << (size * 8)) - 1)
+            uc.mem_write(addr, val.to_bytes(size, "little"))
+        # Pre/post-indexed writeback updates the base register with `addr`
+        # (pre) — capstone exposes writeback via ins.writeback.
+        if getattr(ins, "writeback", False):
+            uc.reg_write(base_id, addr)
+        uc.reg_write(self._reg_map["pc"], pc + 4)
+        self._mmu_flat_count[pc] = self._mmu_flat_count.get(pc, 0) + 1
+        if self._mmu_flat_count[pc] <= 3:
+            log.info("UnicornBackend: MMU flat-fallback %s @0x%08x addr=0x%08x "
+                     "(x%d)", ins.mnemonic, pc, addr, self._mmu_flat_count[pc])
+        return True
 
     # ------------------------------------------------------------------
     # x86 port I/O (IN / OUT) — catch-all so the PC chipset doesn't fault

--- a/src/halucinator/bp_handlers/generic/__init__.py
+++ b/src/halucinator/bp_handlers/generic/__init__.py
@@ -9,3 +9,5 @@ from .function_callers import *
 from .timer import *
 from . import libc
 from .basic_io import *
+from .modbus_tcp_bridge import ModbusTcpBridge  # noqa: F401
+from .socket_bridge import SocketBridge  # noqa: F401

--- a/src/halucinator/bp_handlers/generic/common.py
+++ b/src/halucinator/bp_handlers/generic/common.py
@@ -490,6 +490,44 @@ class SetMemory(BPHandler):
         return False, 0
 
 
+class RegMemWrite(BPHandler):
+    """
+    Write a value to [register + offset], then let execution continue.
+
+    For loop-/poll-breaking points where the address to poke is computed from a
+    LIVE register (e.g. a `this`/`r4` pointer + a field offset) -- which
+    SetMemory / ForceMemValue (fixed address only) cannot express. Used by the
+    X-bus model to instantly ACK a remote I/O exchange ([r4+0x3e]=3 at the
+    XbExchg::RemoteExchange ack-poll) and to mark a phantom I/O device absent
+    ([r0+0x21c]=0xff at IoDeviceNoConf::StateMachine).
+
+    Halucinator configuration usage:
+    - class: halucinator.bp_handlers.RegMemWrite
+      function: <func_name> (Can be anything)
+      registration_args: { reg: r4, offset: 0x3e, value: 3, size: 1, silent: true }
+      addr: <addr>
+    """
+
+    def __init__(self) -> None:
+        self.params: Dict[int, Any] = {}
+
+    def register_handler(  # pylint: disable=too-many-arguments
+        self, qemu: "HalBackend", addr: int, func_name: str,
+        reg: str = "r0", offset: int = 0, value: int = 0, size: int = 1, silent: bool = True
+    ) -> HandlerFunction:  # pylint: disable=unused-argument
+        self.params[addr] = (reg, int(offset), int(value), int(size), silent, func_name)
+        return cast(HandlerFunction, RegMemWrite.write)
+
+    @bp_handler
+    def write(self, qemu: "HalBackend", addr: int) -> HandlerReturn:
+        reg, offset, value, size, silent, func_name = self.params[addr]
+        base = qemu.read_register(reg)
+        qemu.write_memory((base + offset) & 0xFFFFFFFF, size, value)
+        if not silent:
+            hal_log.info("RegMemWrite: %s [%s+0x%x]=0x%x", func_name, reg, offset, value)
+        return False, None
+
+
 class LogAndSkip(BPHandler):
     """Log entry (with r0..r3 + lr) then SkipFunc-return immediately.
 
@@ -1001,9 +1039,9 @@ class IrqReturnArm(BPHandler):
 class IntLvlVecChkArm(BPHandler):
     """ARM xxxIntLvlVecChk(level_p, vec_p) -- return the pending IRQ.
 
-    Per NDSS BAR 2021 paper sec III.D, VxWorks calls this BSP-defined
-    routine from inside its IRQ handler to ask the AIC "which level
-    and which vector caused the interrupt?". The function takes two
+    VxWorks calls this BSP-defined routine from inside its IRQ handler
+    to ask the AIC "which level and which vector caused the interrupt?".
+    The function takes two
     pointer args (r0=level_p, r1=vec_p) and writes the answers.
 
     Our handler returns the level/vec from the latest IRQ injected by

--- a/src/halucinator/bp_handlers/generic/counter.py
+++ b/src/halucinator/bp_handlers/generic/counter.py
@@ -19,25 +19,32 @@ if TYPE_CHECKING:
 
 class Counter(BPHandler):
     '''
-        Returns an increasing value for each addresss accessed
+        Returns an increasing value in r0 on each access -- (previous + increment)
+        & mask, starting from `start`. Models a free-running counter/timer whose
+        backing store does not advance in the re-host (so elapsed-time / timeout
+        loops never progress): each call advances it by `increment`. The `mask`
+        wraps it to a register width (e.g. 0xffff for a 16-bit counter).
 
         Halucinator configuration usage:
         - class: halucinator.bp_handlers.Counter
           function: <func_name> (Can be anything)
           addr: <addr>
-          registration_args:{increment:1} (Optional)
+          registration_args: { increment: 1, mask: 0xffffffff, start: 0 }  (all optional)
     '''
 
     def __init__(self) -> None:
         self.increment: Dict[int, int] = {}
         self.counts: Dict[int, int] = {}
+        self.mask: Dict[int, int] = {}
 
-    def register_handler(self, qemu: "HalBackend", addr: int, func_name: str, increment: int = 1) -> HandlerFunction:
+    def register_handler(self, qemu: "HalBackend", addr: int, func_name: str,
+                         increment: int = 1, mask: int = 0xFFFFFFFF, start: int = 0) -> HandlerFunction:
         '''
 
         '''
-        self.increment[addr] = increment
-        self.counts[addr] = 0
+        self.increment[addr] = int(increment)
+        self.counts[addr] = int(start)
+        self.mask[addr] = int(mask)
 
         return cast(HandlerFunction, Counter.get_value)
 
@@ -46,5 +53,6 @@ class Counter(BPHandler):
         '''
             Gets the counter value
         '''
-        self.counts[addr] += self.increment[addr]
+        mask = self.mask.get(addr, 0xFFFFFFFF)
+        self.counts[addr] = (self.counts[addr] + self.increment[addr]) & mask
         return True, self.counts[addr]

--- a/src/halucinator/bp_handlers/generic/modbus_tcp_bridge.py
+++ b/src/halucinator/bp_handlers/generic/modbus_tcp_bridge.py
@@ -1,0 +1,695 @@
+# Copyright 2026 Christopher Wright
+
+"""ModbusTcpBridge — TCP server on host port 502, delivers Modbus PDUs
+to a configurable firmware handler.
+
+Implements the "rehost the application layer" approach for an
+ARM/VxWorks PLC (and similar VxWorks Modbus/TCP devices):
+
+  the PLC configurator
+         |
+         |  Modbus/TCP (port 502)
+         v
+  +-----------------------------+
+  |   halucinator host TCP-502  |
+  |        server               |
+  +-----------------------------+
+         |
+         |  strip MBAP header (txid, protid, len, unit)
+         |  build ModbusDiagnostics::CommandIn in halucinator scratch
+         v
+  +-----------------------------+
+  |  ModbusTcpBridge.dispatch   |
+  |  - writes the CommandIn     |
+  |    into firmware memory     |
+  |  - sets r0 = &CommandIn      |
+  |  - sets PC = configured      |
+  |    handler entry             |
+  |  - sets LR = trigger PC      |
+  |    (so handler returns to    |
+  |    a known safe PC)          |
+  +-----------------------------+
+         |
+         v
+  Firmware: handler reads CommandIn, builds response, returns
+
+When the trigger PC fires again (handler returned to it), the bridge
+reads the response from the configured response-region and sends it
+back over TCP wrapped in MBAP.
+
+YAML configuration usage:
+  - class: halucinator.bp_handlers.ModbusTcpBridge
+    function: modbus_tcp_bridge
+    addr: 0x23ff7300                 # trigger park — when PC reaches
+                                     # here, the bridge takes over
+    registration_args:
+      tcp_port:      502             # host listen port
+      cmd_in_addr:   0x04700000      # scratch where CommandIn is built
+      response_addr: 0x04700200      # scratch where firmware writes response
+      cmd_in_size:   0x100           # bytes to wipe before each request
+      handler_pc:    0x2016f088      # firmware function to call with r0=&CommandIn
+      return_pc:     0x23ff7300      # handler returns here; bridge resumes
+      buffer_field_offset: 0x40      # where in CommandIn the PDU buffer sits
+                                     # (depends on the firmware's struct layout;
+                                     #  TODO once decompiled — for now, MBAP-stripped
+                                     #  PDU is written here)
+      length_field_offset: 0x44      # where the PDU length is stored
+      response_field_offset: 0x60    # where the firmware writes the response
+      response_length_offset: 0x64   # where firmware writes response length
+      silent: false                  # log each request/response
+
+Notes:
+- The exact ModbusDiagnostics::CommandIn struct layout is firmware-
+  specific and not yet fully recovered for the target (Ghidra labels for
+  EthChannelServer::getWebMessaging were misaligned). The above field
+  offsets are placeholders — adjust per the target firmware.
+- This handler is "single-in-flight" — one client at a time. For
+  the PLC configurator that's fine; the configurator opens one TCP connection.
+- The handler runs IN A BACKGROUND THREAD (host TCP server) and
+  injects state into the emulator at the BP trigger. The trigger PC
+  must be reached periodically (e.g., via the IRQ rotation park
+  mechanism) for new requests to be processed.
+"""
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+import threading
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, cast
+
+from halucinator.bp_handlers.bp_handler import BPHandler, HandlerFunction, HandlerReturn, bp_handler
+from halucinator import hal_log
+
+if TYPE_CHECKING:
+    from halucinator.backends.hal_backend import HalBackend
+
+log = logging.getLogger(__name__)
+hlog = hal_log.getHalLogger()
+
+
+# MBAP header is 7 bytes: txid(2), protid(2), len(2), unit(1)
+MBAP_LEN = 7
+
+
+class _PendingRequest:
+    """Captures a Modbus request waiting for the next BP firing."""
+    __slots__ = ("client_sock", "mbap_txid", "mbap_protid", "mbap_unit", "pdu")
+
+    def __init__(self, client_sock: socket.socket, mbap_txid: int,
+                 mbap_protid: int, mbap_unit: int, pdu: bytes) -> None:
+        self.client_sock = client_sock
+        self.mbap_txid = mbap_txid
+        self.mbap_protid = mbap_protid
+        self.mbap_unit = mbap_unit
+        self.pdu = pdu
+
+
+class ModbusTcpBridge(BPHandler):
+    """TCP-502 listener that bridges Modbus/TCP frames to a firmware
+    handler. See module docstring for the recipe."""
+
+    def __init__(self) -> None:
+        self.cfg: Dict[int, Dict[str, Any]] = {}
+        self.func_names: Dict[int, str] = {}
+        # Per-trigger pending request queue + lock
+        self._pending: Dict[int, Optional[_PendingRequest]] = {}
+        self._lock = threading.Lock()
+        # State machine per trigger: "idle" → "request-pending" → "response-pending"
+        self._state: Dict[int, str] = {}
+
+    def register_handler(
+        self, qemu: "HalBackend", addr: int, func_name: str,
+        tcp_port: int = 502,
+        cmd_in_addr: int = 0x04700000,
+        response_addr: int = 0x04700200,
+        cmd_in_size: int = 0x100,
+        handler_pc: int = 0,
+        return_pc: int = 0,
+        buffer_field_offset: int = 0x40,
+        length_field_offset: int = 0x44,
+        response_field_offset: int = 0x60,
+        response_length_offset: int = 0x64,
+        silent: bool = False,
+        mode: str = "dispatch",
+        regs: int = 256,
+        coils: int = 256,
+        device_id_vendor: str = "Vendor",
+        device_id_product: str = "PLC",
+        device_id_revision: str = "rehost",
+        uart_pty_path: str = "/tmp/vxworks_uart_pty",
+        uart_unit_id: int = 1,
+        uart_response_timeout: float = 3.0,
+        uart_idle_gap: float = 0.05,
+    ) -> HandlerFunction:  # pylint: disable=too-many-arguments
+        self.cfg[addr] = {
+            "tcp_port": tcp_port,
+            "cmd_in_addr": cmd_in_addr,
+            "response_addr": response_addr,
+            "cmd_in_size": cmd_in_size,
+            "handler_pc": handler_pc,
+            "return_pc": return_pc or addr,   # default: handler returns to trigger PC
+            "buffer_field_offset": buffer_field_offset,
+            "length_field_offset": length_field_offset,
+            "response_field_offset": response_field_offset,
+            "response_length_offset": response_length_offset,
+            "silent": silent,
+            "mode": mode,
+            "holding_regs": [0] * regs,
+            "input_regs":   [0] * regs,
+            "coils":        [False] * coils,
+            "discrete":     [False] * coils,
+            "device_id_vendor":   device_id_vendor,
+            "device_id_product":  device_id_product,
+            "device_id_revision": device_id_revision,
+            # uart_rtu mode: route MBAP TCP traffic through the firmware's
+            # Modbus RTU UART path (DBGU pty link from phase 54).
+            "uart_pty_path":         uart_pty_path,
+            "uart_unit_id":          uart_unit_id,
+            "uart_response_timeout": uart_response_timeout,
+            "uart_idle_gap":         uart_idle_gap,
+            "uart_fd":               None,    # opened lazily on first request
+        }
+        self.func_names[addr] = func_name
+        self._pending[addr] = None
+        self._state[addr] = "idle"
+
+        # Spawn TCP listener thread for this trigger
+        t = threading.Thread(target=self._tcp_listener, args=(addr,),
+                             daemon=True,
+                             name=f"{func_name}-tcp-{tcp_port}")
+        t.start()
+        hlog.info("ModbusTcpBridge(%s): listening on tcp/%d, trigger PC=0x%08x, "
+                  "handler=0x%08x", func_name, tcp_port, addr, handler_pc)
+        return cast(HandlerFunction, ModbusTcpBridge.on_trigger)
+
+    # --------------------- TCP listener (host side) ---------------------
+
+    def _tcp_listener(self, trigger_addr: int) -> None:
+        """Accept clients, parse Modbus/TCP frames, enqueue requests."""
+        cfg = self.cfg[trigger_addr]
+        port = cfg["tcp_port"]
+        try:
+            srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            srv.bind(("0.0.0.0", port))
+            srv.listen(1)
+        except Exception as e:  # noqa: BLE001
+            hlog.error("ModbusTcpBridge: listen(%d) failed: %s", port, e)
+            return
+
+        while True:
+            try:
+                client, peer = srv.accept()
+                hlog.info("ModbusTcpBridge: client connected from %s:%d",
+                          peer[0], peer[1])
+                self._serve_client(trigger_addr, client)
+                try:
+                    client.close()
+                except Exception:
+                    pass
+                hlog.info("ModbusTcpBridge: client %s disconnected", peer[0])
+            except Exception as e:  # noqa: BLE001
+                hlog.error("ModbusTcpBridge: accept failed: %s", e)
+                break
+
+    def _serve_client(self, trigger_addr: int, client: socket.socket) -> None:
+        """Read MBAP-framed Modbus requests; for each: enqueue and wait
+        for the bridge to deliver a response."""
+        cfg = self.cfg[trigger_addr]
+        while True:
+            mbap = self._recv_n(client, MBAP_LEN)
+            if mbap is None:
+                return
+            txid, protid, length, unit = struct.unpack(">HHHB", mbap)
+            pdu_len = length - 1  # length includes unit byte
+            if pdu_len < 1 or pdu_len > 253:
+                hlog.error("ModbusTcpBridge: bad PDU length %d", pdu_len)
+                return
+            pdu = self._recv_n(client, pdu_len)
+            if pdu is None:
+                return
+
+            hlog.info("ModbusTcpBridge: req txid=%d unit=%d pdu=%s",
+                      txid, unit, pdu.hex())
+
+            mode = cfg.get("mode", "dispatch")
+            pending = _PendingRequest(client, txid, protid, unit, pdu)
+            if mode == "responder":
+                # Generate the response locally; firmware doesn't see it.
+                resp_pdu = self._responder_handle(cfg, pdu)
+                self._send_response(pending, resp_pdu)
+                continue
+            if mode == "uart_rtu":
+                # Route through the firmware's Modbus RTU UART path:
+                # wrap as RTU, write to pty (firmware UART RX), read
+                # response off pty (firmware UART TX), unwrap.
+                resp_pdu = self._uart_rtu_exchange(cfg, pdu)
+                self._send_response(pending, resp_pdu)
+                continue
+
+            # Dispatch mode: enqueue and wait for the BP trigger to fire +
+            # the firmware to produce a response.
+            with self._lock:
+                self._pending[trigger_addr] = _PendingRequest(
+                    client, txid, protid, unit, pdu)
+                self._state[trigger_addr] = "request-pending"
+            self._wait_until_idle(trigger_addr, client)
+
+    def _wait_until_idle(self, trigger_addr: int, client: socket.socket) -> None:
+        """Block until the BP handler clears the pending request."""
+        import time
+        while True:
+            with self._lock:
+                state = self._state[trigger_addr]
+            if state == "idle":
+                return
+            # Make sure the client is still alive
+            try:
+                client.settimeout(0.05)
+                _ = client.recv(0, socket.MSG_PEEK)
+            except (BlockingIOError, socket.timeout):
+                pass
+            except Exception:
+                with self._lock:
+                    self._pending[trigger_addr] = None
+                    self._state[trigger_addr] = "idle"
+                return
+            time.sleep(0.02)
+
+    @staticmethod
+    def _recv_n(sock: socket.socket, n: int) -> Optional[bytes]:
+        """Receive exactly n bytes; return None on EOF/error."""
+        buf = bytearray()
+        sock.settimeout(None)
+        while len(buf) < n:
+            try:
+                chunk = sock.recv(n - len(buf))
+            except Exception:
+                return None
+            if not chunk:
+                return None
+            buf.extend(chunk)
+        return bytes(buf)
+
+    # --------------------- BP handler (emulator side) ---------------------
+
+    @bp_handler
+    def on_trigger(self, qemu: "HalBackend", addr: int) -> HandlerReturn:
+        """Called when PC reaches the trigger park. Drives the request/
+        response state machine for one TCP client."""
+        cfg = self.cfg[addr]
+        with self._lock:
+            state = self._state[addr]
+            pending = self._pending[addr]
+
+        if state == "idle":
+            # Nothing to do; let execution continue past the trigger
+            return False, None
+
+        if state == "request-pending" and pending is not None:
+            # Build CommandIn in scratch and dispatch into handler
+            try:
+                self._dispatch_request(qemu, addr, cfg, pending)
+            except Exception as e:  # noqa: BLE001
+                hlog.error("ModbusTcpBridge: dispatch failed: %s", e)
+                with self._lock:
+                    self._state[addr] = "idle"
+                    self._pending[addr] = None
+                return False, None
+            # The trigger PC is now set to handler_pc; the handler will
+            # eventually return back to addr, at which point we'll be
+            # in "response-pending" state.
+            with self._lock:
+                self._state[addr] = "response-pending"
+            # Don't SkipFunc — the emulator now needs to RUN the handler.
+            # We've already pointed PC at handler_pc + set LR = addr.
+            return False, None
+
+        if state == "response-pending" and pending is not None:
+            # Handler returned. Read response from scratch and send it back.
+            try:
+                resp_pdu = self._read_response(qemu, cfg)
+                self._send_response(pending, resp_pdu)
+            except Exception as e:  # noqa: BLE001
+                hlog.error("ModbusTcpBridge: read/send failed: %s", e)
+            with self._lock:
+                self._state[addr] = "idle"
+                self._pending[addr] = None
+            return False, None
+
+        return False, None
+
+    def _dispatch_request(self, qemu: "HalBackend", trigger_addr: int,
+                          cfg: Dict[str, Any], pending: _PendingRequest) -> None:
+        """Build CommandIn in scratch memory and redirect PC to handler."""
+        cmd_in_addr = cfg["cmd_in_addr"]
+        cmd_in_size = cfg["cmd_in_size"]
+        buf_off  = cfg["buffer_field_offset"]
+        len_off  = cfg["length_field_offset"]
+
+        # Wipe the CommandIn region
+        zero = bytes(cmd_in_size)
+        try:
+            qemu.write_memory(cmd_in_addr, 1, 0, num_words=cmd_in_size, raw=False)
+        except Exception:
+            # Fall back to multi-byte write
+            try:
+                qemu.write_memory_bytes(cmd_in_addr, zero)  # type: ignore[attr-defined]
+            except Exception:
+                pass
+
+        # Write PDU into the buffer field
+        pdu = pending.pdu
+        try:
+            for i, b in enumerate(pdu):
+                qemu.write_memory(cmd_in_addr + buf_off + i, 1, b)
+        except Exception as _e:  # noqa: BLE001
+            hlog.error("ModbusTcpBridge: write PDU bytes failed: %s", _e)
+
+        # Write length
+        try:
+            qemu.write_memory(cmd_in_addr + len_off, 4, len(pdu))
+        except Exception as _e:  # noqa: BLE001
+            hlog.error("ModbusTcpBridge: write PDU length failed: %s", _e)
+
+        # Set r0 = &CommandIn, LR = return_pc, PC = handler_pc
+        try:
+            qemu.write_register("r0", cmd_in_addr & 0xffffffff)
+            qemu.write_register("lr", cfg["return_pc"] & 0xffffffff)
+            qemu.write_register("pc", cfg["handler_pc"] & 0xffffffff)
+        except Exception as _e:  # noqa: BLE001
+            hlog.error("ModbusTcpBridge: register set failed: %s", _e)
+            return
+
+        if not cfg["silent"]:
+            hlog.info("ModbusTcpBridge: dispatched -- CommandIn @ 0x%08x  "
+                      "PDU len=%d  handler PC=0x%08x  return_pc=0x%08x",
+                      cmd_in_addr, len(pdu), cfg["handler_pc"], cfg["return_pc"])
+
+    def _read_response(self, qemu: "HalBackend", cfg: Dict[str, Any]) -> bytes:
+        """Read the firmware-written response from the configured
+        response region."""
+        resp_addr   = cfg["response_addr"]
+        resp_off    = cfg["response_field_offset"]
+        resp_len_off = cfg["response_length_offset"]
+        # Read length first
+        try:
+            length_bytes = qemu.read_memory(cfg["cmd_in_addr"] + resp_len_off, 4, 1)
+            if isinstance(length_bytes, (bytes, bytearray)):
+                length = struct.unpack("<I", bytes(length_bytes[:4]))[0]
+            else:
+                length = int(length_bytes) & 0xffffffff
+        except Exception:
+            length = 0
+        length = max(0, min(length, 253))
+
+        # Read response bytes
+        resp = bytearray()
+        for i in range(length):
+            try:
+                b = qemu.read_memory(cfg["cmd_in_addr"] + resp_off + i, 1, 1)
+                if isinstance(b, (bytes, bytearray)):
+                    resp.append(b[0])
+                else:
+                    resp.append(int(b) & 0xff)
+            except Exception:
+                break
+        return bytes(resp)
+
+    # --------------------- UART RTU passthrough ---------------------
+    #
+    # `mode: uart_rtu` MBAP-to-RTU bridge. The frame written to the pty
+    # link is consumed by the firmware's serial RX path (At91Dbgu's
+    # feed_rx, then iosLib_tyRead -> M_UART_Manual_Handler @ 0x2013a554
+    # for the target). The firmware's Modbus RTU state machine processes
+    # the frame and writes the response to the same UART TX; the pty
+    # echoes those bytes back to the host, where we drain them, strip
+    # the RTU envelope and forward the PDU as an MBAP response.
+
+    _CRC16_TABLE: Optional[Tuple[int, ...]] = None
+
+    @classmethod
+    def _crc16_table(cls) -> Tuple[int, ...]:
+        if cls._CRC16_TABLE is None:
+            tbl = []
+            for b in range(256):
+                v = b
+                for _ in range(8):
+                    v = (v >> 1) ^ 0xA001 if (v & 1) else v >> 1
+                tbl.append(v)
+            cls._CRC16_TABLE = tuple(tbl)
+        return cls._CRC16_TABLE
+
+    @classmethod
+    def _crc16(cls, data: bytes) -> int:
+        tbl = cls._crc16_table()
+        crc = 0xFFFF
+        for b in data:
+            crc = (crc >> 8) ^ tbl[(crc ^ b) & 0xff]
+        return crc & 0xffff
+
+    def _uart_open(self, cfg: Dict[str, Any]) -> Optional[int]:
+        """Lazy-open the pty link to the firmware's UART."""
+        if cfg.get("uart_fd") is not None:
+            return cfg["uart_fd"]
+        import os
+        path = cfg["uart_pty_path"]
+        try:
+            fd = os.open(path, os.O_RDWR | os.O_NONBLOCK)
+        except FileNotFoundError:
+            hlog.error("ModbusTcpBridge[uart_rtu]: pty %s not present "
+                       "(is At91Dbgu's bridge_mode=pty? did firmware open it?)",
+                       path)
+            return None
+        except Exception as e:  # noqa: BLE001
+            hlog.error("ModbusTcpBridge[uart_rtu]: open(%s) failed: %s",
+                       path, e)
+            return None
+        cfg["uart_fd"] = fd
+        return fd
+
+    def _uart_rtu_exchange(self, cfg: Dict[str, Any], pdu: bytes) -> bytes:
+        """Encode PDU as RTU, write to firmware UART RX, read response,
+        strip RTU. Returns the response PDU (with FC error byte set on
+        any failure)."""
+        import os, select, time
+        fd = self._uart_open(cfg)
+        if fd is None:
+            return self._modbus_exception(pdu[0] if pdu else 0, 0x0B)  # GW_TARGET
+        unit = cfg["uart_unit_id"] & 0xff
+        rtu_frame = bytes([unit]) + pdu
+        crc = self._crc16(rtu_frame)
+        rtu_frame += bytes([crc & 0xff, (crc >> 8) & 0xff])
+
+        # Drain any stale RX bytes
+        deadline_drain = time.time() + 0.05
+        try:
+            while time.time() < deadline_drain:
+                r, _, _ = select.select([fd], [], [], 0)
+                if not r:
+                    break
+                try:
+                    os.read(fd, 4096)
+                except (BlockingIOError, OSError):
+                    break
+        except Exception:
+            pass
+
+        # Write RTU frame
+        try:
+            written = 0
+            while written < len(rtu_frame):
+                _, w, _ = select.select([], [fd], [], 1.0)
+                if not w:
+                    return self._modbus_exception(pdu[0], 0x0B)
+                n = os.write(fd, rtu_frame[written:])
+                if n <= 0:
+                    return self._modbus_exception(pdu[0], 0x0B)
+                written += n
+        except Exception as e:  # noqa: BLE001
+            hlog.error("ModbusTcpBridge[uart_rtu]: write failed: %s", e)
+            return self._modbus_exception(pdu[0], 0x0B)
+
+        # Read response with 3.5-char silent-gap heuristic
+        timeout = cfg["uart_response_timeout"]
+        idle = cfg["uart_idle_gap"]
+        deadline = time.time() + timeout
+        rx = bytearray()
+        last_byte_at: Optional[float] = None
+        while time.time() < deadline:
+            r, _, _ = select.select([fd], [], [], 0.05)
+            if r:
+                try:
+                    chunk = os.read(fd, 4096)
+                except (BlockingIOError, OSError):
+                    chunk = b""
+                if chunk:
+                    rx.extend(chunk)
+                    last_byte_at = time.time()
+                    continue
+            # No new data: if we got at least an RTU response (>=4 bytes:
+            # unit + FC + min_payload + 2*CRC) and have been idle for the
+            # configured gap, we're done.
+            if last_byte_at is not None and len(rx) >= 4 \
+                    and time.time() - last_byte_at >= idle:
+                break
+
+        if len(rx) < 4:
+            return self._modbus_exception(pdu[0], 0x0B)  # gateway path-target
+
+        rx_bytes = bytes(rx)
+        # Strip RTU envelope: unit(1) + PDU(n) + CRC(2)
+        body = rx_bytes[:-2]
+        crc_rx = rx_bytes[-2] | (rx_bytes[-1] << 8)
+        if self._crc16(body) != crc_rx:
+            hlog.warning("ModbusTcpBridge[uart_rtu]: bad CRC on RTU response "
+                         "(got 0x%04x); returning frame anyway", crc_rx)
+        if body[0] != unit:
+            hlog.warning("ModbusTcpBridge[uart_rtu]: unit-id mismatch "
+                         "(expected %d, got %d)", unit, body[0])
+        return body[1:]  # strip unit; return PDU
+
+    # --------------------- Local Modbus responder ---------------------
+    #
+    # `mode: responder` answers Modbus FC=01/02/03/04/05/06/0F/10/2B locally
+    # from the configured simulated register table. The rehosted PLC
+    # firmware keeps running underneath (the unicorn loop ticks, the
+    # scheduler context-switches), so the PLC configurator sees a live PLC on
+    # port 502 even before the firmware-side Modbus dispatch chain is
+    # fully reverse-engineered. Switching `mode: dispatch` once the
+    # processModbusMessage entry is known re-routes traffic through the
+    # firmware.
+
+    @staticmethod
+    def _modbus_exception(fc: int, ec: int) -> bytes:
+        return bytes([fc | 0x80, ec & 0xff])
+
+    def _responder_handle(self, cfg: Dict[str, Any], pdu: bytes) -> bytes:
+        """Generate a Modbus PDU response for the given request PDU."""
+        if not pdu:
+            return self._modbus_exception(0, 0x03)  # ILLEGAL_DATA
+        fc = pdu[0]
+        try:
+            if fc == 0x01:  # Read Coils
+                addr, qty = struct.unpack(">HH", pdu[1:5])
+                if qty < 1 or qty > 2000:
+                    return self._modbus_exception(fc, 0x03)
+                bits = cfg["coils"]
+                if addr + qty > len(bits):
+                    return self._modbus_exception(fc, 0x02)
+                n = (qty + 7) // 8
+                out = bytearray(n)
+                for i in range(qty):
+                    if bits[addr + i]:
+                        out[i >> 3] |= 1 << (i & 7)
+                return bytes([fc, n]) + bytes(out)
+            if fc == 0x02:  # Read Discrete Inputs
+                addr, qty = struct.unpack(">HH", pdu[1:5])
+                if qty < 1 or qty > 2000:
+                    return self._modbus_exception(fc, 0x03)
+                bits = cfg["discrete"]
+                if addr + qty > len(bits):
+                    return self._modbus_exception(fc, 0x02)
+                n = (qty + 7) // 8
+                out = bytearray(n)
+                for i in range(qty):
+                    if bits[addr + i]:
+                        out[i >> 3] |= 1 << (i & 7)
+                return bytes([fc, n]) + bytes(out)
+            if fc in (0x03, 0x04):  # Read Holding / Input Registers
+                addr, qty = struct.unpack(">HH", pdu[1:5])
+                if qty < 1 or qty > 125:
+                    return self._modbus_exception(fc, 0x03)
+                regs = cfg["holding_regs"] if fc == 0x03 else cfg["input_regs"]
+                if addr + qty > len(regs):
+                    return self._modbus_exception(fc, 0x02)
+                payload = bytearray()
+                for v in regs[addr:addr + qty]:
+                    payload += struct.pack(">H", v & 0xffff)
+                return bytes([fc, len(payload)]) + bytes(payload)
+            if fc == 0x05:  # Write Single Coil
+                addr, val = struct.unpack(">HH", pdu[1:5])
+                if val not in (0x0000, 0xff00):
+                    return self._modbus_exception(fc, 0x03)
+                if addr >= len(cfg["coils"]):
+                    return self._modbus_exception(fc, 0x02)
+                cfg["coils"][addr] = (val == 0xff00)
+                return pdu[:5]  # echo
+            if fc == 0x06:  # Write Single Register
+                addr, val = struct.unpack(">HH", pdu[1:5])
+                if addr >= len(cfg["holding_regs"]):
+                    return self._modbus_exception(fc, 0x02)
+                cfg["holding_regs"][addr] = val & 0xffff
+                return pdu[:5]  # echo
+            if fc == 0x0F:  # Write Multiple Coils
+                addr, qty, bc = struct.unpack(">HHB", pdu[1:6])
+                if qty < 1 or qty > 1968 or bc != (qty + 7) // 8:
+                    return self._modbus_exception(fc, 0x03)
+                if addr + qty > len(cfg["coils"]):
+                    return self._modbus_exception(fc, 0x02)
+                data = pdu[6:6 + bc]
+                for i in range(qty):
+                    cfg["coils"][addr + i] = bool(data[i >> 3] & (1 << (i & 7)))
+                return bytes([fc]) + struct.pack(">HH", addr, qty)
+            if fc == 0x10:  # Write Multiple Registers
+                addr, qty, bc = struct.unpack(">HHB", pdu[1:6])
+                if qty < 1 or qty > 123 or bc != qty * 2:
+                    return self._modbus_exception(fc, 0x03)
+                if addr + qty > len(cfg["holding_regs"]):
+                    return self._modbus_exception(fc, 0x02)
+                for i in range(qty):
+                    cfg["holding_regs"][addr + i] = struct.unpack(
+                        ">H", pdu[6 + i * 2:8 + i * 2])[0]
+                return bytes([fc]) + struct.pack(">HH", addr, qty)
+            if fc == 0x17:  # Read/Write Multiple Registers
+                raddr, rqty, waddr, wqty, bc = struct.unpack(
+                    ">HHHHB", pdu[1:10])
+                if (rqty < 1 or rqty > 125 or wqty < 1 or wqty > 121
+                        or bc != wqty * 2):
+                    return self._modbus_exception(fc, 0x03)
+                regs = cfg["holding_regs"]
+                if raddr + rqty > len(regs) or waddr + wqty > len(regs):
+                    return self._modbus_exception(fc, 0x02)
+                for i in range(wqty):
+                    regs[waddr + i] = struct.unpack(
+                        ">H", pdu[10 + i * 2:12 + i * 2])[0]
+                payload = bytearray()
+                for v in regs[raddr:raddr + rqty]:
+                    payload += struct.pack(">H", v & 0xffff)
+                return bytes([fc, len(payload)]) + bytes(payload)
+            if fc == 0x2B and len(pdu) >= 3 and pdu[1] == 0x0E:
+                # Read Device Identification (MEI type 0x0E)
+                rd_code = pdu[2]
+                obj_id = pdu[3] if len(pdu) >= 4 else 0
+                # Build a Basic device-ID response (3 objects: vendor, product, revision)
+                objs = [
+                    (0x00, cfg["device_id_vendor"].encode("ascii", "replace")),
+                    (0x01, cfg["device_id_product"].encode("ascii", "replace")),
+                    (0x02, cfg["device_id_revision"].encode("ascii", "replace")),
+                ]
+                more = 0
+                conformity = 0x01  # Basic, stream-only
+                payload = bytearray([fc, 0x0E, rd_code, conformity, more, 0,
+                                     len(objs)])
+                for oid, val in objs:
+                    payload += bytes([oid, len(val)]) + val
+                return bytes(payload)
+            # Unknown / unsupported function code
+            return self._modbus_exception(fc, 0x01)  # ILLEGAL_FUNCTION
+        except struct.error:
+            return self._modbus_exception(fc, 0x03)  # ILLEGAL_DATA_VALUE
+
+    def _send_response(self, pending: _PendingRequest, resp_pdu: bytes) -> None:
+        """Wrap the PDU in MBAP and send to the original client."""
+        if not resp_pdu:
+            # Build a Modbus error response: function | 0x80, exception code 0x04
+            resp_pdu = bytes([(pending.pdu[0] if pending.pdu else 0) | 0x80, 0x04])
+        mbap = struct.pack(">HHHB",
+                           pending.mbap_txid, pending.mbap_protid,
+                           len(resp_pdu) + 1, pending.mbap_unit)
+        frame = mbap + resp_pdu
+        try:
+            pending.client_sock.sendall(frame)
+        except Exception as _e:  # noqa: BLE001
+            hlog.error("ModbusTcpBridge: send failed: %s", _e)

--- a/src/halucinator/bp_handlers/generic/socket_bridge.py
+++ b/src/halucinator/bp_handlers/generic/socket_bridge.py
@@ -1,0 +1,388 @@
+# Copyright 2026 Christopher Wright
+
+"""SocketBridge — host TCP server <-> firmware BSD-socket syscalls (no TAP).
+
+Bridges a real host TCP client (pymodbus, a PLC configurator, or a stdlib socket) to a
+rehosted firmware's OWN server socket by intercepting the firmware's VxWorks
+socket *thunks* (select / accept / recv / send / close / shutdown / setsockopt
+/ __errno) at the socket-syscall layer. The firmware's real server loop runs;
+we just feed its select/accept/recv and ship its send bytes to the host client.
+
+Designed for an ARM/VxWorks PLC Port502Server (Modbus/UMAS :502), whose
+PollMsgToRout() is a NON-BLOCKING select()-driven poll over the listen fd plus
+all connection fds. Because the firmware polls, the bridge never blocks the
+emulator thread: each select() hook reports readiness from host-side state that
+a background TCP thread maintains; accept/recv/send mutate guest memory only on
+the emulator thread when the thunk fires.
+
+THREADING (load-bearing):
+  - ONE host TCP server daemon thread (accept loop) + per-connection reader and
+    writer daemon threads. These touch ONLY plain-Python state under self._lock
+    (deques/bytearrays/dicts/sockets). They NEVER call any qemu.* / unicorn API
+    (unicorn is not thread-safe).
+  - The EMU thread runs the firmware and, on each intercepted thunk, calls the
+    matching hook which does ALL guest memory/register access and returns the
+    syscall result. No hook blocks (no sleeps / no socket I/O on the emu thread).
+
+SCOPING (safety): the thunks are shared by every socket in the firmware, so each
+hook only bridges Port502Server traffic and PASSES THROUGH everything else:
+  - select  -> bridged only when the caller (lr) is inside PollMsgToRout.
+  - accept  -> bridged only when listenfd == the configured listen_fd.
+  - recv/send/close/shutdown/setsockopt -> bridged only when fd is a bridge fd
+    (in self._fd2conn) or the listen_fd; otherwise the real syscall runs.
+  - __errno -> returns our scratch errno (EWOULDBLOCK-ish) only on the single
+    call immediately following a bridge recv that reported "no data"; otherwise
+    the real __errno runs.
+
+YAML (one SocketBridge instance owns all entries; cached by class):
+  - class: halucinator.bp_handlers.SocketBridge
+    function: select        # role; addr = the select thunk
+    addr: 0x20236f90
+    registration_args: { tcp_port: 502, listen_fd: 11, first_conn_fd: 200,
+                         max_conns: 32, bind_host: "0.0.0.0",
+                         poll_caller_lo: 0x200c91d0, poll_caller_hi: 0x200c962f,
+                         errno_scratch_addr: 0x04700000, errno_value: 0x46,
+                         verbose: false }
+  - { class: ..SocketBridge, function: accept,     addr: 0x201faebc }
+  - { class: ..SocketBridge, function: recv,       addr: 0x201fb354 }
+  - { class: ..SocketBridge, function: send,       addr: 0x201fb16c }
+  - { class: ..SocketBridge, function: close,      addr: 0x20231244 }
+  - { class: ..SocketBridge, function: shutdown,   addr: 0x201fb6a8 }
+  - { class: ..SocketBridge, function: setsockopt, addr: 0x201fb46c }
+  - { class: ..SocketBridge, function: __errno,    addr: 0x2022941c }
+"""
+from __future__ import annotations
+
+import collections
+import socket
+import struct
+import threading
+from typing import TYPE_CHECKING, Any, Deque, Dict, List, Optional, cast
+
+from halucinator.bp_handlers.bp_handler import BPHandler, HandlerFunction, HandlerReturn, bp_handler
+from halucinator import hal_log
+
+if TYPE_CHECKING:
+    from halucinator.backends.hal_backend import HalBackend
+
+hlog = hal_log.getHalLogger()
+
+U32 = 0xFFFFFFFF
+NEG1 = 0xFFFFFFFF   # -1 as an ARM int return
+
+
+class _HostConn:
+    """A host TCP client connection bridged to a guest fd."""
+    __slots__ = ("sock", "peer", "rx", "tx", "guest_fd", "state", "tx_event")
+
+    def __init__(self, sock: socket.socket, peer: Any) -> None:
+        self.sock = sock
+        self.peer = peer                 # (ip, port)
+        self.rx = bytearray()            # host -> firmware
+        self.tx = bytearray()            # firmware -> host
+        self.guest_fd: int = -1
+        self.state = "pending"           # pending -> open -> peer_closed -> dead
+        self.tx_event = threading.Event()
+
+
+class SocketBridge(BPHandler):
+    """Socket-syscall-layer host<->firmware TCP bridge. See module docstring."""
+
+    def __init__(self) -> None:
+        self.func_names: Dict[int, str] = {}     # addr -> role
+        self._lock = threading.Lock()
+        self._pending: Deque[_HostConn] = collections.deque()   # accepted, no fd yet
+        self._fd2conn: Dict[int, _HostConn] = {}
+        self._free_fds: List[int] = []
+        self._next_fd: int = 0
+        self._errno_pending = False              # set by recv "no data"; consumed by __errno
+        self._server_started = False
+        # global config (set on first register_handler)
+        self.tcp_port = 502
+        self.listen_fd = 11
+        self.first_conn_fd = 200
+        self.max_conns = 32
+        self.bind_host = "0.0.0.0"
+        self.poll_lo = 0x200c91d0
+        self.poll_hi = 0x200c962f
+        self.errno_scratch = 0x04700000
+        self.errno_value = 0x46
+        self.verbose = False
+
+    # ---- registration -------------------------------------------------
+    def register_handler(  # pylint: disable=too-many-arguments
+        self, qemu: "HalBackend", addr: int, func_name: str,
+        tcp_port: int = 502, listen_fd: int = 11, first_conn_fd: int = 200,
+        max_conns: int = 32, bind_host: str = "0.0.0.0",
+        poll_caller_lo: int = 0x200c91d0, poll_caller_hi: int = 0x200c962f,
+        errno_scratch_addr: int = 0x04700000, errno_value: int = 0x46,
+        verbose: bool = False,
+    ) -> HandlerFunction:  # pylint: disable=unused-argument
+        self.func_names[addr] = func_name
+        if not self._server_started:
+            self.tcp_port = int(tcp_port)
+            self.listen_fd = int(listen_fd)
+            self.first_conn_fd = int(first_conn_fd)
+            self._next_fd = int(first_conn_fd)
+            self.max_conns = int(max_conns)
+            self.bind_host = bind_host
+            self.poll_lo = int(poll_caller_lo)
+            self.poll_hi = int(poll_caller_hi)
+            self.errno_scratch = int(errno_scratch_addr)
+            self.errno_value = int(errno_value)
+            self.verbose = bool(verbose)
+            self._server_started = True
+            t = threading.Thread(target=self._server_thread, name="SocketBridge-502",
+                                 daemon=True)
+            t.start()
+            hlog.info("SocketBridge: host TCP server starting on %s:%d "
+                      "(listen_fd=%d, conn_fds=%d..%d)", self.bind_host, self.tcp_port,
+                      self.listen_fd, self.first_conn_fd, self.first_conn_fd + self.max_conns - 1)
+        return cast(HandlerFunction, SocketBridge.on_socket_call)
+
+    # ---- host side (background threads; NO qemu access) ---------------
+    def _server_thread(self) -> None:
+        try:
+            srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            srv.bind((self.bind_host, self.tcp_port))
+            srv.listen(8)
+        except Exception as e:  # noqa: BLE001
+            hlog.error("SocketBridge: cannot bind %s:%d (%s) -- bridge inactive",
+                       self.bind_host, self.tcp_port, e)
+            return
+        hlog.info("SocketBridge: listening on tcp/%d", self.tcp_port)
+        while True:
+            try:
+                cs, peer = srv.accept()
+            except Exception:  # noqa: BLE001
+                break
+            cs.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            conn = _HostConn(cs, peer)
+            with self._lock:
+                if len(self._fd2conn) + len(self._pending) >= self.max_conns:
+                    hlog.warning("SocketBridge: max_conns reached, refusing %s", peer)
+                    try:
+                        cs.close()
+                    except Exception:  # noqa: BLE001
+                        pass
+                    continue
+                self._pending.append(conn)
+            hlog.info("SocketBridge: host client connected %s (pending accept)", peer)
+            threading.Thread(target=self._reader_thread, args=(conn,), daemon=True).start()
+            threading.Thread(target=self._writer_thread, args=(conn,), daemon=True).start()
+
+    def _reader_thread(self, conn: _HostConn) -> None:
+        sock = conn.sock
+        while True:
+            try:
+                data = sock.recv(4096)
+            except Exception:  # noqa: BLE001
+                data = b""
+            if not data:
+                with self._lock:
+                    if conn.state in ("pending", "open"):
+                        conn.state = "peer_closed"
+                conn.tx_event.set()
+                return
+            with self._lock:
+                conn.rx.extend(data)
+
+    def _writer_thread(self, conn: _HostConn) -> None:
+        sock = conn.sock
+        while True:
+            conn.tx_event.wait()
+            conn.tx_event.clear()
+            with self._lock:
+                if conn.tx:
+                    chunk = bytes(conn.tx)
+                    del conn.tx[:]
+                else:
+                    chunk = b""
+                dead = conn.state == "dead"
+            if chunk:
+                try:
+                    sock.sendall(chunk)
+                except Exception:  # noqa: BLE001
+                    with self._lock:
+                        conn.state = "peer_closed"
+            if dead:
+                try:
+                    sock.close()
+                except Exception:  # noqa: BLE001
+                    pass
+                return
+
+    # ---- emu side (single dispatch thread; all qemu access here) ------
+    @bp_handler
+    def on_socket_call(self, qemu: "HalBackend", addr: int) -> HandlerReturn:
+        role = self.func_names.get(addr, "")
+        if role == "select":
+            return self._h_select(qemu)
+        if role == "accept":
+            return self._h_accept(qemu)
+        if role == "recv":
+            return self._h_recv(qemu)
+        if role == "send":
+            return self._h_send(qemu)
+        if role == "close":
+            return self._h_close(qemu)
+        if role == "shutdown":
+            return self._h_shutdown(qemu)
+        if role == "setsockopt":
+            return self._h_setsockopt(qemu)
+        if role == "__errno":
+            return self._h_errno(qemu)
+        return False, None
+
+    def _h_select(self, qemu: "HalBackend") -> HandlerReturn:
+        # Only bridge PollMsgToRout's select; pass others through to the real one.
+        lr = qemu.get_ret_addr()
+        if not (self.poll_lo <= lr <= self.poll_hi):
+            return False, None
+        nfds = qemu.get_arg(0)
+        readfds = qemu.get_arg(1)
+        if readfds == 0:
+            return True, 0
+        nwords = ((nfds + 31) >> 5)
+        if nwords < 1:
+            nwords = 1
+        if nwords > 64:           # the master set is 0x100 bytes = 64 words
+            nwords = 64
+        ready_fds: List[int] = []
+        with self._lock:
+            if self._pending:
+                ready_fds.append(self.listen_fd)
+            for fd, conn in self._fd2conn.items():
+                if conn.rx or conn.state == "peer_closed":
+                    ready_fds.append(fd)
+        # zero the readfds region, then set only ready bits
+        words = [0] * nwords
+        count = 0
+        for fd in ready_fds:
+            w = fd >> 5
+            if 0 <= w < nwords:
+                words[w] |= 1 << (fd & 0x1F)
+                count += 1
+        for i in range(nwords):
+            qemu.write_memory(readfds + i * 4, 4, words[i])
+        if self.verbose and count:
+            hlog.info("SocketBridge.select: ready=%s -> %d", ready_fds, count)
+        return True, count
+
+    def _h_accept(self, qemu: "HalBackend") -> HandlerReturn:
+        listenfd = qemu.get_arg(0)
+        if listenfd != self.listen_fd:
+            return False, None      # not Port502Server's listen socket
+        sa_ptr = qemu.get_arg(1)
+        len_ptr = qemu.get_arg(2)
+        with self._lock:
+            if not self._pending:
+                # no pending connection (select gates this; guard anyway)
+                self._errno_pending = True
+                return True, NEG1
+            conn = self._pending.popleft()
+            fd = self._free_fds.pop() if self._free_fds else self._next_fd
+            if fd == self._next_fd:
+                self._next_fd += 1
+            conn.guest_fd = fd
+            conn.state = "open"
+            self._fd2conn[fd] = conn
+            peer = conn.peer
+        # fill sockaddr_in (VxWorks: len(1), family(1), port(be16), addr(be32), 8 zero)
+        if sa_ptr:
+            try:
+                ip4 = socket.inet_aton(peer[0])
+            except Exception:  # noqa: BLE001
+                ip4 = b"\x7f\x00\x00\x01"
+            sa = struct.pack(">BBH4s8x", 16, socket.AF_INET, peer[1] & 0xFFFF, ip4)
+            qemu.write_memory_bytes(sa_ptr, sa)
+        if len_ptr:
+            qemu.write_memory(len_ptr, 4, 16)
+        hlog.info("SocketBridge.accept: %s -> guest fd %d", peer, fd)
+        return True, fd
+
+    def _h_recv(self, qemu: "HalBackend") -> HandlerReturn:
+        fd = qemu.get_arg(0)
+        conn = self._fd2conn.get(fd)
+        if conn is None:
+            return False, None      # not a bridge socket -> real recv
+        buf = qemu.get_arg(1)
+        length = qemu.get_arg(2)
+        with self._lock:
+            have = len(conn.rx)
+            if have > 0:
+                n = min(length, have)
+                chunk = bytes(conn.rx[:n])
+                del conn.rx[:n]
+            elif conn.state == "peer_closed":
+                n = 0
+                chunk = b""
+            else:
+                n = -1
+                chunk = b""
+        if n > 0:
+            qemu.write_memory_bytes(buf, chunk)
+            if self.verbose:
+                hlog.info("SocketBridge.recv: fd %d -> %d bytes", fd, n)
+            return True, n
+        if n == 0:
+            hlog.info("SocketBridge.recv: fd %d peer closed", fd)
+            return True, 0
+        # no data: -1 with errno=EWOULDBLOCK so rcvSocket retries (keeps conn)
+        qemu.write_memory(self.errno_scratch, 4, self.errno_value)
+        self._errno_pending = True
+        return True, NEG1
+
+    def _h_send(self, qemu: "HalBackend") -> HandlerReturn:
+        fd = qemu.get_arg(0)
+        conn = self._fd2conn.get(fd)
+        if conn is None:
+            return False, None      # not a bridge socket -> real send
+        buf = qemu.get_arg(1)
+        length = qemu.get_arg(2)
+        if length <= 0:
+            return True, 0
+        data = qemu.read_memory_bytes(buf, length)
+        with self._lock:
+            conn.tx.extend(data)
+        conn.tx_event.set()
+        if self.verbose:
+            hlog.info("SocketBridge.send: fd %d <- %d bytes", fd, length)
+        return True, length
+
+    def _h_close(self, qemu: "HalBackend") -> HandlerReturn:
+        fd = qemu.get_arg(0)
+        conn = self._fd2conn.get(fd)
+        if conn is None:
+            return False, None      # real close for non-bridge fds
+        with self._lock:
+            self._fd2conn.pop(fd, None)
+            if fd != self._next_fd - 1:
+                self._free_fds.append(fd)
+            else:
+                self._next_fd -= 1
+            conn.state = "dead"
+        conn.tx_event.set()          # wake writer to flush+close
+        hlog.info("SocketBridge.close: guest fd %d torn down", fd)
+        return True, 0
+
+    def _h_shutdown(self, qemu: "HalBackend") -> HandlerReturn:
+        fd = qemu.get_arg(0)
+        if fd not in self._fd2conn:
+            return False, None
+        return True, 0               # let sockClose's close() do the teardown
+
+    def _h_setsockopt(self, qemu: "HalBackend") -> HandlerReturn:
+        fd = qemu.get_arg(0)
+        if fd != self.listen_fd and fd not in self._fd2conn:
+            return False, None
+        return True, 0
+
+    def _h_errno(self, qemu: "HalBackend") -> HandlerReturn:
+        # Return our scratch errno pointer ONLY for the call right after a bridge
+        # recv "no data"; otherwise run the real __errno.
+        if self._errno_pending:
+            self._errno_pending = False
+            return True, self.errno_scratch
+        return False, None

--- a/src/halucinator/diagnostics/README.md
+++ b/src/halucinator/diagnostics/README.md
@@ -1,0 +1,98 @@
+<!-- Copyright 2026 Christopher Wright -->
+
+# `halucinator.diagnostics` — re-hosting diagnostic harnesses
+
+Reusable, **config-agnostic, address-parameterized** harnesses for diagnosing a
+firmware re-host: where is it stuck, who drives a hot loop, which MMIO register is
+polled, is the MMU page table installed, and a snapshot lab for fast model
+iteration. Nothing here is firmware-specific — every address / window / marker is
+supplied via env, so the same tool works on any target.
+
+Run any harness as a module:
+
+```bash
+python -m halucinator.diagnostics.<name>      # e.g. probe_at_pc
+```
+
+## First: use the built-in backend diagnostics where they cover it
+
+The unicorn backend (`halucinator/backends/unicorn_backend.py`) already implements
+a lot via env-vars — prefer these when they fit:
+
+| env var | covers |
+|---|---|
+| `HAL_PC_SAMPLE=1` (+`HAL_PC_SAMPLE_EVERY=N`) | global hot-PC histogram ("where is it stuck") |
+| `HAL_CALL_TRACE=<path>` (+`_MAX`) | `bl`/indirect call-edge graph |
+| `HAL_STEP_TRACE='0xLO-0xHI[:path]'` | single-step PC+sp+r0-r3+sl+ip+lr over a range |
+| `HAL_WATCH_WRITE='0xA,..'` | who writes a field |
+| `HAL_PIN_REGS='0xA=0xV,..'` (+`_PC_LO/HI`,`_ARM_PC`) | pin a RAM "ready" flag nothing sets |
+| `HAL_TRACK_READS=1` (+`HAL_BSS_START/END`) | first read of an uninit .bss global |
+| `HAL_SP_WATCH=1` | stack-pointer warps ≥64MB |
+| `HAL_MAP_UNMAPPED=1` | lazily zero-map stray ld/st gaps |
+| `HAL_AUTO_COUNTER_ADDRS='0xA,..'` (+`_STEP`) | make a free-running-counter MMIO reg monotonic |
+| `HAL_MMU_FLAT_FALLBACK=1`, `HAL_IRQ_CHUNK=N`, `HAL_BREAK_RAM_SPINS=1`, `HAL_RECOVER_BAD_CALLS=1`, `HAL_ARM_CPU_MODEL=` | operational knobs |
+
+These harnesses cover what those env-vars **don't**.
+
+## Common env (all harnesses, via `_common.py`)
+
+`HAL_DIAG_CFGS` (comma-separated `-c` configs, **required**), `HAL_DIAG_SYMS`
+(symbol csv), `HAL_DIAG_SECS` (watchdog, default 180), `HAL_DIAG_ARGS` (extra
+argv). Set `HAL_MMU_FLAT_FALLBACK=1` / `HAL_IRQ_CHUNK=8000` yourself as needed.
+Output goes to stderr; resolve printed addresses with your symbol csv.
+
+## The harnesses
+
+| module | captures | when |
+|---|---|---|
+| `probe_at_pc` | registers + pointer-deref chains at PCs (one/N-shot); `obj→vtable→slot` walks | "what args/pointers enter this instruction?", "which method does this C++ indirect call dispatch to?" |
+| `caller_histogram` | histogram/sequence of the caller `lr` at a function entry (+LR gate) | "who keeps calling this blocking/hot function?" — loop-driver finder (inverse of `HAL_CALL_TRACE`) |
+| `mmio_region_sampler` | hot-block **+** most-polled-MMIO histograms, multi-window | "within this subsystem, which block spins, and which device register is it polling?" |
+| `mmu_fault_introspect` | ARM CP15 TTBR0 + L1 descriptor at a fault PC; operand regs on the first unmapped abort | "is the page table installed?" — the Unicorn ARMv5 MMU/TTBR gate (fix is usually `HAL_MMU_FLAT_FALLBACK=1`) |
+| `snapshot_lab` | boot once → `context_save` + all RAM → restore-and-experiment in ~seconds each | iterating a deep gate without re-booting; needs a `LAB_SPEC` module |
+| `modbus_probe` | a stdlib Modbus/TCP client: connect, send one request, print the reply | round-trip a request through a re-hosted Modbus server (e.g. via a socket bridge) |
+
+Each module's docstring has its exact params + an example.
+
+## Examples
+
+```bash
+# Who drives a hot function (loop-driver finder):
+HAL_DIAG_CFGS=cfg.yaml HAL_DIAG_SYMS=syms.csv TARGET_PC=0x20054d80 MODE=hist \
+  python -m halucinator.diagnostics.caller_histogram
+
+# Resolve a C++ vtable dispatch at a call site:
+HAL_DIAG_CFGS=cfg.yaml PROBE_PCS=0x2001cc14 REGS=r0,lr DEREF='r0 * +8 *' \
+  python -m halucinator.diagnostics.probe_at_pc
+
+# Hot block + the MMIO register polled in that spin:
+HAL_DIAG_CFGS=cfg.yaml BLOCK_REGIONS=0x201b0000-0x201d0000 \
+  MMIO_REGIONS=0xfffb0000-0xfffc0000 python -m halucinator.diagnostics.mmio_region_sampler
+
+# MMU gate introspection at a faulting page-walk instruction:
+HAL_DIAG_CFGS=cfg.yaml FAULT_PC=0x201748f4 VA_REG=r9 \
+  python -m halucinator.diagnostics.mmu_fault_introspect
+
+# Probe a re-hosted Modbus server:
+python -m halucinator.diagnostics.modbus_probe --host 127.0.0.1 --port 502 --fc 0x2b --data 0e0101
+```
+
+## `snapshot_lab` — the `LAB_SPEC` contract
+
+`snapshot_lab` boots once to `BOOT_MARKER`, snapshots CPU+RAM, then restore-and-runs
+each experiment (~seconds each instead of a full re-boot). Point it at a small spec
+module:
+
+```bash
+HAL_DIAG_CFGS=cfg.yaml HAL_DIAG_SYMS=syms.csv LAB_SPEC=my_lab_spec.py \
+  python -m halucinator.diagnostics.snapshot_lab
+```
+
+The spec defines `BOOT_MARKER`, `SUCCESS_MARKERS` (`{addr:name}`), `INTERMEDIATE`
+(`{addr:name}`), `HANG_RANGE`/`HANG_CHUNKS`, and `EXPERIMENTS`
+(`[(name, install_fn)]`, where `install_fn(backend)` adds the unicorn hooks for
+that experiment). You supply a concrete spec for your target's deep gate
+(markers + experiments), keyed to addresses you resolve from your symbol csv.
+
+> A worked re-host that exercises several of these harnesses lives in
+> `test/firmware-rehosting/arm-vxworks-plc/` (the ARM/VxWorks PLC example).

--- a/src/halucinator/diagnostics/__init__.py
+++ b/src/halucinator/diagnostics/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable, config-agnostic re-hosting diagnostic harnesses.
+
+Run any harness as:  python -m halucinator.diagnostics.<name>
+See README.md for the full catalog, params, and the built-in HAL_* env-vars.
+"""

--- a/src/halucinator/diagnostics/_common.py
+++ b/src/halucinator/diagnostics/_common.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Christopher Wright
+
+"""Shared plumbing for the diagnostic harnesses.
+
+All harnesses are CONFIG-AGNOSTIC and ADDRESS-PARAMETERIZED via env vars, so the
+same script works on any firmware/config — nothing target-specific is baked in.
+
+Common env:
+  HAL_DIAG_CFGS   comma-separated -c config files          (required)
+  HAL_DIAG_SYMS   symbol csv for -s                        (optional)
+  HAL_DIAG_SECS   watchdog seconds before os._exit(0)      (default 180)
+  HAL_DIAG_ARGS   extra argv tokens appended verbatim      (optional)
+Plus the usual backend knobs you may want to set yourself, e.g.
+  HAL_MMU_FLAT_FALLBACK=1  HAL_IRQ_CHUNK=8000
+
+A harness supplies an `install(backend)` callback; we wrap UnicornBackend.init so
+the callback runs right after the backend builds its unicorn instance (backend._uc
+is then live and the firmware hasn't started). The callback installs unicorn hooks
+and returns; all capture happens in those hooks on the single emu thread.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from typing import Callable, List, Tuple
+
+import unicorn
+import unicorn.arm_const as arm_const   # noqa: F401  (harnesses import via this module)
+
+
+def env_int(name: str, default: int) -> int:
+    v = os.environ.get(name)
+    return int(v, 0) if v else default
+
+
+def parse_addrs(s: str) -> List[int]:
+    """'0xA,0xB,0xC' -> [0xA,0xB,0xC]."""
+    return [int(x, 0) for x in s.replace(" ", "").split(",") if x]
+
+
+def parse_ranges(s: str) -> List[Tuple[int, int]]:
+    """'0xLO-0xHI,0xLO2-0xHI2' -> [(lo,hi),...]."""
+    out: List[Tuple[int, int]] = []
+    for part in s.replace(" ", "").split(","):
+        if not part:
+            continue
+        lo, hi = part.split("-")
+        out.append((int(lo, 0), int(hi, 0)))
+    return out
+
+
+def in_ranges(addr: int, ranges: List[Tuple[int, int]]) -> bool:
+    for lo, hi in ranges:
+        if lo <= addr < hi:
+            return True
+    return False
+
+
+def _argv() -> List[str]:
+    cfgs = os.environ.get("HAL_DIAG_CFGS")
+    if not cfgs:
+        sys.stderr.write("HAL_DIAG_CFGS is required (comma-separated -c config files)\n")
+        raise SystemExit(2)
+    argv = ["hal"]
+    for c in cfgs.split(","):
+        argv += ["-c", c]
+    syms = os.environ.get("HAL_DIAG_SYMS")
+    if syms:
+        argv += ["-s", syms]
+    argv += ["--emulator", "unicorn"]
+    extra = os.environ.get("HAL_DIAG_ARGS")
+    if extra:
+        argv += extra.split()
+    return argv
+
+
+def run(install: Callable[[object], None], *, deadline: int | None = None) -> None:
+    """Wrap UnicornBackend.init with `install(backend)`, arm a watchdog, run main()."""
+    if deadline is None:
+        deadline = env_int("HAL_DIAG_SECS", 180)
+    from halucinator.backends import unicorn_backend as ub
+
+    _orig = ub.UnicornBackend.init
+
+    def _patched(self):  # noqa: ANN001
+        _orig(self)
+        try:
+            install(self)
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write(f"DIAG: install() failed: {e!r}\n")
+
+    ub.UnicornBackend.init = _patched
+
+    def _watchdog():
+        sys.stderr.write("DIAG: watchdog fired -- exiting\n")
+        sys.stderr.flush()
+        os._exit(0)
+
+    threading.Timer(deadline, _watchdog).start()
+    sys.argv = _argv()
+    from halucinator import main
+    main.main()
+
+
+# convenience: ARM register name -> unicorn const, for harnesses that take REGS=
+ARM_REGS = {
+    "r0": arm_const.UC_ARM_REG_R0, "r1": arm_const.UC_ARM_REG_R1,
+    "r2": arm_const.UC_ARM_REG_R2, "r3": arm_const.UC_ARM_REG_R3,
+    "r4": arm_const.UC_ARM_REG_R4, "r5": arm_const.UC_ARM_REG_R5,
+    "r6": arm_const.UC_ARM_REG_R6, "r7": arm_const.UC_ARM_REG_R7,
+    "r8": arm_const.UC_ARM_REG_R8, "r9": arm_const.UC_ARM_REG_R9,
+    "r10": arm_const.UC_ARM_REG_R10, "sl": arm_const.UC_ARM_REG_R10,
+    "r11": arm_const.UC_ARM_REG_R11, "fp": arm_const.UC_ARM_REG_R11,
+    "r12": arm_const.UC_ARM_REG_R12, "ip": arm_const.UC_ARM_REG_R12,
+    "sp": arm_const.UC_ARM_REG_SP, "lr": arm_const.UC_ARM_REG_LR,
+    "pc": arm_const.UC_ARM_REG_PC, "cpsr": arm_const.UC_ARM_REG_CPSR,
+}

--- a/src/halucinator/diagnostics/caller_histogram.py
+++ b/src/halucinator/diagnostics/caller_histogram.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Christopher Wright
+
+"""caller_histogram.py -- who keeps calling this function? (loop-driver finder)
+
+At a chosen function ENTRY, record the link register (return address) every time
+it fires. The top callers reveal which loop is driving a blocking/hot function
+(e.g. the caller of a semTake, or of a per-cycle dispatch that spins). This is the
+INVERSE of HAL_CALL_TRACE (which records callees keyed by caller).
+
+Env:
+  HAL_DIAG_CFGS / HAL_DIAG_SYMS / HAL_DIAG_SECS   (see _common.py)
+  TARGET_PC   '0x20054d80'   function entry to watch (address-filtered hook)
+  LR_LO/LR_HI '0x20000000'   optional: only record LRs within [LR_LO,LR_HI)
+  MODE        hist|seq        histogram of callers, or rolling last-N sequence
+  SEQ_N       '64'            window size for MODE=seq (default 64)
+  OUT         path            also write the dump here (default: stderr only)
+  DUMP_EVERY  '200000'        emit the running top-10 every N hits (default 0=off)
+
+Resolve the printed LR addresses to function names with your symbol csv.
+
+Example (find the loop driving ComExecCPU::Out):
+  HAL_DIAG_CFGS=cfg.yaml TARGET_PC=0x20054d80 MODE=hist python3 caller_histogram.py
+"""
+import collections
+import os
+import sys
+
+try:
+    from halucinator.diagnostics import _common as C
+except ImportError:  # direct-path execution
+    import _common as C
+import unicorn
+
+
+def install(backend):
+    uc = backend._uc
+    target = int(os.environ["TARGET_PC"], 0)
+    lr_lo = C.env_int("LR_LO", 0)
+    lr_hi = C.env_int("LR_HI", 0xFFFFFFFF)
+    mode = os.environ.get("MODE", "hist")
+    seq_n = C.env_int("SEQ_N", 64)
+    out_path = os.environ.get("OUT")
+    dump_every = C.env_int("DUMP_EVERY", 0)
+    hist = collections.Counter()
+    seq = collections.deque(maxlen=seq_n)
+    n = {"v": 0}
+
+    def cb(u, address, size, _ud):
+        lr = u.reg_read(C.ARM_REGS["lr"]) & ~1
+        if not (lr_lo <= lr < lr_hi):
+            return
+        n["v"] += 1
+        if mode == "seq":
+            seq.append(lr)
+        else:
+            hist[lr] += 1
+        if dump_every and n["v"] % dump_every == 0:
+            _dump(hist, seq, mode, out_path)
+
+    uc.hook_add(unicorn.UC_HOOK_CODE, cb, begin=target, end=target)
+    sys.stderr.write(f"CALLERS: watching 0x{target:08x} (mode={mode})\n")
+    # dump on watchdog exit too
+    import atexit
+    atexit.register(lambda: _dump(hist, seq, mode, out_path))
+
+
+def _dump(hist, seq, mode, out_path):
+    lines = []
+    if mode == "seq":
+        lines.append("CALLERS seq (oldest->newest): " + " -> ".join(f"0x{x:08x}" for x in seq))
+    else:
+        lines.append("CALLERS top:")
+        for lr, c in hist.most_common(15):
+            lines.append(f"  0x{lr:08x}  x{c}")
+    text = "\n".join(lines) + "\n"
+    sys.stderr.write(text)
+    sys.stderr.flush()
+    if out_path:
+        with open(out_path, "w") as f:
+            f.write(text)
+
+
+if __name__ == "__main__":
+    C.run(install)

--- a/src/halucinator/diagnostics/mmio_region_sampler.py
+++ b/src/halucinator/diagnostics/mmio_region_sampler.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Christopher Wright
+
+"""mmio_region_sampler.py -- hot-block + most-polled-MMIO histograms.
+
+Two captures in one run, each restricted to caller-supplied address windows:
+  - UC_HOOK_BLOCK histogram of hot basic-block PCs   -> "where is the CPU spinning"
+  - UC_HOOK_MEM_READ histogram of MMIO read addresses -> "which device register is
+    being polled in that spin"  (the dimension HAL_PC_SAMPLE lacks)
+Multi-window (disjoint ranges) filtering is done in Python, which a single hook
+begin/end can't express -- so you can watch e.g. the networking code AND the EMAC
+window while excluding the rest of boot's noise.
+
+Env:
+  HAL_DIAG_CFGS / HAL_DIAG_SYMS / HAL_DIAG_SECS   (see _common.py)
+  BLOCK_REGIONS  '0x201b0000-0x201d0000,0x20012000-0x20017000'  code windows
+                 (default: all PCs)
+  MMIO_REGIONS   '0xfffb0000-0xfffc0000'  MMIO windows
+                 (default: 0xf0000000-0x100000000, the usual high-MMIO band)
+  TOP            '20'    how many of each to print     (default 20)
+  DUMP_EVERY     '0'     periodic dump every N blocks   (default 0 = on exit only)
+
+Resolve printed PCs with your symbol csv; MMIO addrs are the device registers.
+"""
+import collections
+import os
+import sys
+
+try:
+    from halucinator.diagnostics import _common as C
+except ImportError:  # direct-path execution
+    import _common as C
+import unicorn
+
+
+def install(backend):
+    uc = backend._uc
+    block_regions = C.parse_ranges(os.environ.get("BLOCK_REGIONS", "")) or None
+    mmio_regions = C.parse_ranges(os.environ.get("MMIO_REGIONS", "0xf0000000-0x100000000"))
+    top = C.env_int("TOP", 20)
+    dump_every = C.env_int("DUMP_EVERY", 0)
+    blocks = collections.Counter()
+    reads = collections.Counter()
+    n = {"v": 0}
+
+    def block_cb(u, address, size, _ud):
+        if block_regions is None or C.in_ranges(address, block_regions):
+            blocks[address] += 1
+            n["v"] += 1
+            if dump_every and n["v"] % dump_every == 0:
+                _dump(blocks, reads, top)
+
+    def read_cb(u, access, address, size, value, _ud):
+        if C.in_ranges(address, mmio_regions):
+            reads[address] += 1
+
+    uc.hook_add(unicorn.UC_HOOK_BLOCK, block_cb)
+    # range-gate the mem-read hook to the union span (cheap) then filter precisely
+    lo = min(r[0] for r in mmio_regions)
+    hi = max(r[1] for r in mmio_regions)
+    uc.hook_add(unicorn.UC_HOOK_MEM_READ, read_cb, begin=lo, end=hi)
+    sys.stderr.write(f"SAMPLER: block_regions={block_regions or 'ALL'} mmio_regions={mmio_regions}\n")
+    import atexit
+    atexit.register(lambda: _dump(blocks, reads, top))
+
+
+def _dump(blocks, reads, top):
+    out = ["SAMPLER hot blocks:"]
+    for a, c in blocks.most_common(top):
+        out.append(f"  pc 0x{a:08x}  x{c}")
+    out.append("SAMPLER most-polled MMIO:")
+    for a, c in reads.most_common(top):
+        out.append(f"  mmio 0x{a:08x}  x{c}")
+    sys.stderr.write("\n".join(out) + "\n")
+    sys.stderr.flush()
+
+
+if __name__ == "__main__":
+    C.run(install)

--- a/src/halucinator/diagnostics/mmu_fault_introspect.py
+++ b/src/halucinator/diagnostics/mmu_fault_introspect.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Christopher Wright
+
+"""mmu_fault_introspect.py -- ARM MMU / data-abort introspection.
+
+For diagnosing the classic Unicorn ARMv5 MMU gate (after the firmware enables the
+MMU, translated loads abort because TTBR0/page-walk handling is unreliable). Two
+captures:
+  - UNMAPPED ABORTS: on the first read/write/fetch to an unmapped address it prints
+    the fault addr, access type/size, and the operand registers -- "exactly which
+    access aborts, and the pointer behind it."
+  - CP15 STATE at a chosen fault PC: reads TTBR0 (best-effort across Unicorn CP_REG
+    signatures), takes the faulting VA from a register, derives the active L1 table
+    base, computes the L1 descriptor address for that VA, and reads the descriptor
+    from physical RAM -- so you can see whether the page table is even installed
+    (a common finding is TTBR0==0 -> no translation -> every VA aborts).
+
+If this confirms an MMU translation gate, the fix is usually HAL_MMU_FLAT_FALLBACK=1
+(clear SCTLR.M on the first abort -> run flat). This harness is the DIAGNOSIS.
+
+Env:
+  HAL_DIAG_CFGS / HAL_DIAG_SYMS / HAL_DIAG_SECS   (see _common.py)
+  FAULT_PC   '0x201748f4'   the faulting page-walk instruction (optional)
+  VA_REG     'r9'           register holding the faulting VA at FAULT_PC (default r9)
+  EXIT_ON    'fault'        'fault' = os._exit after first unmapped abort dump; else keep going
+"""
+import os
+import sys
+
+try:
+    from halucinator.diagnostics import _common as C
+except ImportError:  # direct-path execution
+    import _common as C
+import unicorn
+import unicorn.arm_const as arm_const
+
+_ACC = {
+    unicorn.UC_MEM_READ_UNMAPPED: "READ", unicorn.UC_MEM_WRITE_UNMAPPED: "WRITE",
+    unicorn.UC_MEM_FETCH_UNMAPPED: "FETCH", unicorn.UC_MEM_READ_PROT: "READ_PROT",
+    unicorn.UC_MEM_WRITE_PROT: "WRITE_PROT", unicorn.UC_MEM_FETCH_PROT: "FETCH_PROT",
+}
+
+
+def _read_ttbr0(uc):
+    """Best-effort CP15 TTBR0 (c2,c0,0) read across Unicorn versions."""
+    for spec in (
+        (15, 0, 0, 2, 0, 0, 0),     # (cp,is64,sec,crn,crm,opc1,opc2) shape
+        (15, 0, 2, 0, 0, 0),
+        (15, 0, 0, 2, 0, 0),
+    ):
+        try:
+            return uc.reg_read(arm_const.UC_ARM_REG_CP_REG, spec)
+        except Exception:  # noqa: BLE001
+            continue
+    return None
+
+
+def _phys_read32(uc, addr):
+    try:
+        return int.from_bytes(uc.mem_read(addr & 0xFFFFFFFF, 4), "little")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def install(backend):
+    uc = backend._uc
+    fault_pc = os.environ.get("FAULT_PC")
+    va_reg = os.environ.get("VA_REG", "r9").lower()
+    exit_on = os.environ.get("EXIT_ON", "fault")
+    done = {"v": False}
+
+    def abort_cb(u, access, address, size, value, _ud):
+        if done["v"]:
+            return False
+        done["v"] = True
+        regs = "  ".join(f"{r}=0x{u.reg_read(C.ARM_REGS[r]):08x}" for r in ("r0", "r1", "r9", "lr", "pc"))
+        sys.stderr.write(f"MMU-ABORT {_ACC.get(access, access)} addr=0x{address:08x} size={size}  {regs}\n")
+        ttbr0 = _read_ttbr0(u)
+        sys.stderr.write(f"  TTBR0={'?' if ttbr0 is None else hex(ttbr0)}\n")
+        sys.stderr.flush()
+        if exit_on == "fault":
+            os._exit(0)
+        return False   # don't try to recover; let the backend handle it
+
+    for h in (unicorn.UC_HOOK_MEM_READ_UNMAPPED, unicorn.UC_HOOK_MEM_WRITE_UNMAPPED,
+              unicorn.UC_HOOK_MEM_FETCH_UNMAPPED, unicorn.UC_HOOK_MEM_READ_PROT,
+              unicorn.UC_HOOK_MEM_WRITE_PROT, unicorn.UC_HOOK_MEM_FETCH_PROT):
+        try:
+            uc.hook_add(h, abort_cb)
+        except Exception:  # noqa: BLE001
+            pass
+
+    if fault_pc:
+        fp = int(fault_pc, 0)
+
+        def cp15_cb(u, address, size, _ud):
+            ttbr0 = _read_ttbr0(u)
+            va = u.reg_read(C.ARM_REGS.get(va_reg, arm_const.UC_ARM_REG_R9))
+            line = [f"MMU-STATE @0x{address:08x}  {va_reg}(VA)=0x{va:08x}  TTBR0={'?' if ttbr0 is None else hex(ttbr0)}"]
+            if ttbr0:
+                l1_base = ttbr0 & ~0x3FFF
+                desc_addr = l1_base + ((va >> 20) << 2)
+                desc = _phys_read32(u, desc_addr)
+                line.append(f"  L1base=0x{l1_base:08x} desc@0x{desc_addr:08x}="
+                            + ("UNMAPPED" if desc is None else f"0x{desc:08x}"))
+            sys.stderr.write("  ".join(line) + "\n")
+            sys.stderr.flush()
+
+        uc.hook_add(unicorn.UC_HOOK_CODE, cp15_cb, begin=fp, end=fp)
+        sys.stderr.write(f"MMU: CP15 probe armed at 0x{fp:08x}\n")
+    sys.stderr.write("MMU: abort hooks armed\n")
+
+
+if __name__ == "__main__":
+    C.run(install)

--- a/src/halucinator/diagnostics/modbus_probe.py
+++ b/src/halucinator/diagnostics/modbus_probe.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Christopher Wright
+
+"""Minimal stdlib Modbus/TCP probe: connect, send one request, print the reply.
+Default = FC=03 Read Holding Registers (addr 0, qty 1). Also supports a raw
+UMAS-style FC via --fc/--data hex. Proves the socket-layer bridge round-trips a
+request through the firmware's real Port502Server.
+"""
+import argparse
+import socket
+import struct
+import sys
+import time
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=502)
+    ap.add_argument("--unit", type=int, default=1)
+    ap.add_argument("--fc", type=lambda x: int(x, 0), default=0x03)
+    ap.add_argument("--data", default="00000001",
+                    help="hex PDU body after the FC byte (default = addr0 qty1)")
+    ap.add_argument("--wait", type=float, default=8.0)
+    args = ap.parse_args()
+
+    pdu = bytes([args.fc]) + bytes.fromhex(args.data)
+    txid = 0x0001
+    frame = struct.pack(">HHHB", txid, 0, len(pdu) + 1, args.unit) + pdu
+
+    try:
+        s = socket.create_connection((args.host, args.port), timeout=args.wait)
+    except Exception as e:  # noqa: BLE001
+        print(f"PROBE: connect FAILED: {e}")
+        return 2
+    print(f"PROBE: connected to {args.host}:{args.port}")
+    s.settimeout(args.wait)
+    s.sendall(frame)
+    print(f"PROBE: sent  {frame.hex()}  (FC=0x{args.fc:02x})")
+    t0 = time.time()
+    buf = b""
+    try:
+        while time.time() - t0 < args.wait:
+            chunk = s.recv(512)
+            if not chunk:
+                print("PROBE: peer closed")
+                break
+            buf += chunk
+            if len(buf) >= 7:
+                _, _, length, _ = struct.unpack(">HHHB", buf[:7])
+                if len(buf) >= 6 + length:
+                    break
+    except socket.timeout:
+        pass
+    s.close()
+    if not buf:
+        print("PROBE: NO RESPONSE (timeout)")
+        return 1
+    print(f"PROBE: recv  {buf.hex()}  ({len(buf)} bytes)")
+    if len(buf) >= 8:
+        txid_r, protid, length, unit = struct.unpack(">HHHB", buf[:7])
+        rpdu = buf[7:7 + length - 1]
+        fc = rpdu[0] if rpdu else None
+        print(f"PROBE: MBAP txid={txid_r} prot={protid} len={length} unit={unit} "
+              f"respFC=0x{fc:02x}" + (" (EXCEPTION)" if fc and fc & 0x80 else " (OK)"))
+    print("PROBE: RESPONSE RECEIVED -- bridge round-trip works")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/halucinator/diagnostics/probe_at_pc.py
+++ b/src/halucinator/diagnostics/probe_at_pc.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Christopher Wright
+
+"""probe_at_pc.py -- dump registers + dereferenced memory at one or more PCs.
+
+Answers: "what were the exact arg/pointer values entering this instruction?" and
+"which method does this C++ indirect call actually dispatch to?" (via a pointer
+walk obj -> vtable -> slot).
+
+Env:
+  HAL_DIAG_CFGS / HAL_DIAG_SYMS / HAL_DIAG_SECS   (see _common.py)
+  PROBE_PCS   '0x20174..,0x2001cc14'  PCs to break on (address-filtered hook)
+  REGS        'r0,r1,r9,lr'           registers to print          (default r0-r3,lr,sp,pc)
+  DEREF       'r0; r9; r0 * +8 *'     pointer-walk specs, ';'-separated. Each spec
+                                      is space-separated steps: first is a reg, then
+                                      '*' (deref 32-bit) or '+N'/'-N' (offset).
+                                      e.g. 'r0 * +8 *' = mem[mem[r0]+8] (vtable slot).
+  HITS        per-PC max captures     (default 1 = one-shot per PC)
+  EXIT_AFTER  total captures then exit (default 0 = never; rely on watchdog)
+
+Example (find a C++ vtable dispatch target at a call site):
+  HAL_DIAG_CFGS=cfg.yaml HAL_DIAG_SYMS=syms.csv PROBE_PCS=0x2001cc14 \
+  REGS=r0,lr DEREF='r0 * +8 *' python3 probe_at_pc.py
+"""
+import os
+import sys
+
+try:
+    from halucinator.diagnostics import _common as C
+except ImportError:  # direct-path execution
+    import _common as C
+import unicorn
+
+
+def _read32(uc, addr):
+    try:
+        return int.from_bytes(uc.mem_read(addr & 0xFFFFFFFF, 4), "little")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _eval(uc, spec):
+    steps = spec.split()
+    val = uc.reg_read(C.ARM_REGS[steps[0].lower()])
+    for st in steps[1:]:
+        if st == "*":
+            val = _read32(uc, val)
+            if val is None:
+                return None
+        elif st[0] in "+-":
+            val = (val + int(st, 0)) & 0xFFFFFFFF
+    return val
+
+
+def install(backend):
+    uc = backend._uc
+    pcs = C.parse_addrs(os.environ["PROBE_PCS"])
+    regs = [r.strip().lower() for r in os.environ.get("REGS", "r0,r1,r2,r3,lr,sp,pc").split(",") if r.strip()]
+    derefs = [d.strip() for d in os.environ.get("DEREF", "").split(";") if d.strip()]
+    hits_max = C.env_int("HITS", 1)
+    exit_after = C.env_int("EXIT_AFTER", 0)
+    state = {"hits": {p: 0 for p in pcs}, "total": 0}
+
+    def cb(u, address, size, _ud):
+        if state["hits"].get(address, 0) >= hits_max:
+            return
+        state["hits"][address] += 1
+        state["total"] += 1
+        parts = [f"r:{r}=0x{u.reg_read(C.ARM_REGS[r]):08x}" for r in regs if r in C.ARM_REGS]
+        for d in derefs:
+            v = _eval(u, d)
+            parts.append(f"[{d}]=" + ("UNMAPPED" if v is None else f"0x{v:08x}"))
+        sys.stderr.write(f"PROBE @0x{address:08x}  " + "  ".join(parts) + "\n")
+        sys.stderr.flush()
+        if exit_after and state["total"] >= exit_after:
+            os._exit(0)
+
+    for p in pcs:
+        uc.hook_add(unicorn.UC_HOOK_CODE, cb, begin=p, end=p)
+    sys.stderr.write(f"PROBE: armed at {[hex(p) for p in pcs]}\n")
+
+
+if __name__ == "__main__":
+    C.run(install)

--- a/src/halucinator/diagnostics/snapshot_lab.py
+++ b/src/halucinator/diagnostics/snapshot_lab.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Christopher Wright
+
+"""snapshot_lab.py -- boot ONCE, snapshot, then restore-and-experiment in seconds.
+
+The iteration-speed multiplier for deep gates: instead of re-booting (tens of
+seconds) for every model tweak, boot once to a chosen marker, snapshot the full
+unicorn CPU context + all RAM, then for each experiment RESTORE the snapshot,
+install that experiment's hook bundle, and run a bounded IRQ-draining chunk loop
+until a success marker / hang / off-rails / timeout -- ~1-2 s per experiment.
+
+This is the GENERALIZED form of a per-firmware experiment lab. All addresses are
+supplied by a small EXPERIMENT SPEC module you point at via env -- nothing here
+is firmware-specific; you supply a concrete spec for your target.
+
+Env:
+  HAL_DIAG_CFGS / HAL_DIAG_SYMS                 (see _common.py)
+  LAB_SPEC      path to a python file defining the spec (see below)   (required)
+  LAB_BOOT_SECS native-boot watchdog seconds                          (default 120)
+  LAB_EXP_SECS  per-experiment budget seconds                         (default 90)
+  LAB_CHUNK     instructions per emu_start chunk                      (default 8000)
+
+The LAB_SPEC module must define:
+  BOOT_MARKER       : int        PC to boot to, then snapshot
+  SUCCESS_MARKERS   : {int:str}  PCs whose hit = experiment succeeded (reported)
+  INTERMEDIATE      : {int:str}  PCs to log-and-continue past (milestones)
+  HANG_RANGE        : (lo,hi)    PC range that, if sampled for HANG_CHUNKS
+                                 consecutive chunks, means "pended/idle"
+  HANG_CHUNKS       : int        (e.g. 400)
+  EXPERIMENTS       : [(name, install_fn)]   install_fn(backend) adds uc hooks
+
+NOTE: PC-writing hooks disrupt unicorn's emu_start instruction `count` cap, so an
+experiment can overshoot LAB_EXP_SECS -- the wall-clock deadline still bounds it.
+Once such hooks are part of the real config, validate natively (run_cfg.py), not
+in the lab.
+"""
+import importlib.util
+import os
+import sys
+import time
+
+try:
+    from halucinator.diagnostics import _common as C
+except ImportError:  # direct-path execution
+    import _common as C
+import unicorn
+
+
+def _load_spec(path):
+    spec = importlib.util.spec_from_file_location("lab_spec", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _snapshot(uc):
+    ctx = uc.context_save()
+    mem = [(b, bytes(uc.mem_read(b, e - b + 1))) for (b, e, _p) in uc.mem_regions()]
+    return ctx, mem
+
+
+def _restore(uc, snap):
+    ctx, mem = snap
+    for b, data in mem:
+        uc.mem_write(b, data)
+    uc.context_restore(ctx)
+
+
+def _drain_irqs(backend):
+    pend = getattr(backend, "_pending_irqs", None)
+    apply = getattr(backend, "_apply_pending_irq", None)
+    if pend and apply:
+        while pend:
+            apply(pend.pop(0))
+
+
+def _chunks(backend, targets, inter, deadline, hang_range, hang_chunks, chunk):
+    uc = backend._uc
+    rd = backend.read_register
+    thumb = 1 if getattr(backend, "_is_thumb", False) else 0
+    lo, hi = hang_range
+    streak = 0
+    while time.time() < deadline:
+        _drain_irqs(backend)
+        pc = rd("pc")
+        try:
+            uc.emu_start(pc | thumb, 0xFFFFFFFF, timeout=0, count=chunk)
+        except unicorn.UcError:
+            pass
+        npc = rd("pc")
+        if npc in targets:
+            return ("SUCCESS", npc)
+        if npc in inter:
+            sys.stderr.write(f"  >> {inter[npc]}\n")
+            # nudge past the marker so we don't re-hit it forever
+            continue
+        if lo <= npc <= hi:
+            streak += 1
+            if streak >= hang_chunks:
+                return ("HANG", npc)
+        else:
+            streak = 0
+    return ("TIMEOUT", None)
+
+
+def make_loop(spec_path):
+    spec = _load_spec(spec_path)
+    boot_secs = C.env_int("LAB_BOOT_SECS", 120)
+    exp_secs = C.env_int("LAB_EXP_SECS", 90)
+    chunk = C.env_int("LAB_CHUNK", 8000)
+
+    def lab_loop(backend):
+        uc = backend._uc
+        t0 = time.time()
+        sys.stderr.write("LAB: booting to BOOT_MARKER...\n")
+        res, _ = _chunks(backend, {spec.BOOT_MARKER}, getattr(spec, "INTERMEDIATE", {}),
+                         time.time() + boot_secs, getattr(spec, "HANG_RANGE", (0, 0)),
+                         10 ** 9, chunk)
+        if res != "SUCCESS":
+            sys.stderr.write(f"LAB: did not reach BOOT_MARKER ({res})\n")
+            return
+        sys.stderr.write(f"LAB: reached boot marker in {time.time()-t0:.0f}s; snapshotting\n")
+        snap = _snapshot(uc)
+        mb = sum(len(d) for _, d in snap[1]) >> 20
+        sys.stderr.write(f"LAB: snapshot {mb} MB\n")
+        for name, install in spec.EXPERIMENTS:
+            _restore(uc, snap)
+            try:
+                install(backend)
+            except Exception as e:  # noqa: BLE001
+                sys.stderr.write(f"LAB [{name}]: install failed {e!r}\n")
+                continue
+            t = time.time()
+            res, addr = _chunks(backend, dict(spec.SUCCESS_MARKERS), getattr(spec, "INTERMEDIATE", {}),
+                                time.time() + exp_secs, getattr(spec, "HANG_RANGE", (0, 0)),
+                                getattr(spec, "HANG_CHUNKS", 400), chunk)
+            tag = spec.SUCCESS_MARKERS.get(addr, hex(addr) if addr else "-")
+            sys.stderr.write(f"LAB [{name}]: {res} {tag}  ({time.time()-t:.1f}s)\n")
+            sys.stderr.flush()
+        sys.stderr.write("LAB: done\n")
+
+    return lab_loop
+
+
+def main():
+    spec_path = os.environ.get("LAB_SPEC")
+    if not spec_path:
+        sys.stderr.write("LAB_SPEC=<path to experiment spec module> is required\n")
+        raise SystemExit(2)
+    from halucinator import main as halmain
+    halmain._in_process_dispatch_loop = make_loop(spec_path)
+    sys.argv = C._argv()
+    halmain.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -14,7 +14,7 @@ import os
 import sys
 import argparse
 import signal
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 # avatar2 is imported best-effort. The pluggable-backend refactor means
 # the unicorn/ghidra/renode paths don't touch avatar2 at all, and avatar2
@@ -907,6 +907,27 @@ def _qemu_backend_dispatch_loop(backend: "HalBackend") -> None:
             backend.cont()
 
 
+def _instantiate_peripheral(name: str, memory: Any, db_path: str) -> Any:
+    """Resolve an `emulate:` peripheral name to an instance. Searches the
+    at91 module (At91SysCtrl/At91Emac/At91Dbgu), then the generic module
+    (GenericPeripheral/HaltPeripheral). Returns None if the name is unknown
+    (region falls back to plain RAM)."""
+    from halucinator.peripheral_models import at91, generic
+    cls = (getattr(at91, name, None)
+           or getattr(generic, name, None))
+    if cls is None:
+        log.warning("Unknown emulate peripheral %r; region %s left as RAM",
+                    name, memory.name)
+        return None
+    kwargs: Dict[str, Any] = {}
+    # Pull peripheral-specific kwargs from the YAML `properties` block
+    # (HalMemConfig.properties is the generic per-peripheral dict slot).
+    extra = getattr(memory, "properties", None)
+    if isinstance(extra, dict):
+        kwargs.update(extra)
+    return cls(memory.name, memory.base_addr, memory.size, **kwargs)
+
+
 def _emulate_with_unicorn_backend(
     config: Any,
     target_name: Optional[str],
@@ -940,7 +961,11 @@ def _emulate_with_unicorn_backend(
     backend: "HalBackend" = UnicornBackend(arch=arch)
 
     # Register memory regions from config, loading any firmware file bytes
-    # into the region on add.
+    # into the region on add. Regions with an `emulate:` peripheral get
+    # their hw_read/hw_write bound to the unicorn MMIO hooks (the avatar2
+    # path does this via avatar-rmemory; the in-process path wires it here).
+    auto_peripherals: List[Any] = []
+    mmio_db = os.path.join(outdir, "mmio_trace.sqlite")
     for memory in config.memories.values():
         region = MemoryRegion(
             name=memory.name,
@@ -949,8 +974,25 @@ def _emulate_with_unicorn_backend(
             permissions=memory.permissions or "rwx",
             file=memory.file,
         )
-        log.info("Adding Memory: %s Addr: 0x%08x Size: 0x%08x",
-                 memory.name, memory.base_addr, memory.size)
+        emulate_name = getattr(memory, "emulate", None)
+        if emulate_name:
+            periph = _instantiate_peripheral(emulate_name, memory, mmio_db)
+            if periph is not None:
+                region.read_hook = (
+                    lambda off, sz, _p=periph, _b=backend: _p.hw_read(
+                        off, sz, pc=_b.regs.pc))
+                region.write_hook = (
+                    lambda off, sz, val, _p=periph, _b=backend: _p.hw_write(
+                        off, sz, val, pc=_b.regs.pc))
+                auto_peripherals.append(periph)
+                if periph.__class__.__name__ == "AutoPeripheral":
+                    backend.skip_svc = True
+                    # NB: backend.auto_recover_loops stays OFF — forcing a
+                    # return out of a non-MMIO loop can land on a stale LR and
+                    # fault; the MMIO breaker + skip_svc keep firmware running.
+        log.info("Adding Memory: %s Addr: 0x%08x Size: 0x%08x%s",
+                 memory.name, memory.base_addr, memory.size,
+                 f" (emulate={emulate_name})" if emulate_name else "")
         backend.add_memory_region(region)
 
     backend.init()
@@ -1043,11 +1085,15 @@ def _in_process_dispatch_loop(backend: "HalBackend") -> None:
             backend.execute_return(ret_value)  # sets pc=lr, blocks until
                                                 # next breakpoint
         else:
-            # Not yet supported: single-step past bp then continue.
-            # For now treat as terminal.
-            log.warning("Non-intercept bp_handler return on unicorn "
-                        "not yet supported; stopping.")
-            return
+            # Observe/patch-and-continue handler (do_intercept=False): the
+            # firmware should keep executing the real instruction at this PC.
+            # Step past the breakpoint once, then continue to the next one.
+            cont_past = getattr(backend, "continue_past_breakpoint", None)
+            if cont_past is None:
+                log.warning("Non-intercept bp_handler return not supported on "
+                            "%s; stopping.", type(backend).__name__)
+                return
+            cont_past()
 
 
 def _renode_mmio_setup(

--- a/src/halucinator/peripheral_models/at91.py
+++ b/src/halucinator/peripheral_models/at91.py
@@ -1,0 +1,385 @@
+# Copyright 2026 Christopher Wright
+
+"""AT91RM9200 peripheral models: At91SysCtrl (System Controller / ST-PIT
+status), At91Emac (EMAC + MII/PHY link-up), and At91Dbgu (Debug UART).
+These model the AT91 silicon and are OS-agnostic (used by the ARM/VxWorks
+re-host, but applicable to any OS on the AT91RM9200).
+
+--- At91Dbgu (below) ---
+Models the AT91 debug UART register window so firmware that writes to
+THR (transmit holding register) gets its bytes captured and forwarded
+to the host. Used by ARM/AT91-family VxWorks rehosts.
+
+Register layout (relative to base, typically 0xFFFFF200):
+    0x00  CR    Control Register  (RESET / ENABLE bits)
+    0x04  MR    Mode Register
+    0x08  IER   Interrupt Enable Register
+    0x0C  IDR   Interrupt Disable Register
+    0x10  IMR   Interrupt Mask Register
+    0x14  CSR   Channel Status Register
+                 bit 0 RXRDY  (RX data available in RHR)
+                 bit 1 TXRDY  (TX register empty, ready for new byte)
+                 bit 9 TXEMPTY (TX shift register empty)
+    0x18  RHR   Receiver Holding Register
+    0x1C  THR   Transmitter Holding Register
+    0x20  BRGR  Baud Rate Generator Register
+    0x40  C1R   Chip ID 1
+    0x44  C2R   Chip ID 2
+    0x48  FNTR  Force NTRST
+    0x100+      PDC (peripheral DMA controller; unhandled here)
+
+Bridging modes:
+- "log" (default): captures TX bytes to a log file (one byte per write,
+  newline-separated lines for readability)
+- "stderr": prints captured bytes directly to halucinator stderr/log
+- "pty": creates a host pty pair; reads from the slave end push into RX,
+  TX bytes are written to the slave. (Future work; stub raises.)
+- "tcp": creates a TCP server on a configured port; one client at a
+  time. (Future work; stub raises.)
+
+YAML usage:
+    peripherals:
+      at91_dbgu:
+        base_addr: 0xFFFFF200
+        size: 0x200
+        emulate: At91Dbgu
+        permissions: rw-
+        # Optional class_args via the future bridge_mode field; for now
+        # the default 'log' mode writes to /tmp/<name>_uart.log.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any, Optional
+
+from .generic import GenericPeripheral
+from .. import hal_log
+
+log = logging.getLogger(__name__)
+hlog = hal_log.getHalLogger()
+
+
+# Register offsets
+REG_CR   = 0x00
+REG_MR   = 0x04
+REG_IER  = 0x08
+REG_IDR  = 0x0c
+REG_IMR  = 0x10
+REG_CSR  = 0x14
+REG_RHR  = 0x18
+REG_THR  = 0x1c
+REG_BRGR = 0x20
+
+# CSR status bits
+CSR_RXRDY   = 1 << 0
+CSR_TXRDY   = 1 << 1
+CSR_TXEMPTY = 1 << 9
+
+
+class At91Dbgu(GenericPeripheral):
+    """AT91 Debug UART peripheral model with host bridging.
+
+    Default: captures TX bytes to /tmp/<name>_uart.log. Reads from CSR
+    return TXRDY|TXEMPTY always (firmware sees the UART as immediately
+    ready to send). RX is empty unless a future bridge mode pushes
+    bytes.
+    """
+
+    def __init__(self, name: str, address: int, size: int,
+                 bridge_mode: str = "log",
+                 log_path: Optional[str] = None,
+                 reg_offset: int = 0,
+                 pty_link_path: Optional[str] = None,
+                 **kwargs: Any) -> None:
+        super().__init__(name, address, size, **kwargs)
+        self.bridge_mode = bridge_mode
+        self.log_path = log_path or f"/tmp/{name}_uart.log"
+        # reg_offset: where the DBGU register block actually starts
+        # within this mapped peripheral region. The AT91 DBGU is at
+        # absolute 0xFFFFF200 but page-alignment forces the mapped
+        # region to start at 0xFFFFF000, so reg_offset=0x200.
+        self.reg_offset = reg_offset
+        # pty mode state
+        self._pty_master_fd: Optional[int] = None
+        self._pty_slave_path: Optional[str] = None
+        self._pty_link_path = pty_link_path or f"/tmp/{name}_pty"
+        self._pty_reader_thread = None
+        self._pty_stop = False
+        self._mode_reg = 0
+        self._ier = 0
+        self._imr = 0
+        self._brgr = 0
+        # RX buffer for future bidirectional bridging
+        self._rx_buf: bytearray = bytearray()
+        # TX byte accumulator (for ASCII-line capture in log mode)
+        self._tx_line: bytearray = bytearray()
+        # Total bytes captured (logged)
+        self.tx_count = 0
+        # Open log file in "w" so each run starts fresh
+        try:
+            self._log_fp = open(self.log_path, "wb")
+            hlog.info("At91Dbgu(%s): base=0x%08x size=0x%x bridge=%s "
+                      "log=%s", name, address, size, bridge_mode,
+                      self.log_path)
+        except Exception as _e:  # noqa: BLE001
+            hlog.error("At91Dbgu: failed to open log %s: %s", self.log_path, _e)
+            self._log_fp = None
+
+        # If pty bridge mode requested, open a pty pair and spawn a
+        # reader thread that feeds incoming host bytes into the RX
+        # buffer. The slave-side path is symlinked to pty_link_path so
+        # host tools can talk to a stable path.
+        if bridge_mode == "pty":
+            self._open_pty()
+
+    # ---------- pty bridge ----------
+
+    def _open_pty(self) -> None:
+        """Open a host pty pair and start a reader thread. The slave
+        side is symlinked to `pty_link_path` for stable host access."""
+        import pty as _pty
+        import threading
+
+        try:
+            master_fd, slave_fd = _pty.openpty()
+            slave_path = os.ttyname(slave_fd)
+            self._pty_master_fd = master_fd
+            self._pty_slave_path = slave_path
+            # Symlink the slave to a stable path
+            try:
+                if os.path.islink(self._pty_link_path) or os.path.exists(self._pty_link_path):
+                    os.unlink(self._pty_link_path)
+                os.symlink(slave_path, self._pty_link_path)
+            except Exception as _e:  # noqa: BLE001
+                hlog.error("At91Dbgu: pty symlink failed: %s", _e)
+            os.close(slave_fd)  # keep only master; clients open via the symlink
+
+            def _reader() -> None:
+                while not self._pty_stop:
+                    try:
+                        chunk = os.read(master_fd, 64)
+                        if chunk:
+                            self.feed_rx(chunk)
+                            hlog.info("At91Dbgu(%s) pty<-host: %d bytes",
+                                      self.name, len(chunk))
+                    except OSError:
+                        break
+                    except Exception as _e:  # noqa: BLE001
+                        hlog.error("At91Dbgu pty reader: %s", _e)
+                        break
+
+            t = threading.Thread(target=_reader, daemon=True,
+                                 name=f"{self.name}-pty-reader")
+            t.start()
+            self._pty_reader_thread = t
+            hlog.info("At91Dbgu(%s): pty bridge open. Slave=%s "
+                      "(symlinked %s).  Use:  python3 -c 'open(\"%s\",\"wb\").write(b\"abc\")'  to send bytes.",
+                      self.name, slave_path, self._pty_link_path,
+                      self._pty_link_path)
+        except Exception as _e:  # noqa: BLE001
+            hlog.error("At91Dbgu: pty open failed: %s", _e)
+
+    # ---------- helpers ----------
+
+    def _emit_tx(self, byte: int) -> None:
+        """Forward a TX byte to the configured bridge sink."""
+        b = byte & 0xff
+        self.tx_count += 1
+        if self.bridge_mode == "stderr":
+            try:
+                sys.stderr.write(chr(b))
+                sys.stderr.flush()
+            except Exception:
+                pass
+        elif self.bridge_mode == "pty" and self._pty_master_fd is not None:
+            try:
+                os.write(self._pty_master_fd, bytes([b]))
+            except Exception:
+                pass
+        # Always also accumulate to log_path for offline review
+        if self._log_fp is not None:
+            try:
+                self._log_fp.write(bytes([b]))
+                # Flush on newline or every 64 bytes for visibility
+                if b == 0x0a or self.tx_count % 64 == 0:
+                    self._log_fp.flush()
+            except Exception:
+                pass
+        # Also accumulate ASCII line and log when newline appears
+        self._tx_line.append(b)
+        if b == 0x0a or len(self._tx_line) >= 256:
+            try:
+                line = bytes(self._tx_line).rstrip(b"\r\n").decode(
+                    "ascii", errors="replace")
+                if line:
+                    hlog.info("At91Dbgu TX: %s", line)
+            except Exception:
+                pass
+            self._tx_line.clear()
+
+    def _pop_rx(self) -> int:
+        """Pop one byte from the RX buffer, or 0 if empty."""
+        if self._rx_buf:
+            b = self._rx_buf[0]
+            del self._rx_buf[0]
+            return b
+        return 0
+
+    def feed_rx(self, data: bytes) -> None:
+        """Public API: push bytes into the RX queue. Future bridge code
+        (pty reader / TCP server) calls this to feed firmware input."""
+        self._rx_buf.extend(data)
+
+    # ---------- peripheral interface ----------
+
+    def hw_read(self, offset: int, size: int,
+                pc: int = 0xBAADBAAD, **kwargs: Any) -> int:
+        abs_addr = self.address + offset
+        # Translate the offset from the mapped region into the actual
+        # DBGU register offset.
+        offset = offset - self.reg_offset
+        if offset not in (REG_CSR, REG_RHR, REG_MR, REG_IER, REG_IMR,
+                          REG_BRGR) and os.environ.get("HAL_MMIO_LOG") == "1":
+            # Non-DBGU register in this page (AIC at +0x000, PIO/PMC/ST/RTC
+            # higher up, chip-ID, etc.) -- all return 0 here. Prime suspect
+            # for "firmware read a status/presence bit, got 0, wrong branch".
+            if not hasattr(self, "_nondbgu_seen"):
+                self._nondbgu_seen = set()
+            if abs_addr not in self._nondbgu_seen:
+                self._nondbgu_seen.add(abs_addr)
+                hlog.info("DBGU-PAGE non-DBGU read pc=0x%08x addr=0x%08x "
+                          "size=%d -> 0x0 (unmodeled)", pc, abs_addr, size)
+        if offset < 0:
+            # Read from a page-aligned address BEFORE the DBGU register
+            # block; absorbed silently.
+            return 0
+        if offset == REG_CSR:
+            # Status: always ready to TX; RXRDY if buffer non-empty.
+            val = CSR_TXRDY | CSR_TXEMPTY
+            if self._rx_buf:
+                val |= CSR_RXRDY
+            return val
+        if offset == REG_RHR:
+            return self._pop_rx()
+        if offset == REG_MR:
+            return self._mode_reg
+        if offset == REG_IER:
+            return self._ier
+        if offset == REG_IMR:
+            return self._imr
+        if offset == REG_BRGR:
+            return self._brgr
+        # Other registers (chip ID, etc.) - return 0
+        return 0
+
+    def hw_write(self, offset: int, size: int, value: int,
+                 pc: int = 0xBAADBAAD, **kwargs: Any) -> bool:
+        offset = offset - self.reg_offset
+        if offset < 0:
+            return True
+        if offset == REG_THR:
+            self._emit_tx(value)
+            return True
+        if offset == REG_MR:
+            self._mode_reg = value & 0xffffffff
+            return True
+        if offset == REG_IER:
+            self._ier |= value & 0xffffffff
+            self._imr |= value & 0xffffffff
+            return True
+        if offset == REG_IDR:
+            self._imr &= ~(value & 0xffffffff)
+            return True
+        if offset == REG_BRGR:
+            self._brgr = value & 0xffffffff
+            return True
+        if offset == REG_CR:
+            # CR writes (reset / enable). Just absorb -- no real
+            # hardware state to manipulate. Could log if useful.
+            return True
+        # Other writes (chip ID, PDC, etc.) absorbed silently
+        return True
+
+    def __del__(self) -> None:
+        try:
+            if getattr(self, "_log_fp", None) is not None:
+                self._log_fp.flush()
+                self._log_fp.close()
+        except Exception:
+            pass
+        try:
+            self._pty_stop = True
+            if getattr(self, "_pty_master_fd", None) is not None:
+                os.close(self._pty_master_fd)
+            if getattr(self, "_pty_link_path", None) and \
+               os.path.islink(self._pty_link_path):
+                os.unlink(self._pty_link_path)
+        except Exception:
+            pass
+
+
+class At91SysCtrl(GenericPeripheral):
+    '''AT91RM9200 system-controller window (0xffff0000) that reports the
+    System Timer (ST) periodic-interval as always-pending, so the System-IRQ
+    dispatcher (mr9200Int1Dispatcher) actually invokes the registered clock
+    handler each time the synthesised clock tick is injected.
+
+    The dispatcher gates the clock call on (ST_SR & ST_IMR) & PITS: it reads
+    ST_SR (0xfffffd10, status) and ST_IMR (0xfffffd1c, interrupt mask) and only
+    calls the PIT/clock handler when bit0 is set in both. With a plain
+    GenericPeripheral those read 0, so tickAnnounce never runs and the scheduler
+    idle-spins. Returning bit0=1 for those two registers (and 0 elsewhere, like
+    GenericPeripheral) makes each injected System IRQ drive one clock tick.
+    Read-to-clear is irrelevant here -- we re-assert every tick by construction.'''
+    _PITS_REGS = (0xfffffd10, 0xfffffd1c)  # ST_SR, ST_IMR
+
+    def hw_read(self, offset: int, size: int, pc: int = 0xBAADBAAD, **kwargs: Any) -> int:
+        if (self.address + offset) in self._PITS_REGS:
+            return 1
+        return super().hw_read(offset, size, pc=pc, **kwargs)
+
+
+class At91Emac(GenericPeripheral):
+    '''AT91RM9200 peripheral window (0xfffb0000) that models just enough of the
+    EMAC + its MII/PHY management so the firmware's Ethernet bring-up
+    (ipAttach -> mr920End -> ARM920_SetupPhy) sees an LXT971 PHY with the link
+    UP, instead of spinning on an unmodeled PHY / a link that never comes up.
+
+    EMAC is at base 0xfffbc000. readPhyRegister(): writes EMAC_MAN (0xfffbc034)
+    with the PHY-reg # in bits 18..22, polls EMAC_ISR (0xfffbc024) bit0 for
+    "management done", then reads EMAC_MAN[15:0] for the result. We:
+      * EMAC_ISR (0xfffbc024): report bit0=1 (management frame done) so the
+        poll completes immediately.
+      * EMAC_MAN (0xfffbc034): return the requested PHY register's value
+        (decoded from the last EMAC_MAN write): MII status (reg1) = link-up +
+        autoneg-complete; PHY id (regs 2/3) = LXT971A (0x0013 / 0x78e0).
+      * EMAC_SR (0xfffbc008): link + MDIO-idle bits set.
+    Everything else falls through to GenericPeripheral (returns 0).'''
+    _EMAC_BASE = 0xfffbc000
+    _ISR = _EMAC_BASE + 0x024   # EMAC_ISR  (management-done in bit0)
+    _MAN = _EMAC_BASE + 0x034   # EMAC_MAN  (PHY maintenance: write cmd / read result)
+    _SR = _EMAC_BASE + 0x008    # EMAC_SR   (link / idle status)
+    # PHY register values to report (LXT971A, link up, autoneg complete).
+    _PHY = {0: 0x1000, 1: 0x786d, 2: 0x0013, 3: 0x78e0}
+
+    def __init__(self, name: str, address: int, size: int, **kwargs: Any) -> None:
+        super().__init__(name, address, size, **kwargs)
+        self._last_man = 0
+
+    def hw_read(self, offset: int, size: int, pc: int = 0xBAADBAAD, **kwargs: Any) -> int:
+        addr = self.address + offset
+        if addr == self._ISR:
+            return 1                       # management frame done
+        if addr == self._SR:
+            return 0x06                    # link up (bit1) + MDIO idle (bit2)
+        if addr == self._MAN:
+            phy_reg = (self._last_man >> 18) & 0x1f
+            return (self._last_man & 0xffff0000) | self._PHY.get(phy_reg, 0)
+        return super().hw_read(offset, size, pc=pc, **kwargs)
+
+    def hw_write(self, offset: int, size: int, value: int, pc: int = 0xBAADBAAD, **kwargs: Any) -> bool:
+        if (self.address + offset) == self._MAN:
+            self._last_man = value & 0xffffffff
+        return super().hw_write(offset, size, value, pc=pc, **kwargs)


### PR DESCRIPTION
> **⚠️ Depends on #30 (x86/i386 target) — please merge #30 first.**
> This branch and #30 both extend the same multi-arch registry/backend files
> (`config/target_archs.py`, `backends/irq/__init__.py`, `backends/unicorn_backend.py`,
> `backends/hal_backend.py`, `backends/ghidra_backend.py`, `main.py`,
> `qemu_targets/__init__.py`). Merging #30 first avoids conflicts; I'll rebase this on
> top of master once #30 lands.

A worked HALucinator re-host of an **ARM (AT91RM9200) VxWorks 6.x PLC** that boots full
multitasking VxWorks and serves its own **Modbus/UMAS server on TCP `:502`** — a real
Modbus client gets real responses from the firmware's own `Port502Server`.

Builds on the multi-arch IRQ framework (#28); adds only the re-host delta:

- **backends:** opt-in `HAL_MMU_FLAT_FALLBACK` (clear `SCTLR.M` on the first data/prefetch
  abort to run flat past the firmware's own MMU/vmLib gate); `main.py`
  `_instantiate_peripheral` wiring so `emulate:` peripheral models bind to MMIO.
- **peripheral_models/at91.py:** `At91SysCtrl` (ST/PIT status so the system tick advances),
  `At91Emac` (EMAC MII/PHY link-up), `At91Dbgu` (Debug UART) — AT91 silicon models, OS-agnostic.
- **bp_handlers:** `RegMemWrite` (write `[live-register + offset]`); extended the existing
  `Counter` with `mask`/`start`; `SocketBridge` (host TCP ⇄ the firmware's VxWorks socket
  syscalls, no TAP); `ModbusTcpBridge`.
- **diagnostics:** reusable, config-agnostic re-hosting harnesses (`modbus_probe`,
  `caller_histogram`, `mmio_region_sampler`, `mmu_fault_introspect`, `probe_at_pc`,
  `snapshot_lab`), runnable as `python -m halucinator.diagnostics.<tool>`.
- **example:** `test/firmware-rehosting/arm-vxworks-plc/` — symbol-driven config,
  `extract_symbols.py` (VxWorks in-image symtab extractor), `run_cfg.py`, a README, and a
  general re-hosting `PLAYBOOK.md` (firmware-agnostic method + deep VxWorks track). Boots to
  the `:502` LISTEN; a real client gets Read-Device-ID and UMAS responses. The firmware image
  and recovered symbols are proprietary and git-ignored.

## Testing

Verified end-to-end from a clean checkout: `extract_symbols.py` → boot → `:502` LISTEN →
real Modbus/UMAS round-trip (Read Device ID + UMAS both answered by the firmware's own server).
