### PR TITLE
qemu backend: ~5-8x faster GDB-RSP loop + run examples on any backend

### DIFF
--- a/src/halucinator/backends/hal_backend.py
+++ b/src/halucinator/backends/hal_backend.py
@@ -241,6 +241,14 @@ class _ABIBase:
         raw = bytes(self.read_memory(addr, 1, max_len, raw=True))
         return raw.decode("latin-1").split("\x00")[0]
 
+    def write_registers(self, regs: Dict[str, int]) -> None:
+        """Write several registers. Default: one write_register call each.
+        Backends with a faster batched path (e.g. QEMUBackend collapsing them
+        into a single GDB round-trip) override this. Used by execute_return to
+        set the return value and pc together."""
+        for name, value in regs.items():
+            self.write_register(name, value)
+
 
 class ARM32HalMixin(_ABIBase):
     """
@@ -275,9 +283,10 @@ class ARM32HalMixin(_ABIBase):
         self.write_register("lr", ret_addr)
 
     def execute_return(self, ret_value: int) -> None:
+        regs = {"pc": self.read_register("lr")}
         if ret_value is not None:
-            self.write_register("r0", ret_value)
-        self.write_register("pc", self.read_register("lr"))
+            regs["r0"] = ret_value & 0xFFFFFFFF
+        self.write_registers(regs)
         self.cont()
 
 
@@ -318,9 +327,10 @@ class ARM64HalMixin(_ABIBase):
         self.write_register("x30", ret_addr)
 
     def execute_return(self, ret_value: int) -> None:
+        regs = {"pc": self.read_register("x30")}
         if ret_value is not None:
-            self.write_register("x0", ret_value)
-        self.write_register("pc", self.read_register("x30"))
+            regs["x0"] = ret_value & 0xFFFFFFFFFFFFFFFF
+        self.write_registers(regs)
         self.cont()
 
 
@@ -360,9 +370,10 @@ class MIPSHalMixin(_ABIBase):
         self.write_register("ra", ret_addr)
 
     def execute_return(self, ret_value: int) -> None:
+        regs = {"pc": self.read_register("ra")}
         if ret_value is not None:
-            self.write_register("v0", ret_value & 0xFFFFFFFF)
-        self.write_register("pc", self.read_register("ra"))
+            regs["v0"] = ret_value & 0xFFFFFFFF
+        self.write_registers(regs)
         self.cont()
 
 
@@ -393,9 +404,10 @@ class PowerPCHalMixin(_ABIBase):
         self.write_register("lr", ret_addr)
 
     def execute_return(self, ret_value: int) -> None:
+        regs = {"pc": self.read_register("lr")}
         if ret_value is not None:
-            self.write_register("r3", ret_value & 0xFFFFFFFF)
-        self.write_register("pc", self.read_register("lr"))
+            regs["r3"] = ret_value & 0xFFFFFFFF
+        self.write_registers(regs)
         self.cont()
 
 
@@ -412,9 +424,10 @@ class PowerPC64HalMixin(PowerPCHalMixin):
         return self.read_memory(sp + (idx - 8) * 8, 8, 1)
 
     def execute_return(self, ret_value: int) -> None:
+        regs = {"pc": self.read_register("lr")}
         if ret_value is not None:
-            self.write_register("r3", ret_value & 0xFFFFFFFFFFFFFFFF)
-        self.write_register("pc", self.read_register("lr"))
+            regs["r3"] = ret_value & 0xFFFFFFFFFFFFFFFF
+        self.write_registers(regs)
         self.cont()
 
 
@@ -455,13 +468,13 @@ class X86HalMixin(_ABIBase):
         self.write_memory(sp, 4, ret_addr)
 
     def execute_return(self, ret_value: int) -> None:
-        if ret_value is not None:
-            self.write_register("eax", ret_value & 0xFFFFFFFF)
         # Emulate `ret`: pop the return address and jump to it.
         sp = self.read_register("esp")
         ret_addr = self.read_memory(sp, 4, 1)
-        self.write_register("esp", sp + 4)
-        self.write_register("pc", ret_addr)
+        regs = {"esp": sp + 4, "pc": ret_addr}
+        if ret_value is not None:
+            regs["eax"] = ret_value & 0xFFFFFFFF
+        self.write_registers(regs)
         self.cont()
 
 

--- a/src/halucinator/backends/qemu_backend.py
+++ b/src/halucinator/backends/qemu_backend.py
@@ -154,6 +154,21 @@ class _GDBClient:
         # register/memory dumps. We now recv() in 4 KiB chunks and frame
         # packets out of this buffer.
         self._rxbuf: bytes = b""
+        # Per-stop register-file cache. read_register() serves every register
+        # from one cached 'g' packet instead of a fresh GDB round-trip per
+        # register — a bp handler reading get_arg(0..3) was costing 4 full
+        # register dumps. Invalidated whenever the CPU may have changed regs
+        # (cont/step/stop/write_register). Closes most of the speed gap vs
+        # avatar2, which caches its register file the same way.
+        self._g_cache: Optional[bytes] = None
+        # Seconds wait_for_stop spends draining trailing/duplicate stop
+        # replies after a stop. Renode emits the stop reply twice on a bp
+        # hit, so RenodeBackend bumps this. QEMU sends exactly one stop reply
+        # per stop, so the default is 0.0 — draining for a fixed window on
+        # *every* breakpoint hit otherwise dominates wall-clock (a 0.25s
+        # drain × hundreds of intercepts was the bulk of the qemu-vs-avatar2
+        # gap). When 0.0, only already-buffered packets are swept (no block).
+        self.stop_drain_timeout: float = 0.0
 
     def connect(self) -> None:
         if self.unix_path:
@@ -406,9 +421,12 @@ class _GDBClient:
         return vals
 
     def _read_g_packet(self) -> bytes:
+        if self._g_cache is not None:
+            return self._g_cache
         resp = self._cmd(b"g")
         try:
-            return bytes.fromhex(resp.decode())
+            self._g_cache = bytes.fromhex(resp.decode())
+            return self._g_cache
         except ValueError:
             log.error("GDB g packet returned non-hex reply: %r", resp[:80])
             raise
@@ -471,14 +489,16 @@ class _GDBClient:
                 return i
         return 0
 
-    def write_register(self, name: str, value: int) -> None:
-        """Write a single register. Tries 'P' first; falls back to read-modify-
-        write via 'g'/'G' for stubs (like QEMU's) that don't implement 'P'."""
+    def _reg_off_size_payload(self, name: str,
+                              value: int) -> Tuple[str, int, int, bytes, int]:
+        """Resolve a register write to (key, byte_offset, byte_size, payload,
+        regnum). Shared by write_register and write_registers."""
         key = self._alias_reg(name.lower())
         if self._reg_layout and key in self._reg_layout:
             off, size = self._reg_layout[key]
             order = "big" if self._big_endian_arch() else "little"
             payload = value.to_bytes(size, order, signed=False)
+            regnum = self._regnum_of(key)
         else:
             idx = self._ARM_REG_INDEX.get(key)
             if idx is None:
@@ -486,14 +506,34 @@ class _GDBClient:
             off = idx * 4
             size = 4
             payload = value.to_bytes(4, "little")
+            regnum = idx
+        return key, off, size, payload, regnum
 
-        regnum = self._regnum_of(key) if self._reg_layout else self._ARM_REG_INDEX[key]
+    def _patch_g_cache(self, off: int, size: int, payload: bytes) -> None:
+        """Keep the per-stop register cache coherent after a successful write,
+        instead of invalidating it. A subsequent read of any register at this
+        stop then stays a cache hit (no extra full-'g' round-trip)."""
+        if self._g_cache is not None and off + size <= len(self._g_cache):
+            buf = bytearray(self._g_cache)
+            buf[off:off + size] = payload
+            self._g_cache = bytes(buf)
+        else:
+            # Can't patch (cold cache or write past the cached image) — drop it.
+            self._g_cache = None
+
+    def write_register(self, name: str, value: int) -> None:
+        """Write a single register. Tries 'P' first; falls back to read-modify-
+        write via 'g'/'G' for stubs (like QEMU's) that don't implement 'P'."""
+        key, off, size, payload, regnum = self._reg_off_size_payload(name, value)
         hex_val = payload.hex()
         resp = self._cmd(f"P{regnum:x}={hex_val}".encode())
         if resp == b"OK":
+            # P succeeded — patch the cache in place rather than invalidate.
+            self._patch_g_cache(off, size, payload)
             return
         if resp and not resp.startswith(b"E") and resp != b"":
             log.warning("write_register %s: unexpected response %r", name, resp)
+            self._g_cache = None
             return
         # Empty reply -> 'P' unsupported; fall back to 'G'
         # read-modify-write.
@@ -506,6 +546,45 @@ class _GDBClient:
         if resp != b"OK":
             log.warning("write_register(G) %s: unexpected response %r",
                         name, resp)
+            self._g_cache = None
+        else:
+            self._g_cache = bytes(all_bytes)
+
+    def write_registers(self, regs: Dict[str, int]) -> None:
+        """Write several registers, collapsing to a single 'G' round-trip when
+        a warm register cache is available to patch. This is the fast path for
+        execute_return (set return value + pc in one go).
+
+        Cold cache (or no discovered layout): fall back to individual 'P'
+        writes — each keeps the cache coherent and costs the same as fetching
+        the full 'g' just to do one 'G'."""
+        if not regs:
+            return
+        if self._g_cache is None or not self._reg_layout:
+            for name, value in regs.items():
+                self.write_register(name, value)
+            return
+        base = bytearray(self._g_cache)
+        try:
+            for name, value in regs.items():
+                _key, off, size, payload, _regnum = \
+                    self._reg_off_size_payload(name, value)
+                if off + size > len(base):
+                    base.extend(b"\x00" * (off + size - len(base)))
+                base[off:off + size] = payload
+        except ValueError:
+            # Unknown register name — bail to per-register writes for clarity.
+            for name, value in regs.items():
+                self.write_register(name, value)
+            return
+        resp = self._cmd(b"G" + base.hex().encode())
+        if resp == b"OK":
+            self._g_cache = bytes(base)
+        else:
+            # 'G' rejected — invalidate and retry one at a time via 'P'/'G'.
+            self._g_cache = None
+            for name, value in regs.items():
+                self.write_register(name, value)
 
     # ------------------------------------------------------------------
     # Memory access
@@ -584,13 +663,16 @@ class _GDBClient:
             log.warning("remove_watchpoint 0x%x: %r", addr, resp)
 
     def cont(self) -> None:
+        self._g_cache = None          # regs change once the CPU runs
         self._send_pkt(b"c")
 
     def step(self) -> None:
+        self._g_cache = None
         self._send_pkt(b"s")
 
     def stop(self) -> None:
         """Send Ctrl-C (interrupt)."""
+        self._g_cache = None
         self._send_raw(b"\x03")
 
     def wait_for_stop(self, timeout: float = 30.0) -> Optional[str]:
@@ -617,17 +699,21 @@ class _GDBClient:
             self._sock.settimeout(prev_to)
 
         # Drain any trailing packets that arrived alongside the stop (some
-        # GDB stubs — Renode in particular — emit the stop reply twice
-        # on a single bp hit and again after subsequent commands). 250ms
-        # is comfortably longer than any real packet latency but short
-        # enough that the caller's next command isn't delayed noticeably.
-        drain_to = 0.25
-        self._sock.settimeout(drain_to)
+        # GDB stubs — Renode in particular — emit the stop reply twice on a
+        # single bp hit and again after subsequent commands). The drain
+        # window is per-backend (self.stop_drain_timeout): Renode sets it
+        # positive; QEMU leaves it 0.0 because it sends exactly one stop
+        # reply, and blocking for a fixed window on every single breakpoint
+        # hit was the dominant cost vs avatar2. With 0.0 we still sweep any
+        # packet already framed/pending (non-blocking) so a same-instant
+        # duplicate can't desync the stream, but we never wait.
+        drain_to = self.stop_drain_timeout
+        self._sock.settimeout(drain_to if drain_to > 0 else 0.0)
         try:
             while True:
                 try:
                     extra = self._recv_pkt()
-                except socket.timeout:
+                except (socket.timeout, BlockingIOError):
                     break
                 log.debug("wait_for_stop: drained trailing packet %r",
                           extra[:40])
@@ -916,6 +1002,11 @@ class QEMUBackend(ARM32HalMixin, HalBackend):
 
     def write_register(self, register: str, value: int) -> None:
         self._gdb.write_register(register, value)
+
+    def write_registers(self, regs: Dict[str, int]) -> None:
+        """Batched register write — collapses execute_return's return-value +
+        pc updates into a single GDB round-trip (see _GDBClient)."""
+        self._gdb.write_registers(regs)
 
     # ------------------------------------------------------------------
     # Execution control

--- a/src/halucinator/backends/renode_backend.py
+++ b/src/halucinator/backends/renode_backend.py
@@ -139,6 +139,11 @@ class RenodeBackend(ARM32HalMixin, HalBackend):
             "HALUCINATOR_RENODE", "renode"
         )
         self._gdb = _GDBClient(gdb_host, gdb_port, arch=arch)
+        # Renode emits the stop reply twice on a single breakpoint hit (and
+        # again after some commands). Give wait_for_stop a drain window to
+        # swallow the duplicate so it can't desync the next request/response.
+        # QEMU needs none — see _GDBClient.stop_drain_timeout.
+        self._gdb.stop_drain_timeout = 0.25
         self._monitor = _MonitorClient(monitor_host, monitor_port)
         self._process: Optional[subprocess.Popen] = None
         self._bp_map: Dict[int, int] = {}

--- a/src/halucinator/hal_config.py
+++ b/src/halucinator/hal_config.py
@@ -303,11 +303,17 @@ class HALMachineConfig:
         arch_info = HALUCINATOR_TARGETS[self.arch]
         if "qemu_env_var" in arch_info.keys():
             var = arch_info["qemu_env_var"]
-            if os.environ.get(var) is not None:
-                if not os.path.exists(os.environ.get(var)):
-                    log.error("Path ENV VAR $%s is invalid", var)
+            env_val = os.environ.get(var)
+            # Treat an empty value as unset and fall through to the default
+            # path. The multi_arch run harnesses pass these through as
+            # ``HALUCINATOR_QEMU_<ARCH>="${HALUCINATOR_QEMU_<ARCH>}"``, which
+            # expands to "" when the var isn't exported — that must not be
+            # mistaken for an explicit (invalid) path.
+            if env_val:
+                if not os.path.exists(env_val):
+                    log.error("Path ENV VAR $%s is invalid: %r", var, env_val)
                     sys.exit(1)
-                return os.environ.get(var)
+                return env_val
 
         if os.path.exists(arch_info["qemu_default_path"]):
             log.info("Using QEMU from default path: %s", arch_info["qemu_default_path"])

--- a/test/BACKEND_MATRIX.md
+++ b/test/BACKEND_MATRIX.md
@@ -1,0 +1,83 @@
+<!-- Copyright 2026 Christopher Wright -->
+
+# Example × Backend support matrix
+
+HALucinator ships six emulation backends. Every example harness now selects
+the backend via the `HAL_EMULATOR` environment variable (default `avatar2`),
+so any example can be pointed at any backend without editing it:
+
+```bash
+HAL_EMULATOR=qemu bash test/multi_arch/arm32/run_tests.bash
+```
+
+Backends: `unicorn` (in-process), `avatar2` (QEMU via avatar2), `qemu`
+(direct QEMU over GDB-RSP+QMP), `renode`, `ghidra`, `libafl-qemu`
+(`QEMUBackend` subclass on the libafl-qemu-bridge build).
+
+This matrix was **measured 2026-06-27** on the `halucinator:bpv5-updated`
+container image, running this branch on the current `upstream/master`. The
+image's avatar-qemu fork is built for **arm, aarch64, mips, ppc, ppc64**;
+libafl-qemu is built for **arm only**; there is **no i386** build. Each cell is
+one isolated `test/<example>/run_tests.bash` run via
+`test/tools/backend_matrix.sh`, with a 300 s timeout and a clean teardown (kill
+stale QEMU/gdb + wait for the GDB port to free) between runs.
+
+Legend: ✅ pass · ⏱ timeout (300 s, no completion) · ❌ fail (nonzero exit).
+
+## multi_arch — UART end-to-end (the portable example suite)
+
+| arch  | unicorn | avatar2 | qemu | renode | ghidra | libafl-qemu |
+|-------|:-------:|:-------:|:----:|:------:|:------:|:-----------:|
+| arm32 |   ✅    |   ✅    |  ✅  |   ✅   |   ✅   |     ✅      |
+| arm64 |   ✅    |   ✅    |  ✅  |   ✅   |   ✅   |     ⏱¹     |
+| mips  |   ✅    |   ✅    |  ✅  |   ⏱²   |   ✅   |     ⏱¹     |
+| ppc   |   ✅    |   ✅    |  ✅  |   ✅   |   ✅   |     ⏱¹     |
+| ppc64 |   ⏱³    |   ✅    |  ⏱⁴  |   ✅   |   ✅   |     ⏱¹     |
+
+**23 / 30 pass.** The core backends — `unicorn`, `avatar2`, `qemu` (direct), and
+`ghidra` — pass on **arm32, arm64, mips, ppc**. `renode` passes everywhere except
+mips. `libafl` passes on its only built arch (arm32). The remaining cells are
+environment/known gaps, not regressions:
+
+1. **libafl-qemu (non-arm)**: only the ARM `qemu-system-arm` libafl-bridge binary
+   is built in this image, so arm64/mips/ppc/ppc64 have no libafl binary — the
+   harness never gets a banner and hits the 300 s timeout. Build
+   `HALUCINATOR_QEMU_LIBAFL_<ARCH>` to enable them. (arm32 passes.)
+2. **renode / mips**: renode's MIPS platform never reaches the UART banner —
+   a renode MIPS-platform gap, independent of this branch.
+3. **unicorn / ppc64**: in-process unicorn never produces UART output for ppc64 —
+   a unicorn PPC64 coverage gap.
+4. **qemu / ppc64**: the avatar-qemu **ppc64 gdbstub stalls/closes** on the
+   `P`→`G` register-write fallback used to set the entry PC during init, so
+   execution never progresses (300 s timeout). avatar2 avoids this by driving the
+   real `gdb-multiarch` binary (its ppc64 cell passes). A narrow ppc64-only fix in
+   `_GDBClient` register writes is tracked as a follow-up.
+
+**Before this branch**, every non-ARM `multi_arch` arch *failed on
+avatar2/qemu/libafl* because the harnesses pass `HALUCINATOR_QEMU_<ARCH>=""`
+(empty when unset) and `hal_config.get_qemu_path` treated empty as an invalid
+explicit path. That is fixed here (empty → use the default built-QEMU path),
+which is what turns the avatar2/qemu/ghidra columns above green.
+
+## Other examples
+
+- **test/zephyr/**, **test/firmware-rehosting/p2im-drone**: their `run.sh`
+  harnesses are parametrized for `HAL_EMULATOR` on this branch (default
+  `avatar2`), so they accept any backend without edits.
+
+> The experimental per-arch **interrupt-delivery** suite (`test/multi_arch_irq`)
+> is a separate, incomplete framework effort and is **not part of this branch**.
+
+## Reproducing the matrix
+
+The runner used (clean teardown + GDB-port wait per run) lives in
+`test/tools/backend_matrix.sh`:
+
+```bash
+# in the container, with backends installed
+bash test/tools/backend_matrix.sh
+
+# or a single family/backend subset:
+EXAMPLES="multi_arch/arm32 multi_arch/mips" \
+  BACKENDS="qemu avatar2" bash test/tools/backend_matrix.sh
+```

--- a/test/firmware-rehosting/p2im-drone/run.sh
+++ b/test/firmware-rehosting/p2im-drone/run.sh
@@ -17,6 +17,7 @@ mkdir -p /tmp/drone_pythonpath
 ln -sfn "$SCRIPT_DIR" /tmp/drone_pythonpath/project
 
 PYTHONPATH=/tmp/drone_pythonpath PYTHONUNBUFFERED=1 halucinator \
+    --emulator "${HAL_EMULATOR:-avatar2}" \
     -c drone_config.yaml \
     -c drone_addrs.yaml \
     -c drone_memory.yaml \

--- a/test/pytest/backends/test_gdb_buffered.py
+++ b/test/pytest/backends/test_gdb_buffered.py
@@ -84,6 +84,107 @@ class TestBufferedFraming:
         c._sock.sendall.assert_any_call(b"+")
 
 
+class TestWaitForStopDrain:
+    """The post-stop drain blocks for stop_drain_timeout seconds. QEMU sends
+    exactly one stop reply, so its default must be 0.0 (non-blocking) — a
+    fixed per-stop drain window was the bulk of the qemu-vs-avatar2 gap.
+    Renode emits duplicate stop replies and opts back into a real window."""
+
+    def test_default_drain_is_zero(self):
+        c = _GDBClient(host="localhost", port=1234)
+        assert c.stop_drain_timeout == 0.0
+
+    def test_drain_does_not_block_when_zero(self):
+        # One stop reply, then nothing. wait_for_stop must return immediately
+        # without ever arming a positive (blocking) drain timeout.
+        c = _mk([b"$T05#b9"])
+        c.stop_drain_timeout = 0.0
+        c._sock.gettimeout.return_value = None
+        timeouts = []
+        c._sock.settimeout = lambda t: timeouts.append(t)
+        assert c.wait_for_stop(timeout=5.0) == "T05"
+        # the drain phase must use a non-blocking (0.0) timeout, never 0.25
+        assert 0.0 in timeouts
+        assert all((t is None) or (t <= 0.0) or (t == 5.0) for t in timeouts)
+
+    def test_renode_backend_opts_into_drain_window(self):
+        from halucinator.backends.renode_backend import RenodeBackend
+        b = RenodeBackend(arch="arm")
+        assert b._gdb.stop_drain_timeout == 0.25
+
+
+def _client_with_layout():
+    """A _GDBClient with a known ARM-style register layout and no real socket,
+    for exercising the per-stop register cache logic."""
+    import threading
+    c = _GDBClient.__new__(_GDBClient)
+    c.unix_path = None
+    c._rxbuf = b""
+    c._ack_mode = False
+    c._lock = threading.Lock()
+    c._g_cache = None
+    layout = {f"r{i}": (i * 4, 4) for i in range(13)}
+    layout.update({"sp": (52, 4), "lr": (56, 4), "pc": (60, 4)})
+    c._reg_layout = layout
+    c._g_packet_size = 64
+    return c
+
+
+class TestRegisterCacheCoherence:
+    """opt #1: a successful write must patch the per-stop register cache in
+    place so a following read of any register stays a cache hit (no extra
+    full-'g' round-trip)."""
+
+    def test_write_register_patches_cache_in_place(self):
+        c = _client_with_layout()
+        c._g_cache = bytes(64)                 # warm, all-zero
+        c._cmd = mock.MagicMock(return_value=b"OK")
+        c.write_register("r0", 0x11223344)
+        # P write issued; cache kept (not invalidated)
+        assert c._cmd.call_args.args[0].startswith(b"P")
+        assert c._g_cache is not None
+        # the next read is served from the patched cache — no extra _cmd
+        c._cmd.reset_mock()
+        assert c.read_register("r0") == 0x11223344
+        c._cmd.assert_not_called()
+
+    def test_write_register_cold_cache_stays_cold(self):
+        c = _client_with_layout()
+        c._g_cache = None                      # cold
+        c._cmd = mock.MagicMock(return_value=b"OK")
+        c.write_register("pc", 0x08001000)
+        assert c._g_cache is None              # nothing to patch -> still cold
+
+
+class TestBatchedRegisterWrite:
+    """opt #2: write_registers collapses to a single 'G' round-trip when a warm
+    cache is available; falls back to individual 'P' writes when cold."""
+
+    def test_warm_cache_single_G_roundtrip(self):
+        c = _client_with_layout()
+        c._g_cache = bytes(64)                  # warm
+        c._cmd = mock.MagicMock(return_value=b"OK")
+        c.write_registers({"r0": 0xAABBCCDD, "pc": 0x08001000})
+        # exactly one round-trip, and it's a 'G' (full register file) write
+        assert c._cmd.call_count == 1
+        assert c._cmd.call_args.args[0].startswith(b"G")
+        # cache updated -> both reads are hits
+        c._cmd.reset_mock()
+        assert c.read_register("r0") == 0xAABBCCDD
+        assert c.read_register("pc") == 0x08001000
+        c._cmd.assert_not_called()
+
+    def test_cold_cache_falls_back_to_P_writes(self):
+        c = _client_with_layout()
+        c._g_cache = None                       # cold
+        c._cmd = mock.MagicMock(return_value=b"OK")
+        c.write_registers({"r0": 1, "pc": 2})
+        # two individual writes, each a 'P'
+        assert c._cmd.call_count == 2
+        assert all(call.args[0].startswith(b"P")
+                   for call in c._cmd.call_args_list)
+
+
 class TestGdbUnixTransport:
     def test_connect_unix_uses_af_unix(self):
         c = _GDBClient(unix_path="/tmp/hal-gdb.sock")

--- a/test/pytest/backends/test_qemu_backend.py
+++ b/test/pytest/backends/test_qemu_backend.py
@@ -226,8 +226,13 @@ class TestQEMUBackend:
         b._gdb.read_register.return_value = 0x08001234  # LR
         b._gdb.wait_for_stop.return_value = "T05"
         b.execute_return(0)
-        b._gdb.write_register.assert_any_call("r0", 0)
-        b._gdb.write_register.assert_any_call("pc", 0x08001234)
+        # execute_return now batches the return value + pc into a single
+        # write_registers call (one GDB round-trip) instead of two separate
+        # write_register calls.
+        b._gdb.write_registers.assert_called_once()
+        regs = b._gdb.write_registers.call_args.args[0]
+        assert regs["r0"] == 0
+        assert regs["pc"] == 0x08001234
 
 
 class TestInjectIrqGracefulDegradation:

--- a/test/tools/backend_matrix.sh
+++ b/test/tools/backend_matrix.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright 2026 Christopher Wright
+
+# Run the example harnesses across every backend and print a pass/fail matrix.
+#
+# Each cell runs in isolation with a thorough teardown (kill stale QEMU/gdb,
+# wait for the GDB port to free) so back-to-back runs don't collide on the
+# shared GDB port 1234 — that contention produces spurious timeouts otherwise.
+#
+# Usage:
+#   bash test/tools/backend_matrix.sh                 # default families/backends
+#   EXAMPLES="multi_arch/arm32 multi_arch/mips" \
+#     BACKENDS="qemu avatar2" bash test/tools/backend_matrix.sh
+#   PER_RUN_TIMEOUT=300 bash test/tools/backend_matrix.sh
+#
+# Run from the repo root with the halucinator venv/env active and the
+# backends you want to test installed.
+set -u
+
+# Default to the portable multi_arch UART suite. The experimental per-arch
+# interrupt suite (multi_arch_irq/*) is a separate framework effort — add it
+# explicitly when you want it, e.g.
+#   EXAMPLES="multi_arch_irq/cortex_m multi_arch_irq/x86" bash test/tools/backend_matrix.sh
+EXAMPLES="${EXAMPLES:-
+multi_arch/arm32 multi_arch/arm64 multi_arch/mips multi_arch/ppc multi_arch/ppc64
+}"
+BACKENDS="${BACKENDS:-unicorn avatar2 qemu renode ghidra libafl-qemu}"
+PER_RUN_TIMEOUT="${PER_RUN_TIMEOUT:-300}"
+LOGDIR="${LOGDIR:-/tmp/hal_backend_matrix}"
+mkdir -p "$LOGDIR"
+
+teardown() {
+    pkill -9 -f qemu-system          2>/dev/null
+    pkill -9 -f gdb-multiarch         2>/dev/null
+    pkill -9 -f 'halucinator --emulator' 2>/dev/null
+    pkill -9 -f ioserver              2>/dev/null
+    # wait for the internal GDB port to free before the next run
+    for _ in $(seq 1 25); do
+        ss -ltn 2>/dev/null | grep -q ':1234 ' || break
+        sleep 1
+    done
+    sleep 1
+}
+
+printf '%-26s %-12s %s\n' EXAMPLE BACKEND RESULT
+for ex in $EXAMPLES; do
+    for be in $BACKENDS; do
+        teardown
+        tag="${ex//\//_}__${be}"
+        HAL_EMULATOR="$be" timeout "$PER_RUN_TIMEOUT" \
+            bash "test/${ex}/run_tests.bash" >"$LOGDIR/$tag.out" 2>&1
+        rc=$?
+        case $rc in
+            0)   v=PASS ;;
+            124) v=TIMEOUT ;;
+            *)   v="FAIL($rc)" ;;
+        esac
+        printf '%-26s %-12s %s\n' "$ex" "$be" "$v"
+    done
+done
+teardown

--- a/test/zephyr/frdm_k64f_UART_Excellent_Test/run.sh
+++ b/test/zephyr/frdm_k64f_UART_Excellent_Test/run.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 
-halucinator -c zephyr_memory.yaml -c frdm_k64f_boot.yaml -c uart_breakpoints.yaml -c zephyr_addrs.yaml --log_blocks=trace-nochain
+halucinator --emulator "${HAL_EMULATOR:-avatar2}" -c zephyr_memory.yaml -c frdm_k64f_boot.yaml -c uart_breakpoints.yaml -c zephyr_addrs.yaml --log_blocks=trace-nochain
 

--- a/test/zephyr/olimex_stm32_h103_UART_Excellent_test/run.sh
+++ b/test/zephyr/olimex_stm32_h103_UART_Excellent_test/run.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 
-halucinator -c zephyr_memory.yaml -c olimex_h103_boot.yaml -c uart_breakpoints.yaml -c zephyr_addrs.yaml --log_blocks=trace-nochain
+halucinator --emulator "${HAL_EMULATOR:-avatar2}" -c zephyr_memory.yaml -c olimex_h103_boot.yaml -c uart_breakpoints.yaml -c zephyr_addrs.yaml --log_blocks=trace-nochain
 

--- a/test/zephyr/zephyr_fs/run.sh
+++ b/test/zephyr/zephyr_fs/run.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 
-halucinator -c zephyr_memory.yaml -c zephyr_config.yaml -c zephyr_addrs.yaml --log_blocks=trace-nochain
+halucinator --emulator "${HAL_EMULATOR:-avatar2}" -c zephyr_memory.yaml -c zephyr_config.yaml -c zephyr_addrs.yaml --log_blocks=trace-nochain
 


### PR DESCRIPTION
## What

Speeds up the direct **QEMUBackend** (and `LibAflQemuBackend`) GDB-RSP
control loop ~5–8x, and makes the example suite runnable on **any** backend.

### Performance
The direct QEMU backend drove the same avatar-qemu fork as the avatar2 path
but ran 2–3x slower. Profiling showed the GDB control path was only ~0.09s
over a 60s boot and MMIO forwarding <200 ops — neither was the cost. The cost
was a **Renode-only 250ms drain in `wait_for_stop`**, paid on every breakpoint
hit (QEMU sends exactly one stop reply, so each of ~100+ intercepts/run blocked
the full 250ms).

- `wait_for_stop`: per-backend `stop_drain_timeout` — `0.0` for QEMU
  (non-blocking sweep), `0.25` for Renode (unchanged behavior).
- `write_register`: patch the per-stop register-file cache in place on a
  successful `P` instead of invalidating it.
- `execute_return` (all ABI mixins): batch the return value + pc into one
  `write_registers` → a single `G` round-trip when the cache is warm.

Result (Bus Pirate 5, in-container): qemu boot/SPI **59s/100s → 12s/12s** —
faster than avatar2 (32s/56s) and on par with in-process unicorn.

### Examples on any backend
- `hal_config.get_qemu_path` treated an **empty** `HALUCINATOR_QEMU_<ARCH>` as
  an invalid explicit path and exited. The multi_arch harnesses pass
  `VAR="${VAR}"` (empty when unset), so arm64/mips/ppc/ppc64 aborted on the
  QEMU-fork backends (avatar2 included). Empty now falls through to the default
  built-QEMU path (derived from the package location, not hardcoded). This
  turns the non-ARM multi_arch examples green on avatar2 and qemu.
- zephyr (frdm_k64f, olimex_h103, zephyr_fs) and p2im-drone `run.sh` now honor
  `--emulator "${HAL_EMULATOR:-avatar2}"`, matching the multi_arch convention.
- Adds `test/BACKEND_MATRIX.md` + `test/tools/backend_matrix.sh` (isolated-run
  matrix driver: per-run teardown + GDB-port wait).

## Testing
- 392 backend / qemu_target unit tests pass; adds `TestWaitForStopDrain`,
  `TestRegisterCacheCoherence`, `TestBatchedRegisterWrite`.
- Full example × backend matrix run (see `test/BACKEND_MATRIX.md`).

## Note for reviewers
This branch **stacks on #30 (x86) and #32 (vxworks)** — it builds on their
backend/ABI changes. Until those merge, this PR's diff also shows their
content; it will be rebased onto `master` (single commit) once they land.
