### PR TITLE
halucinator-mcp: multi-session MCP server exposing emulation as LLM tools

### DIFF
--- a/.github/workflows/virtual-environment-tests.yml
+++ b/.github/workflows/virtual-environment-tests.yml
@@ -126,6 +126,10 @@ jobs:
         pip install -e deps/avatar2/
         pip install -r src/requirements.txt
         pip install -e src
+        # MCP server extra (mcp[cli] + capstone). The CI runners are Python
+        # 3.10 (jammy) / 3.12 (noble), both >= the SDK's 3.10 floor, so the
+        # MCP tests under test/pytest/mcp_server/ run on both.
+        pip install -e 'src/[mcp]'
         pip install pytest-cov pytest-timeout
 
     - name: Build QEMU (cached)
@@ -292,6 +296,13 @@ jobs:
         set -x
         source $(pwd)/virtualenvs/halucinator/bin/activate
         halucinator --help
+
+    - name: smoke-test halucinator-mcp entry point
+      run: |
+        set -e
+        set -x
+        source $(pwd)/virtualenvs/halucinator/bin/activate
+        halucinator-mcp --help
 
     - name: test make_bin
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ htmlcov/
 virtualenvs/
 venv/
 .venv/
+.venv-mcp/
+
+# Local MCP client wiring (machine-specific absolute paths) + session scratch
+.mcp.json
+tmp/mcp_session/
 
 # VSCode extension session artifacts dropped into example/demo dirs
 # (project config, Ghidra project, disassembly listing, handler cache)

--- a/src/halucinator/mcp/README.md
+++ b/src/halucinator/mcp/README.md
@@ -1,0 +1,203 @@
+<!-- Copyright 2026 Christopher Wright -->
+
+# halucinator-mcp — MCP server for HALucinator
+
+`halucinator-mcp` exposes HALucinator firmware emulation as an
+[MCP](https://modelcontextprotocol.io/) server, so an LLM client (Claude
+Desktop, Claude Code, custom MCP clients) can drive emulation interactively —
+read/write registers and memory, set breakpoints and watchpoints, inject IRQs,
+look up symbols, disassemble, and step or continue execution — across **several
+firmware images at once**.
+
+## Architecture
+
+The server owns a **SessionManager**, not a single emulator. Each
+`start_emulation` spawns a worker subprocess (`python -m
+halucinator.mcp._worker`) that owns exactly one emulation session; every tool
+call is proxied to the right worker over a line-delimited JSON-RPC pipe. This
+process-per-session model is what makes concurrent firmware images possible:
+HALucinator keeps process-wide global state (the bp-handler intercept tables,
+the `peripheral_server` zmq sockets bound to fixed `ipc://` paths, class-level
+peripheral buffers), so two sessions cannot safely share one interpreter.
+Isolation also buys crash containment (a unicorn segfault on bad firmware takes
+down only its worker) and a hard-kill escape for wedged firmware.
+
+```
+MCP client ──stdio/http──> halucinator-mcp ──JSON-RPC pipes──> worker (session "alpha")
+                           (SessionManager)                └──> worker (session "beta")
+```
+
+Modules: `server.py` (FastMCP tools/resources), `manager.py` (SessionManager +
+worker supervision), `_worker.py` (per-session driver), `session.py` (the
+single-session emulation handle each worker runs), `_codec.py` (hex + JSON-RPC
+wire codec).
+
+## Install
+
+The MCP layer needs **Python 3.10+** (the MCP SDK's floor); the rest of
+HALucinator runs on 3.9. Use a dedicated virtualenv:
+
+```sh
+python3.10 -m venv .venv-mcp
+.venv-mcp/bin/pip install -e 'src/[mcp]'      # mcp[cli] + capstone
+# Plus HALucinator's own runtime deps (not pulled by the extra):
+.venv-mcp/bin/pip install -r src/requirements.txt
+.venv-mcp/bin/pip install -e deps/avatar2/ --no-deps
+```
+
+The `requirements.txt` pin of `setuptools<81` provides the `distutils` shim
+that the forked `avatar2` imports, so 3.10–3.12 all work; 3.10 or 3.11 are the
+safest choices.
+
+## Run
+
+### Stdio (recommended; what Claude Desktop / Claude Code expect)
+
+```sh
+halucinator-mcp
+```
+
+For Claude Code, add `.mcp.json` in your project root (point `command` at the
+venv binary so the right interpreter + deps are used):
+
+```json
+{
+  "mcpServers": {
+    "halucinator": {
+      "command": "/abs/path/to/.venv-mcp/bin/halucinator-mcp"
+    }
+  }
+}
+```
+
+Claude Desktop: the same block under `mcpServers` in
+`~/Library/Application Support/Claude/claude_desktop_config.json`.
+
+### Streamable HTTP (remote / multi-client)
+
+```sh
+halucinator-mcp --http --host 0.0.0.0 --port 8765 --auth-token "$TOKEN"
+```
+
+Client URL: `http://<host>:8765/mcp`, with header
+`Authorization: Bearer <TOKEN>`.
+
+**Security:** the tools read and write firmware memory and registers — anyone
+who can reach the port has full control of the emulated target. The default
+bind is `127.0.0.1`. Binding a non-loopback host **without** `--auth-token`
+(or the `HALUCINATOR_MCP_TOKEN` env var) logs a loud warning; always set a
+token for remote use, behind TLS / a tunnel.
+
+CLI: `--max-sessions N` (default 4) caps concurrent sessions; `--port-base`
+(default 5600) sets the base for each session's peripheral_server rx/tx port
+pair (two consecutive ports per session).
+
+## Supported backends
+
+| Backend | Notes |
+|---|---|
+| `unicorn` | Fast, in-process. ARM/ARM64/MIPS/PPC/PPC64/x86. Default. |
+| `ghidra`  | Slower, but useful for archs the QEMU build doesn't ship. |
+
+`avatar2`, `qemu`, and `renode` need a subprocess + dispatch loop; drive them
+via the `halucinator` CLI directly.
+
+## Sessions
+
+`start_emulation(...)` returns a `session_id`. **Every tool takes an optional
+`session_id`** — omit it when exactly one session is active (it resolves to
+that one); pass it explicitly to disambiguate when several are running.
+`list_sessions()` enumerates them. Resources mirror this:
+`halu://sessions` (the list) and `halu://session/{session_id}/status`.
+
+## Concurrency contract
+
+A backend isn't thread-safe while it's executing, so **while a non-blocking
+`cont()` is in flight, register/memory queries are rejected** with a
+`SessionError` — call `stop()` first. `get_status()` stays available (it
+reports `running: true` and `pc: null` without touching the backend). For long
+runs the pattern is: `cont(blocking=False)` → poll `get_status()` →
+`stop()` → inspect. A blocking `cont(timeout=N)` pauses the firmware and
+returns `state="timeout"` if it doesn't halt in time.
+
+## Tools
+
+### Lifecycle
+| Tool | Description |
+|---|---|
+| `start_emulation(config_paths, emulator='unicorn', target_name='halucinator', session_id=None)` | Spawn a worker, load YAML config(s), register HAL intercepts. Returns metadata incl. `session_id`. Does NOT advance the firmware. |
+| `shutdown_emulation(session_id=None)` | Tear down a session + its worker/ports. |
+| `list_sessions()` | Active sessions: id, target, emulator, arch, state, ports, alive. |
+| `get_status(session_id=None)` | Active flag, PC, last run state, running/exited flags. |
+| `list_supported_backends()` | In-process backends. |
+
+### Memory + registers
+| Tool | Description |
+|---|---|
+| `read_register(name)` / `write_register(name, value)` | One register. |
+| `read_registers()` / `list_registers()` | Snapshot / names. |
+| `read_memory(addr, size)` / `write_memory(addr, hex_data)` | Up to 65 536 bytes; hex strings. |
+| `read_word(addr, size=4)` / `write_word(addr, value, size=4)` | Endian-aware word (big on MIPS/PPC, little on ARM/x86); `size` 1/2/4/8. |
+
+### Breakpoints + intercepts
+| Tool | Description |
+|---|---|
+| `set_breakpoint(addr)` → `bp_id` / `remove_breakpoint(bp_id)` / `list_breakpoints()` | Debug breakpoints. |
+| `list_intercepts()` | HAL intercepts from the YAML; bp_id, addr, function, hit count. |
+
+### Execution control
+| Tool | Description |
+|---|---|
+| `cont(timeout=30, blocking=True)` | Resume until breakpoint/intercept/exit. `blocking=False` returns at once; poll `get_status`. |
+| `step()` | Single instruction (unicorn). |
+| `stop()` | Pause an in-progress non-blocking cont. |
+| `inject_irq(irq_num)` | Hardware IRQ (Cortex-M / ARM). |
+
+### Symbols + analysis
+| Tool | Description |
+|---|---|
+| `lookup_symbol(name)` / `lookup_address(addr)` | Forward / reverse symbol lookup. |
+| `list_memory_regions()` | Configured regions. |
+| `disassemble(addr=PC, count=8, thumb=null)` | capstone, arch-aware. |
+| `set_watchpoint(addr, write=True, read=False, size=4)` → `bp_id` / `remove_watchpoint(bp_id)` / `list_watchpoints()` | Halt on memory access. |
+| `read_string(addr, max_len=256)` | NUL-terminated string. |
+| `get_args(count)` | First `count` function args per the target ABI (use at a function entry / intercept). |
+
+(Every tool above also accepts `session_id`.)
+
+## Example session
+
+```jsonc
+> start_emulation({ config_paths: [
+    "test/multi_arch/arm32/test_uart_config.yaml",
+    "test/multi_arch/arm32/test_uart_addrs.yaml",
+    "test/multi_arch/arm32/test_uart_memory.yaml" ] })
+{ session_id: "halucinator-1", arch: "cortex-m3", entry_addr: 0x08000113, ... }
+
+> lookup_symbol({ name: "uart_init" })            // 0x080000c9
+> set_breakpoint({ addr: 0x080000c9 })            // 4  (bp_id)
+> cont({ timeout: 5 })                            // { state: "debug_bp", pc: 0x080000c8, bp_id: 4 }
+> read_register({ name: "r0" })                   // 0x40000000  (uart_id arg)
+> read_word({ addr: 0x20000000 })                 // little-endian word
+> shutdown_emulation({})
+```
+
+## Tests
+
+```sh
+.venv-mcp/bin/python -m pytest test/pytest/mcp_server/ -q     # 3.10+: all
+PYTHONPATH=src python3 -m pytest test/pytest/mcp_server/ -q   # 3.9: SDK tests skip
+```
+
+`test_session.py`, `test_codec.py`, `test_worker.py`, `test_manager.py` are
+SDK-free and run on 3.9; `test_server.py` self-skips (`importorskip`) without
+the MCP SDK.
+
+## Notes
+
+- One worker process per session; kill `halucinator-mcp` and all workers are
+  reaped (atexit + SessionManager teardown).
+- A `bp_handler` that blocks on external I/O (e.g. `UARTPublisher.read(block=True)`)
+  parks the worker inside Python; `stop()` can't interrupt that. Use
+  `cont(timeout=N)` and design handlers accordingly. A worker that ignores its
+  own `emu_stop` timeout is force-killed and the session marked crashed.

--- a/src/halucinator/mcp/__init__.py
+++ b/src/halucinator/mcp/__init__.py
@@ -1,0 +1,23 @@
+"""halucinator.mcp — MCP (Model Context Protocol) server for HALucinator.
+
+Exposes HALucinator emulation primitives (memory, registers, breakpoints,
+control flow, analysis) as MCP tools so an LLM client (Claude Desktop, Claude
+Code, custom MCP clients) can drive firmware emulation interactively. The
+server supervises one worker subprocess per session (see manager.py /
+_worker.py), so several firmware images can run at once.
+
+Run as a stdio server:
+    halucinator-mcp
+or:
+    python -m halucinator.mcp
+
+Run as a streamable-HTTP server (set --auth-token for remote use):
+    halucinator-mcp --http --port 8765
+
+Note: building/running the server needs the MCP SDK (Python 3.10+); the
+session-layer primitives below import without it.
+"""
+from .session import HalucinatorSession, SessionError
+from .manager import SessionManager
+
+__all__ = ["HalucinatorSession", "SessionError", "SessionManager"]

--- a/src/halucinator/mcp/__main__.py
+++ b/src/halucinator/mcp/__main__.py
@@ -1,0 +1,7 @@
+# Copyright 2026 Christopher Wright
+
+"""`python -m halucinator.mcp` entry point — same as halucinator-mcp."""
+from .server import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/halucinator/mcp/_codec.py
+++ b/src/halucinator/mcp/_codec.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Christopher Wright
+
+"""Wire codec shared by the MCP server, the SessionManager, and its worker
+subprocesses.
+
+Two concerns live here so there's a single source of truth:
+
+1. Hex (de)serialisation of raw memory. Bytes can't cross a JSON boundary —
+   neither the MCP tool boundary (read_memory returns a hex string to the
+   client) nor the manager<->worker pipe — so memory always travels as a
+   lowercase hex string.
+2. The line-delimited JSON-RPC framing used between manager.py and
+   _worker.py: one JSON object per line on stdin/stdout.
+
+The BYTES_* tables let the worker transparently convert the one session
+method that returns bytes (read_memory) and the one that takes bytes
+(write_memory) without special-casing them at every call site.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+
+# --- hex <-> bytes -------------------------------------------------------
+
+def bytes_to_hex(data: bytes) -> str:
+    return data.hex()
+
+
+def hex_to_bytes(s: str) -> bytes:
+    s = s.strip().lower()
+    if s.startswith("0x"):
+        s = s[2:]
+    if len(s) % 2 != 0:
+        raise ValueError("hex string must have even length")
+    return bytes.fromhex(s)
+
+
+# --- per-method bytes handling for the manager<->worker boundary ---------
+
+# Session methods whose return value is raw bytes; hex-encode it over the wire.
+BYTES_RESULT_METHODS = frozenset({"read_memory"})
+# Session methods with a single bytes-typed parameter -> that parameter's name;
+# the worker hex-decodes it before the call.
+BYTES_PARAM_METHODS: Dict[str, str] = {"write_memory": "data"}
+
+
+# --- JSON-RPC framing ----------------------------------------------------
+
+def encode_frame(obj: Dict[str, Any]) -> bytes:
+    """Serialise one protocol object to a single newline-terminated line."""
+    return (json.dumps(obj, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def decode_frame(line: bytes) -> Dict[str, Any]:
+    """Parse one protocol line back into an object."""
+    return json.loads(line.decode("utf-8"))
+
+
+def make_request(rid: int, method: str, params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    return {"id": rid, "method": method, "params": params or {}}
+
+
+def make_ok(rid: Optional[int], result: Any) -> Dict[str, Any]:
+    return {"id": rid, "ok": True, "result": result}
+
+
+def make_error(
+    rid: Optional[int], exc_type: str, message: str, tb: str = "",
+) -> Dict[str, Any]:
+    return {
+        "id": rid,
+        "ok": False,
+        "error": {"type": exc_type, "message": message, "traceback": tb},
+    }

--- a/src/halucinator/mcp/_worker.py
+++ b/src/halucinator/mcp/_worker.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Christopher Wright
+
+"""Per-session emulation worker — one process owns exactly one
+HalucinatorSession and speaks line-delimited JSON-RPC to the SessionManager
+over stdin/stdout.
+
+Run as: ``python -m halucinator.mcp._worker``. Not a user-facing entry point;
+manager.py spawns it.
+
+Why a separate process per session: HALucinator keeps process-wide singleton
+state (the bp_handlers intercept LUTs, the peripheral_server zmq sockets bound
+to fixed ipc:// paths, class-level peripheral buffers), so two sessions cannot
+safely share one interpreter. Isolating each session in its own process is the
+only way to drive several firmware images at once without rewriting that core
+state — and it also buys crash isolation (a unicorn segfault on bad firmware
+takes down only its worker) and a hard-kill escape hatch for wedged firmware.
+
+CRITICAL — stdout discipline: stdout carries ONLY JSON-RPC frames. Python
+logging is sent to stderr, but some halucinator code prints to stdout directly
+(e.g. peripheral_server.run_server's ``print``). To keep those from corrupting
+the frame stream we dup the real stdout fd for framing at startup and then
+point fd 1 (and sys.stdout) at stderr, so any stray writes land on stderr.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import traceback
+from typing import Any, BinaryIO, Dict
+
+
+log = logging.getLogger("halucinator.mcp.worker")
+
+
+def _redirect_stdout_to_stderr() -> BinaryIO:
+    """Reserve the real stdout for protocol frames; send everything else to
+    stderr. Returns a *buffered* binary file writing to the original stdout
+    (the pipe back to the manager).
+
+    Buffered, not raw: a raw FileIO.write() does a single write() syscall and
+    can short-write on a pipe, silently dropping the tail of a frame larger
+    than the pipe buffer (a 64 KiB read_memory result is ~128 KiB of hex). A
+    BufferedWriter loops until every byte is flushed, so callers must flush()
+    after each frame.
+    """
+    real_stdout_fd = os.dup(sys.stdout.fileno())
+    frame_out = os.fdopen(real_stdout_fd, "wb")
+    # Point fd 1 at stderr so bare print()/C-level writes can't corrupt frames.
+    os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
+    try:
+        sys.stdout.flush()
+    except Exception:  # noqa: BLE001
+        pass
+    return frame_out
+
+
+def _allowed(session: Any, method: str) -> bool:
+    """Only public methods defined on the HalucinatorSession class may be
+    dispatched — never dunders, private helpers, or arbitrary attributes."""
+    if not method or method.startswith("_"):
+        return False
+    fn = getattr(type(session), method, None)
+    return callable(fn)
+
+
+def _dispatch(session: Any, rid: Any, method: str,
+              params: Dict[str, Any]) -> Dict[str, Any]:
+    from . import _codec
+    from .session import SessionError
+
+    if not _allowed(session, method):
+        return _codec.make_error(
+            rid, "SessionError", f"unknown or disallowed method: {method!r}",
+        )
+    try:
+        call_params = dict(params)
+        bytes_param = _codec.BYTES_PARAM_METHODS.get(method)
+        if bytes_param is not None and bytes_param in call_params:
+            call_params[bytes_param] = _codec.hex_to_bytes(call_params[bytes_param])
+        result = getattr(session, method)(**call_params)
+        if method in _codec.BYTES_RESULT_METHODS:
+            result = _codec.bytes_to_hex(result)
+        return _codec.make_ok(rid, result)
+    except SessionError as exc:
+        return _codec.make_error(rid, "SessionError", str(exc),
+                                 traceback.format_exc())
+    except Exception as exc:  # noqa: BLE001
+        return _codec.make_error(rid, type(exc).__name__, str(exc),
+                                 traceback.format_exc())
+
+
+def main() -> int:
+    frame_out = _redirect_stdout_to_stderr()
+
+    logging.basicConfig(
+        level=logging.INFO, stream=sys.stderr,
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+    )
+
+    from . import _codec
+    from .session import HalucinatorSession
+
+    session = HalucinatorSession()
+    stdin = sys.stdin.buffer
+
+    def emit(obj: Dict[str, Any]) -> None:
+        # Buffered writer: write + flush guarantees the whole frame reaches
+        # the manager even when it exceeds the pipe buffer.
+        frame_out.write(_codec.encode_frame(obj))
+        frame_out.flush()
+
+    try:
+        for line in stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                req = _codec.decode_frame(line)
+            except Exception as exc:  # noqa: BLE001 — malformed frame
+                emit(_codec.make_error(None, "ProtocolError",
+                                       f"bad frame: {exc}"))
+                continue
+            emit(_dispatch(session, req.get("id"), req.get("method", ""),
+                           req.get("params") or {}))
+    finally:
+        # Manager closed the pipe (or we're exiting): tear the session down so
+        # the backend, zmq sockets, and global LUTs are released cleanly.
+        try:
+            session.shutdown()
+        except Exception:  # noqa: BLE001
+            log.exception("worker: error during final shutdown")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/halucinator/mcp/manager.py
+++ b/src/halucinator/mcp/manager.py
@@ -1,0 +1,353 @@
+# Copyright 2026 Christopher Wright
+
+"""SessionManager — supervises one emulation worker subprocess per session.
+
+The MCP server holds a single SessionManager (no HalucinatorSession of its
+own). Each `start_emulation` spawns a `python -m halucinator.mcp._worker`
+subprocess that owns exactly one HalucinatorSession, and every tool call is
+proxied to the right worker over the line-delimited JSON-RPC pipe (see
+_codec). This is what makes several firmware images drivable from one server
+despite HALucinator's process-wide global state (intercept LUTs,
+peripheral_server zmq sockets) — see _worker.py for the full rationale.
+
+Each session gets a distinct rx/tx port pair so the per-worker
+peripheral_server endpoints (whose ipc:// paths embed the port) never collide.
+"""
+from __future__ import annotations
+
+import atexit
+import collections
+import logging
+import os
+import select
+import subprocess
+import sys
+import threading
+import time
+from typing import Any, Deque, Dict, List, Optional, Tuple
+
+from . import _codec
+from .session import SessionError, DEFAULT_CONT_TIMEOUT
+
+log = logging.getLogger(__name__)
+
+
+# Read timeouts (seconds) for the manager-side wait on a worker response.
+# These are backstops against a wedged worker — a crashed worker is detected
+# immediately via EOF on the pipe regardless of timeout. `start` loads firmware
+# and binds zmq, so it's allowed to be slow; `cont` gets timeout+grace computed
+# per call.
+_DEFAULT_READ_TIMEOUT = 60.0
+_START_READ_TIMEOUT = 180.0
+_CONT_GRACE = 10.0
+
+
+def _worker_env() -> Dict[str, str]:
+    """Environment for a worker subprocess.
+
+    The worker must import halucinator, but it runs from the server's cwd
+    (which a test may have chdir'd) so a relative PYTHONPATH=src wouldn't
+    resolve. Anchor on the halucinator package's *actual* location — its
+    source root is on the import path regardless of cwd, and works for both a
+    pip/editable install and a PYTHONPATH-driven tree. Other deps live in
+    site-packages, already on the child's default path."""
+    import halucinator
+    src_root = os.path.dirname(
+        os.path.dirname(os.path.abspath(halucinator.__file__)))
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    parts = [src_root] + ([existing] if existing else [])
+    env["PYTHONPATH"] = os.pathsep.join(parts)
+    return env
+
+
+class WorkerHandle:
+    """Manager-side handle to one worker subprocess."""
+
+    def __init__(self, session_id: str, proc: subprocess.Popen,
+                 meta: Dict[str, Any], ports: Tuple[int, int]):
+        self.session_id = session_id
+        self.proc = proc
+        self.meta = meta
+        self.ports = ports
+        self._lock = threading.Lock()
+        self._rid = 0
+        self._rbuf = b""  # leftover bytes after the last newline-framed read
+        self._stderr_tail: Deque[str] = collections.deque(maxlen=200)
+        # A worker logs heavily to stderr; drain it continuously so a full
+        # pipe buffer can't backpressure and wedge the worker.
+        self._stderr_thread = threading.Thread(
+            target=self._drain_stderr, daemon=True,
+            name=f"worker-stderr-{session_id}")
+        self._stderr_thread.start()
+
+    def _drain_stderr(self) -> None:
+        try:
+            for line in self.proc.stderr:  # type: ignore[union-attr]
+                self._stderr_tail.append(
+                    line.decode("utf-8", "replace").rstrip())
+        except Exception:  # noqa: BLE001 — pipe closed on teardown
+            pass
+
+    def _stderr_summary(self) -> str:
+        return " | ".join(list(self._stderr_tail)[-5:]) or "(no stderr)"
+
+    def call(self, method: str, params: Dict[str, Any],
+             read_timeout: float = _DEFAULT_READ_TIMEOUT) -> Any:
+        with self._lock:
+            return self._rpc(method, params, read_timeout)
+
+    def _rpc(self, method: str, params: Dict[str, Any],
+             read_timeout: float) -> Any:
+        """One request/response round-trip. Caller must hold self._lock."""
+        if self.proc.poll() is not None:
+            self.meta["state"] = "crashed"
+            raise SessionError(
+                f"session {self.session_id!r} is not running "
+                f"(exited {self.proc.returncode}): {self._stderr_summary()}")
+        req = _codec.encode_frame(
+            _codec.make_request(self._next_id(), method, params))
+        try:
+            self.proc.stdin.write(req)        # type: ignore[union-attr]
+            self.proc.stdin.flush()           # type: ignore[union-attr]
+        except (BrokenPipeError, OSError) as exc:
+            self.meta["state"] = "crashed"
+            raise SessionError(
+                f"session {self.session_id!r} crashed (write failed: "
+                f"{exc}): {self._stderr_summary()}") from None
+
+        line = self._read_frame(read_timeout)
+        if line is None:
+            # Worker is wedged (e.g. firmware unbreakable by emu_stop).
+            self.meta["state"] = "wedged"
+            self._force_kill()
+            raise SessionError(
+                f"session {self.session_id!r} timed out after "
+                f"{read_timeout:.0f}s and was killed; start a fresh session")
+        if line == b"":
+            self.meta["state"] = "crashed"
+            raise SessionError(
+                f"session {self.session_id!r} crashed: "
+                f"{self._stderr_summary()}")
+        resp = _codec.decode_frame(line)
+        if not resp.get("ok"):
+            err = resp.get("error") or {}
+            etype = err.get("type", "Error")
+            msg = err.get("message", "unknown worker error")
+            # A SessionError from the worker is a clean precondition failure —
+            # surface its message verbatim. Anything else keeps its type
+            # prefix so the cause isn't lost.
+            if etype == "SessionError":
+                raise SessionError(msg)
+            raise SessionError(f"{etype}: {msg}")
+        return resp.get("result")
+
+    def _read_frame(self, timeout: float) -> Optional[bytes]:
+        """Read one newline-terminated frame from the worker's stdout within
+        *timeout* seconds total.
+
+        Reads the raw fd directly (not the buffered Popen.stdout) so the
+        select() timeout and the bytes consumed stay consistent — select on a
+        buffered object can't see bytes already pulled into its buffer. Returns
+        the frame (incl. trailing newline), b"" on EOF/crash, or None on
+        timeout. Any bytes past the newline are retained for the next read.
+        """
+        fd = self.proc.stdout.fileno()          # type: ignore[union-attr]
+        deadline = time.monotonic() + timeout
+        while b"\n" not in self._rbuf:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            ready, _, _ = select.select([fd], [], [], remaining)
+            if not ready:
+                return None
+            chunk = os.read(fd, 65536)
+            if not chunk:
+                return b""  # EOF — worker died
+            self._rbuf += chunk
+        line, _, rest = self._rbuf.partition(b"\n")
+        self._rbuf = rest
+        return line + b"\n"
+
+    def _next_id(self) -> int:
+        self._rid += 1
+        return self._rid
+
+    def _force_kill(self) -> None:
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=3.0)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                try:
+                    self.proc.wait(timeout=3.0)
+                except subprocess.TimeoutExpired:
+                    pass
+
+    def shutdown(self) -> None:
+        """Best-effort graceful teardown, then ensure the process is gone.
+
+        Acquire the per-worker lock non-blockingly: if a call is in flight
+        (e.g. a slow `start`), don't wait on it — closing stdin + killing the
+        process is enough, and waiting could stall atexit for the full read
+        timeout. Only attempt the graceful `shutdown` RPC when no call holds
+        the lock.
+        """
+        if self._lock.acquire(blocking=False):
+            try:
+                if self.proc.poll() is None:
+                    self._rpc("shutdown", {}, read_timeout=10.0)
+            except Exception:  # noqa: BLE001 — already crashing/wedged
+                pass
+            finally:
+                self._lock.release()
+        try:
+            if self.proc.stdin is not None:
+                self.proc.stdin.close()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self.proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            self._force_kill()
+
+
+class SessionManager:
+    """Owns the set of live worker sessions for one MCP server process."""
+
+    def __init__(self, max_sessions: int = 4, port_base: int = 5600):
+        self.max_sessions = max_sessions
+        self.port_base = port_base
+        self._sessions: Dict[str, WorkerHandle] = {}
+        self._used_ports: set = set()
+        self._counter = 0
+        self._lock = threading.RLock()
+        atexit.register(self.shutdown_all)
+
+    # --- ports / ids -----------------------------------------------------
+
+    def _alloc_ports(self) -> Tuple[int, int]:
+        p = self.port_base
+        while p in self._used_ports or (p + 1) in self._used_ports:
+            p += 2
+        self._used_ports.add(p)
+        self._used_ports.add(p + 1)
+        return p, p + 1
+
+    def _free_ports(self, ports: Tuple[int, int]) -> None:
+        self._used_ports.discard(ports[0])
+        self._used_ports.discard(ports[1])
+
+    # --- lifecycle -------------------------------------------------------
+
+    def create(self, config_paths: List[str], emulator: str = "unicorn",
+               target_name: str = "halucinator",
+               session_id: Optional[str] = None,
+               start_periph_server: bool = True) -> Dict[str, Any]:
+        with self._lock:
+            if len(self._sessions) >= self.max_sessions:
+                raise SessionError(
+                    f"max sessions ({self.max_sessions}) reached; "
+                    f"shut one down before starting another")
+            if session_id is None:
+                self._counter += 1
+                session_id = f"{target_name}-{self._counter}"
+            if session_id in self._sessions:
+                raise SessionError(f"session_id {session_id!r} already exists")
+            rx, tx = self._alloc_ports()
+            proc = subprocess.Popen(
+                [sys.executable, "-m", "halucinator.mcp._worker"],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, env=_worker_env(),
+            )
+            meta = {
+                "session_id": session_id, "target_name": target_name,
+                "emulator": emulator, "arch": None, "state": "starting",
+                "rx_port": rx, "tx_port": tx,
+            }
+            handle = WorkerHandle(session_id, proc, meta, (rx, tx))
+            self._sessions[session_id] = handle
+
+        # Drive the start RPC outside the registry lock (the worker has its
+        # own lock); on any failure, reap the half-born session without
+        # masking the original start error (destroy() may itself raise if a
+        # concurrent teardown already removed the session).
+        try:
+            result = handle.call("start", {
+                "config_paths": config_paths, "emulator": emulator,
+                "target_name": target_name, "rx_port": rx, "tx_port": tx,
+                "start_periph_server": start_periph_server,
+            }, read_timeout=_START_READ_TIMEOUT)
+        except Exception:
+            try:
+                self.destroy(session_id)
+            except Exception:  # noqa: BLE001
+                pass
+            raise
+        handle.meta["arch"] = result.get("arch")
+        handle.meta["state"] = "ready"
+        result["session_id"] = session_id
+        return result
+
+    def resolve(self, session_id: Optional[str]) -> WorkerHandle:
+        """Map a (possibly omitted) session_id to a worker. With exactly one
+        session, session_id may be omitted and resolves to it."""
+        with self._lock:
+            if session_id is not None:
+                handle = self._sessions.get(session_id)
+                if handle is None:
+                    raise SessionError(f"no such session: {session_id!r}")
+                return handle
+            if not self._sessions:
+                raise SessionError(
+                    "no active sessions; call start_emulation first")
+            if len(self._sessions) == 1:
+                return next(iter(self._sessions.values()))
+            raise SessionError(
+                f"multiple sessions active ({sorted(self._sessions)}); "
+                f"pass session_id to pick one")
+
+    def call(self, session_id: Optional[str], method: str,
+             read_timeout: Optional[float] = None, **params: Any) -> Any:
+        handle = self.resolve(session_id)
+        if read_timeout is None:
+            if method == "cont" and params.get("blocking", True):
+                read_timeout = float(
+                    params.get("timeout", DEFAULT_CONT_TIMEOUT)) + _CONT_GRACE
+            else:
+                read_timeout = _DEFAULT_READ_TIMEOUT
+        return handle.call(method, params, read_timeout=read_timeout)
+
+    def list_sessions(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [
+                dict(h.meta, alive=(h.proc.poll() is None))
+                for h in self._sessions.values()
+            ]
+
+    def destroy(self, session_id: str) -> Dict[str, Any]:
+        with self._lock:
+            handle = self._sessions.pop(session_id, None)
+            if handle is None:
+                raise SessionError(f"no such session: {session_id!r}")
+        # Tear the worker down BEFORE freeing its ports: the worker's
+        # peripheral_server holds zmq ipc:// endpoints derived from those
+        # ports until the process actually exits, so releasing them earlier
+        # would let a new session grab them and collide.
+        handle.shutdown()
+        with self._lock:
+            self._free_ports(handle.ports)
+        return {"session_id": session_id, "shutdown": True}
+
+    def shutdown_all(self) -> None:
+        with self._lock:
+            handles = list(self._sessions.values())
+            self._sessions.clear()
+            self._used_ports.clear()
+        for handle in handles:
+            try:
+                handle.shutdown()
+            except Exception:  # noqa: BLE001
+                log.exception("error shutting down session %s",
+                              handle.session_id)

--- a/src/halucinator/mcp/server.py
+++ b/src/halucinator/mcp/server.py
@@ -1,0 +1,461 @@
+# Copyright 2026 Christopher Wright
+
+"""FastMCP server exposing HALucinator emulation as MCP tools + resources.
+
+Run with stdio (the transport Claude Desktop / Claude Code expect when
+they spawn a server from claude_desktop_config.json / .mcp.json):
+
+    halucinator-mcp
+
+Run as a streamable-HTTP server (useful when the emulator runs on a
+beefy Linux host and the Claude client lives elsewhere):
+
+    halucinator-mcp --http --port 8765
+
+The server owns a SessionManager, not a single session: each
+`start_emulation` spawns a worker subprocess driving one firmware image, so
+several can run at once (see manager.py / _worker.py). Every tool takes an
+optional `session_id`; when exactly one session exists it may be omitted and
+resolves to that session, so the common single-firmware case stays simple.
+"""
+from __future__ import annotations
+
+import argparse
+import hmac
+import json
+import logging
+import os
+import sys
+from contextlib import asynccontextmanager
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from .session import SessionError, SUPPORTED_BACKENDS, DEFAULT_CONT_TIMEOUT
+from .manager import SessionManager
+
+# Import FastMCP at module scope. This module uses
+# `from __future__ import annotations`, so tool annotations are strings that
+# FastMCP evaluates with eval_str=True against this module's globals — every
+# annotation type below (List/Dict/Any/Optional/int/str/bool/float) therefore
+# has to be importable here. We still want `import halucinator.mcp.server` to
+# succeed without the SDK (the session-layer tests import the package on 3.9),
+# so fall back to a stand-in and raise a friendly error from build_server().
+try:
+    from mcp.server.fastmcp import FastMCP
+    _MCP_IMPORT_ERROR: Optional[ImportError] = None
+except ImportError as _exc:  # pragma: no cover — exercised only without the SDK
+    FastMCP = None  # type: ignore[assignment,misc]
+    _MCP_IMPORT_ERROR = _exc
+
+log = logging.getLogger(__name__)
+
+# Hex codec lives in _codec (shared with the worker/manager wire). Re-exported
+# under the existing private names the tests use.
+from ._codec import bytes_to_hex as _bytes_to_hex  # noqa: E402,F401
+from ._codec import hex_to_bytes as _hex_to_bytes  # noqa: E402,F401
+
+
+def build_server(name: str = "halucinator", max_sessions: int = 4,
+                 port_base: int = 5600) -> Any:
+    """Build a FastMCP server with all HALucinator tools registered.
+
+    A single SessionManager is created here and captured by the tools and
+    resources via closure (so resources, which don't get a request Context,
+    can still reach it). The lifespan tears every worker down on server stop.
+    """
+    if FastMCP is None:  # pragma: no cover — install hint
+        raise SessionError(
+            "The MCP SDK isn't installed. "
+            "Install it with: pip install 'mcp[cli]>=1.0'"
+        ) from _MCP_IMPORT_ERROR
+
+    manager = SessionManager(max_sessions=max_sessions, port_base=port_base)
+
+    @asynccontextmanager
+    async def _lifespan(_server: Any):
+        try:
+            yield {}
+        finally:
+            manager.shutdown_all()
+
+    mcp = FastMCP(name, lifespan=_lifespan)
+
+    # ------------------------------------------------------------------
+    # Lifecycle tools
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def start_emulation(
+        config_paths: List[str],
+        emulator: str = "unicorn",
+        target_name: str = "halucinator",
+        session_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Load HALucinator YAML config files, spawn a worker, and prepare a
+        backend. Returns session metadata including a `session_id` to pass to
+        later tools (omit session_id on other tools when only one session is
+        active).
+
+        config_paths: one or more paths to halucinator config YAMLs
+            (machine, memories, intercepts, addrs). Same files you'd pass to
+            `halucinator -c`.
+        emulator: backend to drive in-process — 'unicorn' (fast,
+            ARM/ARM64/MIPS/PPC/x86) or 'ghidra'. avatar2/qemu/renode aren't
+            drivable from the in-process worker.
+        target_name: short name for the tmp/<name>/ output dir.
+        session_id: optional explicit id; auto-generated if omitted.
+
+        Does NOT advance the firmware — call cont() / step() to run.
+        """
+        return manager.create(config_paths, emulator=emulator,
+                              target_name=target_name, session_id=session_id)
+
+    @mcp.tool()
+    def shutdown_emulation(session_id: Optional[str] = None) -> Dict[str, Any]:
+        """Tear down a session and release its worker + ports."""
+        handle = manager.resolve(session_id)
+        return manager.destroy(handle.session_id)
+
+    @mcp.tool()
+    def list_sessions() -> List[Dict[str, Any]]:
+        """List active sessions: session_id, target_name, emulator, arch,
+        state, ports, and whether the worker is alive."""
+        return manager.list_sessions()
+
+    @mcp.tool()
+    def get_status(session_id: Optional[str] = None) -> Dict[str, Any]:
+        """Return session state: active flag, PC, last run outcome,
+        running/exited flags, last error. With no active session returns
+        {active: False}."""
+        if session_id is None and not manager.list_sessions():
+            return {"active": False}
+        return manager.call(session_id, "status")
+
+    @mcp.tool()
+    def list_supported_backends() -> List[str]:
+        """Return the in-process backends this MCP server can drive."""
+        return list(SUPPORTED_BACKENDS)
+
+    # ------------------------------------------------------------------
+    # Memory + register tools
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def read_register(name: str, session_id: Optional[str] = None) -> int:
+        """Read one architectural register by name. Common names: 'pc', 'sp',
+        'lr', 'r0'..'r15' on ARM; arch-specific otherwise."""
+        return manager.call(session_id, "read_register", name=name)
+
+    @mcp.tool()
+    def write_register(name: str, value: int,
+                       session_id: Optional[str] = None) -> None:
+        """Set an architectural register. Effective on next cont/step."""
+        manager.call(session_id, "write_register", name=name, value=value)
+
+    @mcp.tool()
+    def read_registers(session_id: Optional[str] = None) -> Dict[str, int]:
+        """Snapshot every architectural register the backend exposes."""
+        return manager.call(session_id, "read_registers")
+
+    @mcp.tool()
+    def list_registers(session_id: Optional[str] = None) -> List[str]:
+        """Names of registers this backend can read/write."""
+        return manager.call(session_id, "list_registers")
+
+    @mcp.tool()
+    def read_memory(addr: int, size: int,
+                    session_id: Optional[str] = None) -> str:
+        """Read up to 65536 bytes from *addr*; returns a lowercase hex string
+        (no 0x prefix). Use bytes.fromhex(...) on the client side."""
+        return manager.call(session_id, "read_memory", addr=addr, size=size)
+
+    @mcp.tool()
+    def write_memory(addr: int, hex_data: str,
+                     session_id: Optional[str] = None) -> bool:
+        """Write *hex_data* (a hex string, optionally 0x-prefixed) to *addr*.
+        Length must be 1..65536 bytes."""
+        return manager.call(session_id, "write_memory", addr=addr,
+                            data=hex_data)
+
+    @mcp.tool()
+    def read_word(addr: int, size: int = 4,
+                  session_id: Optional[str] = None) -> int:
+        """Read a *size*-byte word at *addr*, decoded with the target's
+        endianness (big-endian on MIPS/PPC, little-endian on ARM/x86). size
+        must be 1, 2, 4, or 8 (use 8 for ppc64/arm64)."""
+        return manager.call(session_id, "read_word", addr=addr, size=size)
+
+    @mcp.tool()
+    def write_word(addr: int, value: int, size: int = 4,
+                   session_id: Optional[str] = None) -> bool:
+        """Write *value* as a *size*-byte word at *addr* using the target's
+        endianness. *value* is masked to *size* bytes. size must be 1, 2, 4,
+        or 8."""
+        return manager.call(session_id, "write_word", addr=addr, value=value,
+                            size=size)
+
+    # ------------------------------------------------------------------
+    # Breakpoints + intercepts
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def set_breakpoint(addr: int, session_id: Optional[str] = None) -> int:
+        """Install a debug breakpoint at *addr*; returns an opaque bp_id.
+        cont() returns when execution reaches *addr*."""
+        return manager.call(session_id, "set_breakpoint", addr=addr)
+
+    @mcp.tool()
+    def remove_breakpoint(bp_id: int,
+                          session_id: Optional[str] = None) -> bool:
+        """Remove a previously-installed debug breakpoint."""
+        return manager.call(session_id, "remove_breakpoint", bp_id=bp_id)
+
+    @mcp.tool()
+    def list_breakpoints(session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Debug breakpoints installed via set_breakpoint."""
+        return manager.call(session_id, "list_breakpoints")
+
+    @mcp.tool()
+    def list_intercepts(session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """HAL intercepts loaded from the YAML config. Each entry has bp_id,
+        addr, function name, handler class, and hit count."""
+        return manager.call(session_id, "list_intercepts")
+
+    # ------------------------------------------------------------------
+    # Execution control
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def cont(timeout: float = DEFAULT_CONT_TIMEOUT, blocking: bool = True,
+             session_id: Optional[str] = None) -> Dict[str, Any]:
+        """Resume execution until a breakpoint, intercept, or exit.
+
+        With blocking=True (default) returns when execution halts or *timeout*
+        seconds elapse (then state='timeout'). With blocking=False returns
+        immediately; poll get_status until running=False. Backend queries are
+        rejected while a non-blocking cont runs — stop() first."""
+        return manager.call(session_id, "cont", blocking=blocking,
+                            timeout=timeout)
+
+    @mcp.tool()
+    def step(session_id: Optional[str] = None) -> Dict[str, Any]:
+        """Single-step one instruction (unicorn; ghidra raises)."""
+        return manager.call(session_id, "step")
+
+    @mcp.tool()
+    def stop(session_id: Optional[str] = None) -> Dict[str, Any]:
+        """Pause an in-progress non-blocking cont(). Idempotent."""
+        return manager.call(session_id, "stop")
+
+    @mcp.tool()
+    def inject_irq(irq_num: int, session_id: Optional[str] = None) -> bool:
+        """Inject hardware interrupt *irq_num* (Cortex-M / ARM only)."""
+        return manager.call(session_id, "inject_irq", irq_num=irq_num)
+
+    # ------------------------------------------------------------------
+    # Symbol + memory layout introspection
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def lookup_symbol(name: str,
+                      session_id: Optional[str] = None) -> Optional[int]:
+        """Forward symbol lookup: returns address, or None if unknown."""
+        return manager.call(session_id, "lookup_symbol", name=name)
+
+    @mcp.tool()
+    def lookup_address(addr: int,
+                       session_id: Optional[str] = None) -> Optional[str]:
+        """Reverse symbol lookup: returns the symbol containing *addr*."""
+        return manager.call(session_id, "lookup_address", addr=addr)
+
+    @mcp.tool()
+    def list_memory_regions(session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Memory regions registered with the backend (including any
+        Python-emulated peripheral stubs)."""
+        return manager.call(session_id, "list_memory_regions")
+
+    # ------------------------------------------------------------------
+    # Analysis — disassembly, watchpoints, strings, call args
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def disassemble(addr: Optional[int] = None, count: int = 8,
+                    thumb: Optional[bool] = None,
+                    session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Disassemble *count* instructions (1..256) starting at *addr*
+        (defaults to PC). thumb overrides ARM/Thumb decoding on ARM. Returns
+        addr, size, raw bytes (hex), mnemonic, op_str, and combined text."""
+        return manager.call(session_id, "disassemble", addr=addr, count=count,
+                            thumb=thumb)
+
+    @mcp.tool()
+    def set_watchpoint(addr: int, write: bool = True, read: bool = False,
+                       size: int = 4,
+                       session_id: Optional[str] = None) -> int:
+        """Install a memory-access watchpoint over [addr, addr+size).
+        Execution halts (cont returns) on read/write to the range."""
+        return manager.call(session_id, "set_watchpoint", addr=addr,
+                            write=write, read=read, size=size)
+
+    @mcp.tool()
+    def remove_watchpoint(bp_id: int,
+                          session_id: Optional[str] = None) -> bool:
+        """Remove a watchpoint previously installed via set_watchpoint."""
+        return manager.call(session_id, "remove_watchpoint", bp_id=bp_id)
+
+    @mcp.tool()
+    def list_watchpoints(session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Watchpoints installed via set_watchpoint."""
+        return manager.call(session_id, "list_watchpoints")
+
+    @mcp.tool()
+    def read_string(addr: int, max_len: int = 256,
+                    session_id: Optional[str] = None) -> str:
+        """Read a NUL-terminated string from *addr* (latin-1), reading at most
+        *max_len* bytes (1..65536)."""
+        return manager.call(session_id, "read_string", addr=addr,
+                            max_len=max_len)
+
+    @mcp.tool()
+    def get_args(count: int, session_id: Optional[str] = None) -> List[int]:
+        """Read the first *count* (0..16) function arguments per the target
+        ABI. Meaningful at a function entry — e.g. a HAL intercept or a
+        breakpoint on a prologue."""
+        return manager.call(session_id, "get_args", count=count)
+
+    # ------------------------------------------------------------------
+    # Resources — read-only addressable views, backed by the manager closure
+    # (resources don't receive a request Context, so the closure is how they
+    # reach session state).
+    # ------------------------------------------------------------------
+
+    @mcp.resource("halu://sessions")
+    def _resource_sessions() -> str:
+        return json.dumps(manager.list_sessions(), indent=2)
+
+    @mcp.resource("halu://session/{session_id}/status")
+    def _resource_status(session_id: str) -> str:
+        return json.dumps(manager.call(session_id, "status"), indent=2)
+
+    return mcp
+
+
+def bearer_auth_asgi(inner_app: Any, token: str) -> Any:
+    """Wrap an ASGI app so every request must carry
+    `Authorization: Bearer <token>`.
+
+    Implemented as a plain ASGI shim (not an SDK auth provider) so it's
+    insensitive to FastMCP's evolving auth API: it works against whatever
+    `streamable_http_app()` returns. Default-deny: BOTH `http` and `websocket`
+    request scopes are authenticated; only the `lifespan` scope (and any other
+    non-request scope) passes through, so the app's startup/shutdown still
+    runs. An unauthenticated http request gets 401; a websocket gets a policy
+    close (1008).
+    """
+    expected = f"Bearer {token}"
+
+    async def app(scope: Dict[str, Any], receive: Callable[..., Awaitable[Any]],
+                  send: Callable[..., Awaitable[Any]]) -> None:
+        stype = scope.get("type")
+        if stype in ("http", "websocket"):
+            headers = dict(scope.get("headers") or [])
+            provided = headers.get(b"authorization", b"").decode("latin-1")
+            # constant-time compare to avoid leaking the token via timing
+            if not hmac.compare_digest(provided, expected):
+                if stype == "websocket":
+                    await send({"type": "websocket.close", "code": 1008})
+                else:
+                    await send({
+                        "type": "http.response.start", "status": 401,
+                        "headers": [(b"content-type", b"text/plain"),
+                                    (b"www-authenticate", b"Bearer")],
+                    })
+                    await send({"type": "http.response.body",
+                                "body": b"401 Unauthorized\n"})
+                return
+        await inner_app(scope, receive, send)
+
+    return app
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """`halucinator-mcp` console-script entry point."""
+    parser = argparse.ArgumentParser(
+        prog="halucinator-mcp",
+        description="MCP server exposing HALucinator emulation primitives "
+                    "(memory, registers, breakpoints, control) as tools "
+                    "for LLM clients (Claude Desktop, Claude Code, etc.).",
+    )
+    parser.add_argument(
+        "--http", action="store_true",
+        help="Use streamable-HTTP transport instead of stdio.",
+    )
+    parser.add_argument(
+        "--host", default="127.0.0.1",
+        help="HTTP host (default: 127.0.0.1). Binding 0.0.0.0 exposes "
+             "memory/register read-write to the network — use --auth-token.",
+    )
+    parser.add_argument(
+        "--port", type=int, default=8765,
+        help="HTTP port (default: 8765).",
+    )
+    parser.add_argument(
+        "--name", default="halucinator",
+        help="MCP server name reported to clients.",
+    )
+    parser.add_argument(
+        "--max-sessions", type=int, default=4,
+        help="Max concurrent emulation sessions (default: 4).",
+    )
+    parser.add_argument(
+        "--port-base", type=int, default=5600,
+        help="Base port for per-session peripheral_server rx/tx pairs "
+             "(default: 5600; each session uses two consecutive ports).",
+    )
+    parser.add_argument(
+        "--auth-token", default=os.environ.get("HALUCINATOR_MCP_TOKEN"),
+        help="Require this bearer token on every HTTP request (or set "
+             "HALUCINATOR_MCP_TOKEN). Strongly recommended with --http, "
+             "required in spirit when binding a non-loopback --host.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="Enable debug logging on stderr.",
+    )
+    args = parser.parse_args(argv)
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    # MCP stdio uses stdout for protocol frames; force logging to stderr.
+    logging.basicConfig(
+        level=log_level, stream=sys.stderr,
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+    )
+
+    server = build_server(args.name, max_sessions=args.max_sessions,
+                          port_base=args.port_base)
+    if args.http:
+        server.settings.host = args.host
+        server.settings.port = args.port
+        _is_loopback = args.host in ("127.0.0.1", "::1", "localhost")
+        if not args.auth_token and not _is_loopback:
+            log.warning(
+                "SECURITY: serving on %s:%s with NO --auth-token. The MCP "
+                "tools can read/write firmware memory and registers — anyone "
+                "who can reach this port has full control. Set --auth-token "
+                "(or HALUCINATOR_MCP_TOKEN), or bind 127.0.0.1.",
+                args.host, args.port,
+            )
+        if args.auth_token:
+            import uvicorn
+            app = bearer_auth_asgi(server.streamable_http_app(), args.auth_token)
+            log.info("HTTP bearer-token auth enabled.")
+            uvicorn.run(app, host=args.host, port=args.port,
+                        log_level=("debug" if args.verbose else "info"))
+        else:
+            server.run(transport="streamable-http")
+    else:
+        server.run()  # stdio
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/halucinator/mcp/session.py
+++ b/src/halucinator/mcp/session.py
@@ -1,0 +1,854 @@
+# Copyright 2026 Christopher Wright
+
+"""HalucinatorSession — long-lived emulation handle for the MCP server.
+
+One process owns at most one session at a time (kept simple for v1).
+The session holds:
+  * a parsed HalucinatorConfig (from one or more YAML files)
+  * an instantiated HalBackend (unicorn / ghidra are in-process and
+    drivable from the MCP request thread; avatar2 / qemu / renode
+    require a subprocess + dispatch loop, so the in-process MCP only
+    supports unicorn and ghidra in v1)
+  * the registered HAL intercepts and any debug breakpoints the MCP
+    client has installed at runtime
+  * a worker thread that runs the cont/step blocking calls so
+    individual MCP tool invocations stay responsive
+
+The session is *not* thread-safe in the sense that two concurrent MCP
+tool calls may race on the underlying backend; FastMCP serialises tool
+dispatch in a single asyncio loop, so that's acceptable. The only
+concurrency is between an in-flight cont() in the worker and a stop()
+or query from the MCP request thread — those go through a small lock.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+log = logging.getLogger(__name__)
+
+
+# Backends that the MCP server can drive in-process. avatar2/qemu/renode
+# need a subprocess + dispatch loop to actually advance the firmware;
+# wiring that in would require keeping main.py's _emulate_with_*_backend
+# infrastructure alive in a worker thread, which is out of scope for v1.
+SUPPORTED_BACKENDS: Tuple[str, ...] = ("unicorn", "ghidra")
+
+# Architectures HALucinator targets that are big-endian. Used to decode
+# multi-byte words from memory the same way the disassembler does (see
+# _capstone, which selects CS_MODE_BIG_ENDIAN for exactly these). Every
+# other supported arch (arm, cortex-m3, arm64, x86) is little-endian.
+_BIG_ENDIAN_ARCHS: Tuple[str, ...] = (
+    "mips", "powerpc", "powerpc:MPC8XX", "ppc64",
+)
+
+# Default wall-clock budget for a blocking cont(); single source of truth so
+# the session, the MCP tool, and the manager's read-timeout all agree.
+DEFAULT_CONT_TIMEOUT: float = 30.0
+
+
+class SessionError(RuntimeError):
+    """Raised when a session-state precondition is violated.
+
+    Examples: calling read_register before start_emulation, calling
+    start_emulation while a session is already active, requesting a
+    backend the MCP server can't drive in-process.
+    """
+
+
+@dataclass
+class _RunResult:
+    """Outcome of one cont()/step() call. Populated by the worker thread."""
+
+    pc: int = 0
+    state: str = "unknown"  # one of: stopped, running, exited, error
+    bp_id: Optional[int] = None
+    handler: Optional[str] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class HalucinatorSession:
+    """Stateful emulation handle owned by the MCP server's lifespan."""
+
+    config: Any = None  # HalucinatorConfig
+    backend: Any = None  # HalBackend
+    target_name: str = "halucinator"
+    emulator: str = "unicorn"
+    outdir: str = "tmp/mcp_session"
+    rx_port: int = 5555
+    tx_port: int = 5556
+    debug_breakpoints: Dict[int, int] = field(default_factory=dict)
+    watchpoints: Dict[int, int] = field(default_factory=dict)  # bp_id -> addr
+    _intercept_addr_to_bp: Dict[int, int] = field(default_factory=dict)
+    _periph_thread: Optional[threading.Thread] = None
+    _running: bool = False
+    _exited: bool = False
+    _last_run: _RunResult = field(default_factory=_RunResult)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _worker: Optional[threading.Thread] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def active(self) -> bool:
+        return self.backend is not None
+
+    def assert_active(self) -> None:
+        if not self.active:
+            raise SessionError(
+                "No active emulation session. Call start_emulation first."
+            )
+
+    def _is_running(self) -> bool:
+        """True while a non-blocking cont() is advancing the firmware on the
+        worker thread."""
+        return (
+            self._running
+            and self._worker is not None
+            and self._worker.is_alive()
+        )
+
+    def assert_idle(self) -> None:
+        """Reject backend-touching operations while a non-blocking cont() is
+        in flight.
+
+        The backend (unicorn in particular) is not thread-safe: reading a
+        register or memory from the MCP request thread while emu_start() is
+        spinning on the worker thread races C state and can crash or return
+        garbage. A lock can't help — emu_start holds the engine for the whole
+        run, and stop()/emu_stop is specifically designed to be the only safe
+        cross-thread call. So the contract is: while running, only stop() and
+        get_status() are valid; everything else must stop() first. Use
+        cont(blocking=False) + poll get_status() for long runs.
+        """
+        if self._is_running():
+            raise SessionError(
+                "Emulation is running (non-blocking cont in progress); "
+                "call stop() before querying or mutating state."
+            )
+
+    def start(
+        self,
+        config_paths: List[str],
+        emulator: str = "unicorn",
+        target_name: str = "halucinator",
+        rx_port: int = 5555,
+        tx_port: int = 5556,
+        start_periph_server: bool = True,
+    ) -> Dict[str, Any]:
+        """Parse the given YAML config files, instantiate the backend,
+        register memory regions and HAL intercepts. Does NOT start
+        execution — the caller invokes cont() / step() to advance.
+        """
+        from halucinator.bp_handlers import intercepts
+        from halucinator.backends.hal_backend import MemoryRegion
+        from halucinator.hal_config import HalucinatorConfig
+
+        if self.active:
+            raise SessionError(
+                "An emulation session is already active. "
+                "Call shutdown_emulation first."
+            )
+        if emulator not in SUPPORTED_BACKENDS:
+            raise SessionError(
+                f"Backend {emulator!r} not supported by the in-process MCP. "
+                f"Supported: {SUPPORTED_BACKENDS!r}. "
+                f"For avatar2 / qemu / renode use the halucinator CLI directly."
+            )
+        if not config_paths:
+            raise SessionError("config_paths must contain at least one YAML file")
+        for path in config_paths:
+            if not os.path.exists(path):
+                raise SessionError(f"Config file not found: {path}")
+
+        config = HalucinatorConfig()
+        for path in config_paths:
+            config.add_yaml(path)
+        # Resolve symbol-named intercepts to bp_addrs and validate the
+        # config before we start instantiating the backend (same step
+        # the CLI's main() calls before emulate_binary).
+        if not config.prepare_and_validate():
+            raise SessionError(
+                "Config validation failed; see halucinator log for details."
+            )
+
+        outdir = os.path.join("tmp", target_name)
+        os.makedirs(os.path.join(outdir, "logs"), exist_ok=True)
+
+        arch = config.machine.arch
+        if emulator == "unicorn":
+            from halucinator.backends.unicorn_backend import (
+                UnicornBackend, _ARCH_MAP,
+            )
+            if arch not in _ARCH_MAP:
+                raise SessionError(
+                    f"UnicornBackend has no mapping for arch={arch!r}. "
+                    f"Supported: {sorted(_ARCH_MAP.keys())!r}."
+                )
+            backend = UnicornBackend(arch=arch)
+        elif emulator == "ghidra":
+            from halucinator.backends.ghidra_backend import GhidraBackend
+            backend = GhidraBackend(arch=arch)
+        else:  # pragma: no cover — guarded above
+            raise SessionError(f"Unsupported backend: {emulator!r}")
+
+        # Register memory regions + init — identical across backends.
+        for mem in config.memories.values():
+            backend.add_memory_region(MemoryRegion(
+                name=mem.name, base_addr=mem.base_addr, size=mem.size,
+                permissions=mem.permissions or "rwx", file=mem.file,
+            ))
+        backend.init()
+
+        backend.avatar = SimpleNamespace(output_directory=outdir, config=config)
+
+        if config.machine.entry_addr is not None:
+            backend.regs.pc = config.machine.entry_addr
+        if config.machine.arch == "cortex-m3":
+            if config.machine.init_sp is not None:
+                backend.regs.sp = config.machine.init_sp
+            if hasattr(backend, "set_vtor"):
+                backend.set_vtor(config.machine.vector_base)
+        elif config.machine.init_sp is not None:
+            backend.regs.sp = config.machine.init_sp
+
+        for intercept in config.intercepts:
+            if intercept.bp_addr is not None:
+                bp_id = intercepts.register_bp_handler(backend, intercept)
+                self._intercept_addr_to_bp[intercept.bp_addr] = bp_id
+
+        # Start the peripheral_server in the background so bp_handlers
+        # that publish over zmq (UARTPublisher, GPIO, etc.) work the
+        # same way they do under the CLI's emulate_binary path. Most
+        # MCP clients don't care about the zmq endpoints — they observe
+        # peripheral I/O through tool return values and the hal_log
+        # output instead — but the publishers themselves still need a
+        # context to bind. Disable via start_periph_server=False if
+        # the caller wants the ports left free.
+        if start_periph_server:
+            try:
+                from halucinator.peripheral_models import (
+                    peripheral_server as periph_server,
+                )
+                periph_server.start(rx_port, tx_port, backend)
+                t = threading.Thread(
+                    target=periph_server.run_server,
+                    daemon=True, name="mcp-periph",
+                )
+                t.start()
+                self._periph_thread = t
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "MCP: peripheral_server failed to start (%s); "
+                    "publishing bp_handlers may raise.", exc,
+                )
+
+        self.config = config
+        self.backend = backend
+        self.target_name = target_name
+        self.emulator = emulator
+        self.outdir = outdir
+        self.rx_port = rx_port
+        self.tx_port = tx_port
+        self._running = False
+        self._exited = False
+        self._last_run = _RunResult(pc=backend.read_register("pc"),
+                                    state="stopped")
+        return {
+            "target_name": target_name,
+            "emulator": emulator,
+            "arch": config.machine.arch,
+            "entry_addr": config.machine.entry_addr,
+            "init_sp": config.machine.init_sp,
+            "memory_regions": [
+                {"name": m.name, "base_addr": m.base_addr, "size": m.size,
+                 "permissions": m.permissions, "emulate_required":
+                 getattr(m, "emulate_required", False)}
+                for m in config.memories.values()
+            ],
+            "intercepts": len(self._intercept_addr_to_bp),
+            "pc": self._last_run.pc,
+        }
+
+    def shutdown(self) -> Dict[str, Any]:
+        """Tear down the backend and forget all state."""
+        from halucinator.bp_handlers import intercepts as ic
+        out = {"was_active": self.active}
+        if self._worker is not None and self._worker.is_alive():
+            from halucinator.peripheral_models.uart import UARTPublisher
+            UARTPublisher.abort_blocking.set()
+            try:
+                self.backend.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            self._worker.join(timeout=2.0)
+        if self._periph_thread is not None:
+            try:
+                from halucinator.peripheral_models import (
+                    peripheral_server as periph_server,
+                )
+                # Flip the stop flag, wait for the run_server poller
+                # loop to exit cleanly, *then* close the sockets and
+                # null the globals. Closing first while the poll is
+                # still running raises ZMQError in the worker thread.
+                periph_server.stop()
+                self._periph_thread.join(timeout=1.0)
+                for attr in ("__RX_SOCKET__", "__TX_SOCKET__"):
+                    sock = getattr(periph_server, attr, None)
+                    if sock is not None:
+                        try:
+                            sock.close(linger=0)
+                        except Exception:  # noqa: BLE001
+                            pass
+                        setattr(periph_server, attr, None)
+                periph_server.__rx_socket__ = None
+                periph_server.__tx_socket__ = None
+                # Re-arm for the next start() call.
+                periph_server.__STOP_SERVER = False
+            except Exception:  # noqa: BLE001
+                pass
+            self._periph_thread = None
+        if self.backend is not None:
+            try:
+                self.backend.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
+        # Forget any global state the intercepts module + hal_stats
+        # accumulated during this session — otherwise a follow-up
+        # start() (or another test in the same process) would see
+        # stale bp handlers and hit counters.
+        from halucinator import hal_stats
+        ic.bp2handler_lut.clear()
+        ic.addr2bp_lut.clear()
+        ic.debugging_bps.clear()
+        ic.watchpoint_bps.clear()
+        ic.initalized_classes.clear()  # sic: name typo'd in upstream
+        hal_stats.stats.clear()
+        # Reset peripheral_models that accumulate per-firmware state.
+        try:
+            from halucinator.peripheral_models.uart import UARTPublisher
+            UARTPublisher.rx_buffers.clear()
+            # Worker is dead by now; re-arm blocking reads for the next session.
+            UARTPublisher.abort_blocking.clear()
+        except Exception:  # noqa: BLE001
+            pass
+        self.config = None
+        self.backend = None
+        self.debug_breakpoints.clear()
+        self.watchpoints.clear()
+        self._intercept_addr_to_bp.clear()
+        self._running = False
+        self._exited = False
+        self._last_run = _RunResult()
+        self._worker = None
+        return out
+
+    # ------------------------------------------------------------------
+    # State queries
+    # ------------------------------------------------------------------
+
+    def status(self) -> Dict[str, Any]:
+        if not self.active:
+            return {"active": False}
+        running = self._is_running()
+        # get_status must stay callable while a non-blocking cont() runs (it's
+        # how the client polls for completion) — but reading the backend PC
+        # mid-emu_start races the worker thread. While running, report
+        # pc=None and skip the backend touch entirely.
+        pc: Optional[int] = None
+        err: Optional[str] = None
+        if not running:
+            with self._lock:
+                try:
+                    pc = self.backend.read_register("pc")
+                except Exception as exc:  # noqa: BLE001
+                    pc = -1
+                    err = str(exc)
+        # Snapshot _last_run once: the worker thread may reassign it
+        # concurrently, and reading its fields individually off self could
+        # mix fields from two different results.
+        lr = self._last_run
+        return {
+            "active": True,
+            "emulator": self.emulator,
+            "arch": self.config.machine.arch,
+            "running": running,
+            "exited": self._exited,
+            "pc": pc,
+            "last_run_state": lr.state,
+            "last_run_bp_id": lr.bp_id,
+            "last_run_handler": lr.handler,
+            "error": err,
+        }
+
+    def list_intercepts(self) -> List[Dict[str, Any]]:
+        from halucinator.bp_handlers import intercepts
+        from halucinator import hal_stats
+        self.assert_active()
+        out: List[Dict[str, Any]] = []
+        for bp_id, info in intercepts.bp2handler_lut.items():
+            stat = hal_stats.stats.get(bp_id, {})
+            out.append({
+                "bp_id": bp_id,
+                "addr": getattr(info, "addr", None),
+                "function": stat.get("function"),
+                "class": info.cls.__class__.__name__
+                if hasattr(info, "cls") else None,
+                "hit_count": stat.get("count", 0),
+                "active": stat.get("active", True),
+            })
+        return out
+
+    def list_breakpoints(self) -> List[Dict[str, Any]]:
+        self.assert_active()
+        return [
+            {"bp_id": bp_id, "addr": addr}
+            for addr, bp_id in self.debug_breakpoints.items()
+        ]
+
+    def list_memory_regions(self) -> List[Dict[str, Any]]:
+        self.assert_active()
+        return [
+            {"name": m.name, "base_addr": m.base_addr, "size": m.size,
+             "permissions": m.permissions,
+             "emulate_required": getattr(m, "emulate_required", False),
+             "file": m.file}
+            for m in self.config.memories.values()
+        ]
+
+    def lookup_symbol(self, name: str) -> Optional[int]:
+        self.assert_active()
+        return self.config.get_addr_for_symbol(name)
+
+    def lookup_address(self, addr: int) -> Optional[str]:
+        self.assert_active()
+        try:
+            return self.config.get_symbol_name(addr)
+        except Exception:  # noqa: BLE001
+            return None
+
+    # ------------------------------------------------------------------
+    # Memory + registers
+    # ------------------------------------------------------------------
+
+    def read_register(self, name: str) -> int:
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            return self.backend.read_register(name)
+
+    def write_register(self, name: str, value: int) -> None:
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            self.backend.write_register(name, value)
+
+    def list_registers(self) -> List[str]:
+        self.assert_active()
+        self.assert_idle()
+        return list(self.backend.list_registers())
+
+    def read_registers(self) -> Dict[str, int]:
+        self.assert_active()
+        self.assert_idle()
+        out: Dict[str, int] = {}
+        with self._lock:
+            for name in self.backend.list_registers():
+                try:
+                    out[name] = self.backend.read_register(name)
+                except Exception:  # noqa: BLE001
+                    pass
+        return out
+
+    def read_memory(self, addr: int, size: int) -> bytes:
+        if size <= 0 or size > 0x10000:
+            raise SessionError("size must be in (0, 65536]")
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            data = self.backend.read_memory(addr, 1, size, raw=True)
+        return bytes(data) if not isinstance(data, bytes) else data
+
+    def write_memory(self, addr: int, data: bytes) -> bool:
+        if not data:
+            raise SessionError("data must not be empty")
+        if len(data) > 0x10000:
+            raise SessionError("data must be <= 65536 bytes")
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            return bool(self.backend.write_memory(
+                addr, 1, data, len(data), raw=True
+            ))
+
+    def byteorder(self) -> str:
+        """The target's byte order ('big' or 'little'), derived from the
+        machine arch — used to (de)serialise multi-byte words."""
+        self.assert_active()
+        return (
+            "big" if self.config.machine.arch in _BIG_ENDIAN_ARCHS
+            else "little"
+        )
+
+    def read_word(self, addr: int, size: int = 4) -> int:
+        """Read a *size*-byte word at *addr* using the target's endianness.
+        size must be 1, 2, 4, or 8 (8 for 64-bit targets like ppc64/arm64)."""
+        if size not in (1, 2, 4, 8):
+            raise SessionError("size must be 1, 2, 4, or 8")
+        order = self.byteorder()
+        return int.from_bytes(self.read_memory(addr, size), order)
+
+    def write_word(self, addr: int, value: int, size: int = 4) -> bool:
+        """Write *value* as a *size*-byte word at *addr* using the target's
+        endianness. *value* is masked to *size* bytes (wraps, never
+        OverflowError). size must be 1, 2, 4, or 8."""
+        if size not in (1, 2, 4, 8):
+            raise SessionError("size must be 1, 2, 4, or 8")
+        order = self.byteorder()
+        masked = value & ((1 << (size * 8)) - 1)
+        return self.write_memory(addr, masked.to_bytes(size, order))
+
+    # ------------------------------------------------------------------
+    # Breakpoints
+    # ------------------------------------------------------------------
+
+    def set_breakpoint(self, addr: int) -> int:
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            bp_id = self.backend.set_breakpoint(addr)
+        self.debug_breakpoints[addr] = bp_id
+        return bp_id
+
+    def remove_breakpoint(self, bp_id: int) -> bool:
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            try:
+                self.backend.remove_breakpoint(bp_id)
+            except Exception:  # noqa: BLE001
+                return False
+        for addr, b in list(self.debug_breakpoints.items()):
+            if b == bp_id:
+                del self.debug_breakpoints[addr]
+        return True
+
+    # ------------------------------------------------------------------
+    # Execution control
+    # ------------------------------------------------------------------
+
+    def cont(self, blocking: bool = True,
+             timeout: float = DEFAULT_CONT_TIMEOUT) -> Dict[str, Any]:
+        """Resume execution. By default we block up to *timeout* seconds
+        for the firmware to hit a breakpoint or exit. With blocking=False
+        we kick off a worker thread and return immediately — the caller
+        can poll status()/wait() to find out what happened."""
+        self.assert_active()
+        if self._worker is not None and self._worker.is_alive():
+            raise SessionError("Already running. Call stop() first.")
+        if self._exited:
+            raise SessionError(
+                "Emulation has exited; call shutdown_emulation + "
+                "start_emulation to start a new run."
+            )
+
+        # Fresh run: make sure blocking UART reads block normally (a prior
+        # stop()/timeout may have set the abort flag to unpark a leaked read).
+        from halucinator.peripheral_models.uart import UARTPublisher
+        UARTPublisher.abort_blocking.clear()
+        self._running = True
+        self._last_run = _RunResult(state="running")
+
+        def _runner() -> None:
+            from halucinator.bp_handlers import intercepts
+            try:
+                self._dispatch_loop(intercepts)
+            except Exception as exc:  # noqa: BLE001
+                self._last_run.error = str(exc)
+                self._last_run.state = "error"
+                log.exception("MCP dispatch loop crashed")
+            finally:
+                self._running = False
+
+        self._worker = threading.Thread(
+            target=_runner, name="mcp-cont", daemon=True
+        )
+        self._worker.start()
+        if blocking:
+            self._worker.join(timeout=timeout)
+            if self._worker.is_alive():
+                # Timed out — pause and let the caller decide. Unpark any
+                # worker parked in a blocking UART read so backend.stop() can
+                # take effect and the dispatch thread can exit (otherwise it
+                # spins forever and leaks into the next run).
+                UARTPublisher.abort_blocking.set()
+                try:
+                    self.backend.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+                self._worker.join(timeout=2.0)
+                if self._last_run.state == "running":
+                    self._last_run.state = "timeout"
+        return self._snapshot_run()
+
+    def step(self) -> Dict[str, Any]:
+        """Single-step one instruction (where the backend supports it)."""
+        self.assert_active()
+        if self._worker is not None and self._worker.is_alive():
+            raise SessionError("Already running. Call stop() first.")
+        if self._exited:
+            raise SessionError(
+                "Emulation has exited; call shutdown_emulation + "
+                "start_emulation to start a new run."
+            )
+        with self._lock:
+            try:
+                self.backend.step()
+                pc = self.backend.read_register("pc")
+            except NotImplementedError as exc:
+                raise SessionError(str(exc)) from None
+        self._last_run = _RunResult(pc=pc, state="stepped")
+        return self._snapshot_run()
+
+    def stop(self) -> Dict[str, Any]:
+        """Pause a running cont(). Idempotent."""
+        self.assert_active()
+        # Unpark a worker parked in a blocking UART read so it can exit.
+        from halucinator.peripheral_models.uart import UARTPublisher
+        UARTPublisher.abort_blocking.set()
+        try:
+            self.backend.stop()
+        except Exception:  # noqa: BLE001
+            pass
+        if self._worker is not None and self._worker.is_alive():
+            self._worker.join(timeout=2.0)
+        # Only declare the engine idle if the worker thread actually exited.
+        # A firmware that ignores emu_stop (tight loop / blocked in a Python
+        # bp_handler) leaves the thread alive; clearing _running there would
+        # let assert_idle pass and let queries race the live engine. Leave
+        # _running set so queries stay rejected until the worker is killed
+        # (the manager force-kills the whole worker process on read timeout).
+        if not (self._worker is not None and self._worker.is_alive()):
+            self._running = False
+        return self._snapshot_run()
+
+    def inject_irq(self, irq_num: int) -> bool:
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            try:
+                self.backend.inject_irq(irq_num)
+            except NotImplementedError as exc:
+                raise SessionError(str(exc)) from None
+            except Exception as exc:  # noqa: BLE001
+                raise SessionError(f"inject_irq failed: {exc}") from None
+        return True
+
+    # ------------------------------------------------------------------
+    # Analysis helpers (read-only inspection for LLM-driven workflows)
+    # ------------------------------------------------------------------
+
+    def set_watchpoint(
+        self, addr: int, write: bool = True, read: bool = False,
+        size: int = 4,
+    ) -> int:
+        """Install a memory-access watchpoint; execution halts when the
+        firmware reads/writes the watched range. Returns an opaque bp_id."""
+        self.assert_active()
+        self.assert_idle()
+        if not write and not read:
+            raise SessionError("watchpoint must watch reads, writes, or both")
+        with self._lock:
+            try:
+                bp_id = self.backend.set_watchpoint(
+                    addr, write=write, read=read, size=size,
+                )
+            except NotImplementedError as exc:
+                raise SessionError(str(exc)) from None
+        self.watchpoints[bp_id] = addr
+        return bp_id
+
+    def remove_watchpoint(self, bp_id: int) -> bool:
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            try:
+                self.backend.remove_watchpoint(bp_id)
+            except Exception:  # noqa: BLE001
+                return False
+        self.watchpoints.pop(bp_id, None)
+        return True
+
+    def list_watchpoints(self) -> List[Dict[str, Any]]:
+        self.assert_active()
+        return [
+            {"bp_id": bp_id, "addr": addr}
+            for bp_id, addr in self.watchpoints.items()
+        ]
+
+    def read_string(self, addr: int, max_len: int = 256) -> str:
+        """Read a NUL-terminated string from *addr* (latin-1 decoded)."""
+        if max_len <= 0 or max_len > 0x10000:
+            raise SessionError("max_len must be in (0, 65536]")
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            return self.backend.read_string(addr, max_len)
+
+    def get_args(self, count: int) -> List[int]:
+        """Read the first *count* function arguments per the target ABI.
+        Meaningful when stopped at a function entry (e.g. a HAL intercept
+        or a breakpoint on a function prologue)."""
+        if count < 0 or count > 16:
+            raise SessionError("count must be in [0, 16]")
+        self.assert_active()
+        self.assert_idle()
+        with self._lock:
+            return [int(self.backend.get_arg(i)) for i in range(count)]
+
+    def disassemble(
+        self, addr: Optional[int] = None, count: int = 8,
+        thumb: Optional[bool] = None,
+    ) -> List[Dict[str, Any]]:
+        """Disassemble *count* instructions starting at *addr* (defaults to
+        the current PC). Returns a list of {addr, size, bytes, mnemonic,
+        op_str, text} dicts. *thumb* overrides Thumb/ARM mode selection on
+        ARM (defaults to Thumb for cortex-m3, ARM otherwise)."""
+        if count <= 0 or count > 256:
+            raise SessionError("count must be in (0, 256]")
+        self.assert_active()
+        self.assert_idle()
+        md, is_thumb = self._capstone(thumb)
+        with self._lock:
+            if addr is None:
+                addr = self.backend.read_register("pc")
+            if is_thumb:
+                addr &= ~1
+            # Over-read so the final instruction isn't truncated. RISC targets
+            # are <=4 bytes/insn but x86 runs up to 15, so budget 16 per insn;
+            # capstone stops after *count* anyway, so the slack is harmless.
+            nbytes = min(count * 16 + 16, 0x10000)
+            code = bytes(self.backend.read_memory(addr, 1, nbytes, raw=True))
+        out: List[Dict[str, Any]] = []
+        for insn in md.disasm(code, addr, count):
+            out.append({
+                "addr": insn.address,
+                "size": insn.size,
+                "bytes": insn.bytes.hex(),
+                "mnemonic": insn.mnemonic,
+                "op_str": insn.op_str,
+                "text": f"{insn.mnemonic} {insn.op_str}".strip(),
+            })
+        return out
+
+    def _capstone(self, thumb: Optional[bool] = None) -> Tuple[Any, bool]:
+        """Build a capstone disassembler matching the session's arch.
+        Returns (Cs, is_thumb)."""
+        try:
+            import capstone as cs
+        except ImportError as exc:  # pragma: no cover — install hint
+            raise SessionError(
+                "Disassembly needs capstone. Install it with: "
+                "pip install 'capstone>=4.0' (or `pip install -e src/[mcp]`)."
+            ) from exc
+        arch = self.config.machine.arch
+        if arch in ("cortex-m3", "arm"):
+            is_thumb = (arch == "cortex-m3") if thumb is None else thumb
+            mode = cs.CS_MODE_THUMB if is_thumb else cs.CS_MODE_ARM
+            return cs.Cs(cs.CS_ARCH_ARM, mode), is_thumb
+        if arch == "arm64":
+            arm64 = getattr(cs, "CS_ARCH_AARCH64", None) or cs.CS_ARCH_ARM64
+            return cs.Cs(arm64, cs.CS_MODE_ARM), False
+        if arch == "mips":
+            return cs.Cs(
+                cs.CS_ARCH_MIPS,
+                cs.CS_MODE_MIPS32 | cs.CS_MODE_BIG_ENDIAN,
+            ), False
+        if arch in ("powerpc", "powerpc:MPC8XX"):
+            return cs.Cs(
+                cs.CS_ARCH_PPC, cs.CS_MODE_32 | cs.CS_MODE_BIG_ENDIAN,
+            ), False
+        if arch == "ppc64":
+            return cs.Cs(
+                cs.CS_ARCH_PPC, cs.CS_MODE_64 | cs.CS_MODE_BIG_ENDIAN,
+            ), False
+        if arch == "x86":
+            return cs.Cs(cs.CS_ARCH_X86, cs.CS_MODE_32), False
+        raise SessionError(f"No capstone mapping for arch {arch!r}")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _dispatch_loop(self, intercepts: Any) -> None:
+        """Mirror main._in_process_dispatch_loop but record the result on
+        self._last_run instead of returning. Runs in the worker thread."""
+        from halucinator import hal_stats
+        backend = self.backend
+        backend.cont()
+        while True:
+            pc = backend.read_register("pc") & ~1
+            bp_id = intercepts.addr2bp_lut.get(pc)
+            if bp_id is None:
+                # Stopped at an address we don't know — could be a debug
+                # breakpoint set by the MCP client, or an exit.
+                debug_bp = self.debug_breakpoints.get(pc)
+                self._last_run = _RunResult(
+                    pc=pc,
+                    state="debug_bp" if debug_bp is not None else "stopped",
+                    bp_id=debug_bp,
+                )
+                if debug_bp is None:
+                    self._exited = True
+                return
+            info = intercepts.bp2handler_lut[bp_id]
+            cls, method = info.cls, info.handler
+            hal_stats.stats[bp_id]["count"] += 1
+            try:
+                do_intercept, ret_value = method(cls, backend, pc)
+            except Exception as exc:  # noqa: BLE001
+                self._last_run = _RunResult(
+                    pc=pc, state="error", bp_id=bp_id,
+                    error=f"bp_handler raised: {exc}",
+                )
+                return
+            if do_intercept:
+                backend.execute_return(ret_value)
+            else:
+                self._last_run = _RunResult(
+                    pc=pc, state="hal_bp", bp_id=bp_id,
+                    handler=hal_stats.stats[bp_id].get("function"),
+                )
+                return
+
+    def _snapshot_run(self) -> Dict[str, Any]:
+        # Don't read the backend PC while the worker thread is still alive
+        # (a wedged/parked run after a timeout or stop()): that read races the
+        # engine on another thread. Report pc=None in that case, mirroring
+        # status(). Snapshot _last_run once so the reported fields are
+        # internally consistent even if the worker reassigns it concurrently.
+        worker_alive = self._worker is not None and self._worker.is_alive()
+        pc: Optional[int] = None
+        if not worker_alive:
+            with self._lock:
+                try:
+                    pc = self.backend.read_register("pc")
+                except Exception:  # noqa: BLE001
+                    pc = -1
+        lr = self._last_run
+        return {
+            "pc": pc,
+            "state": lr.state,
+            "bp_id": lr.bp_id,
+            "handler": lr.handler,
+            "error": lr.error,
+            "running": self._running,
+            "exited": self._exited,
+        }

--- a/src/halucinator/peripheral_models/uart.py
+++ b/src/halucinator/peripheral_models/uart.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import logging
+import threading
+import time
 from collections import defaultdict, deque
 from dataclasses import asdict as _asdict, dataclass
 from typing import Any, DefaultDict, Deque, Dict
@@ -18,6 +20,12 @@ log = logging.getLogger(__name__)
 @peripheral_server.peripheral_model
 class UARTPublisher(object):
     rx_buffers: DefaultDict[int, Deque[str]] = defaultdict(deque)
+    # Set by an emulation supervisor (e.g. the MCP session) to break any
+    # thread parked in a blocking read() so the run can be torn down — a
+    # firmware that reads a UART id no input ever arrives on would otherwise
+    # spin here forever, surviving stop()/shutdown() and leaking into the
+    # next run. Left clear during normal operation (reads block as before).
+    abort_blocking: threading.Event = threading.Event()
 
     @classmethod
     @peripheral_server.tx_msg
@@ -41,7 +49,9 @@ class UARTPublisher(object):
         log.debug("In: UARTPublisher.read id:%s count:%i, block:%s" %
                   (hex(uart_id), count, str(block)))
         while block and (len(cls.rx_buffers[uart_id]) < count):
-            pass
+            if cls.abort_blocking.is_set():
+                break
+            time.sleep(0.0005)
         log.debug("Done Blocking: UARTPublisher.read")
         buffer = cls.rx_buffers[uart_id]
         chars_available = len(buffer)
@@ -67,9 +77,12 @@ class UARTPublisher(object):
         log.debug("In: UARTPublisher.read id:%s count:%i, block:%s" %
                   (hex(uart_id), count, str(block)))
         while block and (len(cls.rx_buffers[uart_id]) < count) :
+            if cls.abort_blocking.is_set():
+                break
             if len(cls.rx_buffers[uart_id]) > 0:
                 if cls.rx_buffers[uart_id][-1] == '\n':
                     break
+            time.sleep(0.0005)
 
         log.debug("Done Blocking: UARTPublisher.read")
         log.debug("rx_buffers %s" % cls.rx_buffers[uart_id])

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -14,3 +14,7 @@ yamllint==1.26.3
 black==26.3.1
 cle
 setuptools<81
+# NOTE: the MCP server's deps (mcp[cli], capstone) are intentionally NOT
+# listed here — they require Python >=3.10, and listing them would break
+# `pip install -r requirements.txt` on the 3.9 baseline. Install them via the
+# extra instead: `pip install -e 'src/[mcp]'` (see src/halucinator/mcp/README.md).

--- a/src/setup.py
+++ b/src/setup.py
@@ -6,7 +6,11 @@
 
 
 import os
-from distutils.core import setup
+
+# setuptools (not distutils): distutils was removed from the stdlib in
+# Python 3.12, and the MCP server's venv runs on 3.12. setuptools.setup
+# is a drop-in for the distutils.core.setup call used below.
+from setuptools import setup
 
 
 def get_packages(rel_dir):
@@ -30,6 +34,7 @@ setup(name='halucinator',
       packages=get_packages('halucinator'),
       entry_points ={'console_scripts': [
             'halucinator = halucinator.main:main',
+            'halucinator-mcp = halucinator.mcp.server:main',
             'qemulog2trace = tools.qemu_to_trace:main',
             'hal_make_addr= halucinator.util.elf_sym_hal_getter:main',
             'hal_dev_uart=halucinator.external_devices.uart:main',
@@ -40,6 +45,12 @@ setup(name='halucinator',
             'hal_dev_802_15_4=halucinator.external_devices.IEEE802_15_4:main',
             'hal_dev_irq_trigger=halucinator.external_devices.trigger_interrupt:main'
         ]},
+      extras_require={
+            # MCP server (`halucinator-mcp`). Upper-bounded below 2.0: the
+            # FastMCP API the server uses is 1.x. Verified against mcp 1.27.
+            # Needs Python >=3.10 (the SDK's floor).
+            'mcp': ['mcp[cli]>=1.2,<2', 'capstone>=4.0'],
+      },
       requires=['avatar2',
                 'zeromq',
                 'PyYAML',

--- a/test/pytest/mcp_server/conftest.py
+++ b/test/pytest/mcp_server/conftest.py
@@ -1,0 +1,12 @@
+# Copyright 2026 Christopher Wright
+
+"""Collection notes for the MCP test package.
+
+`test_session.py` imports only `halucinator.mcp.session`, which has no
+dependency on the MCP SDK, so it runs on the project's baseline Python 3.9.
+`test_server.py` and `test_manager.py` import the MCP SDK (FastMCP), which
+requires Python 3.10+. Each of those modules guards itself with
+`pytest.importorskip("mcp")` at the top, so on 3.9 they skip cleanly rather
+than erroring out collection. (A `collect_ignore` here is unreliable for a
+package-dir conftest, so the per-module importorskip is the real guard.)
+"""

--- a/test/pytest/mcp_server/test_codec.py
+++ b/test/pytest/mcp_server/test_codec.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Christopher Wright
+
+"""Unit tests for the wire codec (_codec.py). Pure, fast, SDK-free — runs on
+every interpreter (no MCP SDK needed)."""
+from __future__ import annotations
+
+import pytest
+
+from halucinator.mcp import _codec
+
+
+class TestHex:
+    @pytest.mark.parametrize("raw", [b"", b"\x00", b"halucinator", bytes(range(256))])
+    def test_roundtrip(self, raw):
+        assert _codec.hex_to_bytes(_codec.bytes_to_hex(raw)) == raw
+
+    def test_prefix_and_case(self):
+        assert _codec.hex_to_bytes("0xDEAD") == b"\xde\xad"
+        assert _codec.hex_to_bytes("dEaD") == b"\xde\xad"
+
+    def test_odd_length(self):
+        with pytest.raises(ValueError, match="even length"):
+            _codec.hex_to_bytes("abc")
+
+
+class TestFraming:
+    def test_request_roundtrip(self):
+        frame = _codec.encode_frame(_codec.make_request(7, "read_memory",
+                                                        {"addr": 16, "size": 4}))
+        assert frame.endswith(b"\n")
+        obj = _codec.decode_frame(frame)
+        assert obj == {"id": 7, "method": "read_memory",
+                       "params": {"addr": 16, "size": 4}}
+
+    def test_ok_and_error_shapes(self):
+        ok = _codec.decode_frame(_codec.encode_frame(_codec.make_ok(1, [1, 2])))
+        assert ok == {"id": 1, "ok": True, "result": [1, 2]}
+        err = _codec.decode_frame(_codec.encode_frame(
+            _codec.make_error(2, "SessionError", "boom", "tb")))
+        assert err["ok"] is False
+        assert err["error"]["type"] == "SessionError"
+        assert err["error"]["message"] == "boom"
+
+    def test_bytes_method_tables(self):
+        # The worker relies on these to (de)serialise memory transparently.
+        assert "read_memory" in _codec.BYTES_RESULT_METHODS
+        assert _codec.BYTES_PARAM_METHODS.get("write_memory") == "data"

--- a/test/pytest/mcp_server/test_manager.py
+++ b/test/pytest/mcp_server/test_manager.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Christopher Wright
+
+"""Tests for the multi-session SessionManager (manager.py).
+
+Drives the manager directly (it spawns real worker subprocesses but doesn't
+need the MCP SDK), against the arm32 firmware. Covers: concurrent independent
+sessions, reaping, session_id resolution, max-sessions, error propagation
+through the pipe, and crash handling (a killed worker surfaces a clean error
+rather than hanging).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from halucinator.mcp.manager import SessionManager
+from halucinator.mcp.session import SessionError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ARM32_DIR = REPO_ROOT / "test" / "multi_arch" / "arm32"
+_FW_PRESENT = (ARM32_DIR / "firmware" / "test_uart.bin").exists()
+
+pytestmark = pytest.mark.skipif(
+    not _FW_PRESENT, reason="arm32 test firmware not built")
+
+
+def _configs():
+    return ["test_uart_config.yaml", "test_uart_addrs.yaml",
+            "test_uart_memory.yaml"]
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch):
+    # Workers inherit cwd; the YAML references firmware/ relatively.
+    monkeypatch.chdir(ARM32_DIR)
+    # High port base so per-session peripheral_server ports don't collide
+    # with anything else on the box.
+    mgr = SessionManager(max_sessions=2, port_base=17600)
+    yield mgr
+    mgr.shutdown_all()
+
+
+def test_single_session_resolves_without_id(manager):
+    info = manager.create(_configs(), emulator="unicorn", target_name="solo")
+    assert info["arch"] == "cortex-m3"
+    sid = info["session_id"]
+    # session_id may be omitted with exactly one session.
+    pc = manager.call(None, "read_register", name="pc")
+    assert pc & ~1 == 0x08000112
+    # explicit id works too
+    assert manager.call(sid, "read_register", name="pc") == pc
+    out = manager.destroy(sid)
+    assert out["shutdown"] is True
+    assert manager.list_sessions() == []
+
+
+def test_two_sessions_independent_and_reaped(manager):
+    a = manager.create(_configs(), target_name="alpha")["session_id"]
+    b = manager.create(_configs(), target_name="beta")["session_id"]
+    assert {s["session_id"] for s in manager.list_sessions()} == {a, b}
+
+    # Distinct rx/tx ports per session (no peripheral_server collision).
+    metas = {s["session_id"]: s for s in manager.list_sessions()}
+    assert metas[a]["rx_port"] != metas[b]["rx_port"]
+
+    # Independent memory at the same address.
+    manager.call(a, "write_word", addr=0x20001000, value=0xAAAAAAAA)
+    manager.call(b, "write_word", addr=0x20001000, value=0x55555555)
+    assert manager.call(a, "read_word", addr=0x20001000) == 0xAAAAAAAA
+    assert manager.call(b, "read_word", addr=0x20001000) == 0x55555555
+
+    # Ambiguous resolution with >1 session and no id.
+    with pytest.raises(SessionError, match="multiple sessions"):
+        manager.call(None, "read_register", name="pc")
+
+    procs = {a: manager.resolve(a).proc, b: manager.resolve(b).proc}
+    manager.shutdown_all()
+    assert manager.list_sessions() == []
+    for p in procs.values():
+        assert p.poll() is not None  # worker reaped
+
+
+def test_max_sessions_enforced(manager):
+    manager.create(_configs(), target_name="one")
+    manager.create(_configs(), target_name="two")
+    with pytest.raises(SessionError, match="max sessions"):
+        manager.create(_configs(), target_name="three")
+
+
+def test_bad_config_propagates_error_and_reaps(manager):
+    with pytest.raises(SessionError, match="not found"):
+        manager.create(["/no/such/config.yaml"], target_name="bad")
+    # The half-born session must have been reaped (no leak, port freed).
+    assert manager.list_sessions() == []
+
+
+def test_unknown_session_id(manager):
+    with pytest.raises(SessionError, match="no such session"):
+        manager.call("ghost", "read_register", name="pc")
+
+
+def test_crashed_worker_surfaces_clean_error(manager):
+    sid = manager.create(_configs(), target_name="victim")["session_id"]
+    handle = manager.resolve(sid)
+    # Hard-kill the worker out from under the manager.
+    handle.proc.kill()
+    handle.proc.wait(timeout=5)
+    # The next call must raise (not hang) and report the crash.
+    with pytest.raises(SessionError, match="not running|crashed"):
+        manager.call(sid, "read_register", name="pc")

--- a/test/pytest/mcp_server/test_server.py
+++ b/test/pytest/mcp_server/test_server.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Christopher Wright
+
+"""Tests for the FastMCP server layer (server.py).
+
+These drive the registered tools — exercising the tool wiring, the hex
+codec, and word endianness through the actual MCP request path (the
+in-memory client/server session, which sets up the lifespan that holds the
+HalucinatorSession). Requires the MCP SDK (Python 3.10+); conftest.py skips
+this whole module when the SDK is absent.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+# The MCP SDK requires Python 3.10+; on the 3.9 baseline it's absent. Skip
+# the whole module before the SDK imports below run.
+pytest.importorskip("mcp", reason="MCP SDK requires Python 3.10+")
+
+from halucinator.mcp.server import (
+    build_server, bearer_auth_asgi, _bytes_to_hex, _hex_to_bytes,
+)
+from mcp.shared.memory import (
+    create_connected_server_and_client_session as _connect,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ARM32_DIR = REPO_ROOT / "test" / "multi_arch" / "arm32"
+_FW_PRESENT = (ARM32_DIR / "firmware" / "test_uart.bin").exists()
+
+
+def _arm32_configs():
+    return [
+        "test_uart_config.yaml",
+        "test_uart_addrs.yaml",
+        "test_uart_memory.yaml",
+    ]
+
+
+def _result(call_result):
+    """Pull the typed return out of an mcp CallToolResult."""
+    sc = call_result.structuredContent
+    if sc and "result" in sc:
+        return sc["result"]
+    return [c.text for c in call_result.content]
+
+
+# ---------------------------------------------------------------------------
+# Hex codec (fast, no firmware) — previously untested
+# ---------------------------------------------------------------------------
+
+class TestHexCodec:
+    @pytest.mark.parametrize("raw", [
+        b"", b"\x00", b"halucinator", bytes(range(256)),
+    ])
+    def test_roundtrip(self, raw):
+        assert _hex_to_bytes(_bytes_to_hex(raw)) == raw
+
+    def test_0x_prefix_and_case(self):
+        assert _hex_to_bytes("0xDEADBEEF") == b"\xde\xad\xbe\xef"
+        assert _hex_to_bytes("DEADbeef") == b"\xde\xad\xbe\xef"
+
+    def test_odd_length_rejected(self):
+        with pytest.raises(ValueError, match="even length"):
+            _hex_to_bytes("abc")
+
+
+# ---------------------------------------------------------------------------
+# Tool registration — every tool the README documents is present
+# ---------------------------------------------------------------------------
+
+_EXPECTED_TOOLS = {
+    "start_emulation", "shutdown_emulation", "get_status",
+    "list_supported_backends", "read_register", "write_register",
+    "read_registers", "list_registers", "read_memory", "write_memory",
+    "read_word", "write_word", "set_breakpoint", "remove_breakpoint",
+    "list_breakpoints", "list_intercepts", "cont", "step", "stop",
+    "inject_irq", "lookup_symbol", "lookup_address", "list_memory_regions",
+    "disassemble", "set_watchpoint", "remove_watchpoint", "list_watchpoints",
+    "read_string", "get_args",
+}
+
+
+class TestToolRegistration:
+    def test_all_expected_tools_registered(self):
+        srv = build_server()
+        names = {t.name for t in asyncio.run(srv.list_tools())}
+        missing = _EXPECTED_TOOLS - names
+        assert not missing, f"missing tools: {sorted(missing)}"
+
+    def test_list_supported_backends_via_client(self):
+        srv = build_server()
+
+        async def go():
+            async with _connect(srv._mcp_server) as client:
+                await client.initialize()
+                return _result(await client.call_tool(
+                    "list_supported_backends", {}))
+
+        vals = asyncio.run(go())
+        assert "unicorn" in vals and "ghidra" in vals
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the tool layer (needs the arm32 firmware)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _FW_PRESENT, reason="arm32 test firmware not built")
+class TestToolEndToEnd:
+    def test_read_write_word_endianness_and_disasm(self, monkeypatch):
+        # The YAML memory file references firmware/test_uart.bin relatively,
+        # so run from the arm32 dir (mirrors test_session.py).
+        monkeypatch.chdir(ARM32_DIR)
+        srv = build_server()
+
+        async def go():
+            async with _connect(srv._mcp_server) as client:
+                await client.initialize()
+                start = _result(await client.call_tool("start_emulation", {
+                    "config_paths": _arm32_configs(),
+                    "emulator": "unicorn",
+                    "target_name": "srvtest",
+                }))
+                # write_word/read_word default to little-endian on cortex-m3
+                await client.call_tool("write_word", {
+                    "addr": 0x20001000, "value": 0x11223344})
+                mem = _result(await client.call_tool("read_memory", {
+                    "addr": 0x20001000, "size": 4}))
+                word = _result(await client.call_tool("read_word", {
+                    "addr": 0x20001000}))
+                disasm = _result(await client.call_tool("disassemble", {
+                    "count": 2}))
+                await client.call_tool("shutdown_emulation", {})
+                return start, mem, word, disasm
+
+        start, mem, word, disasm = asyncio.run(go())
+        assert start["arch"] == "cortex-m3"
+        assert "session_id" in start       # multi-session: id returned
+        assert mem == "44332211"          # little-endian byte order
+        assert word == 0x11223344
+        assert disasm and disasm[0]["mnemonic"]
+
+
+class TestBearerAuth:
+    """The HTTP bearer-token ASGI shim — pure, no real server needed."""
+
+    @staticmethod
+    def _drive(app, scope):
+        sent = []
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(msg):
+            sent.append(msg)
+
+        asyncio.run(app(scope, receive, send))
+        return sent
+
+    def test_rejects_missing_token(self):
+        reached = {"v": False}
+
+        async def inner(scope, receive, send):
+            reached["v"] = True
+
+        app = bearer_auth_asgi(inner, "s3cret")
+        sent = self._drive(app, {"type": "http", "headers": []})
+        assert sent[0]["status"] == 401
+        assert reached["v"] is False
+
+    def test_rejects_wrong_token(self):
+        async def inner(scope, receive, send):
+            raise AssertionError("inner should not run")
+
+        app = bearer_auth_asgi(inner, "s3cret")
+        scope = {"type": "http",
+                 "headers": [(b"authorization", b"Bearer nope")]}
+        assert self._drive(app, scope)[0]["status"] == 401
+
+    def test_accepts_correct_token(self):
+        reached = {"v": False}
+
+        async def inner(scope, receive, send):
+            reached["v"] = True
+
+        app = bearer_auth_asgi(inner, "s3cret")
+        scope = {"type": "http",
+                 "headers": [(b"authorization", b"Bearer s3cret")]}
+        self._drive(app, scope)
+        assert reached["v"] is True
+
+    def test_rejects_websocket_without_token(self):
+        # Default-deny: a websocket scope must NOT bypass auth.
+        async def inner(scope, receive, send):
+            raise AssertionError("inner should not run")
+
+        app = bearer_auth_asgi(inner, "s3cret")
+        sent = self._drive(app, {"type": "websocket", "headers": []})
+        assert sent and sent[0]["type"] == "websocket.close"
+
+    def test_lifespan_passthrough(self):
+        # Non-request scopes (lifespan) must reach inner regardless of auth, or
+        # the app's startup/shutdown (our SessionManager teardown) breaks.
+        reached = {"v": False}
+
+        async def inner(scope, receive, send):
+            reached["v"] = True
+
+        app = bearer_auth_asgi(inner, "s3cret")
+        self._drive(app, {"type": "lifespan"})
+        assert reached["v"] is True
+
+
+@pytest.mark.skipif(not _FW_PRESENT, reason="arm32 test firmware not built")
+class TestMultiSessionViaClient:
+    def test_two_sessions_and_resources(self, monkeypatch):
+        monkeypatch.chdir(ARM32_DIR)
+        srv = build_server(max_sessions=4, port_base=18600)
+
+        async def go():
+            import json
+            async with _connect(srv._mcp_server) as client:
+                await client.initialize()
+                a = _result(await client.call_tool("start_emulation", {
+                    "config_paths": _arm32_configs(), "target_name": "alpha"}))
+                b = _result(await client.call_tool("start_emulation", {
+                    "config_paths": _arm32_configs(), "target_name": "beta"}))
+                # Independent memory under distinct session_ids.
+                await client.call_tool("write_word", {
+                    "addr": 0x20001000, "value": 0xAAAAAAAA,
+                    "session_id": a["session_id"]})
+                await client.call_tool("write_word", {
+                    "addr": 0x20001000, "value": 0x55555555,
+                    "session_id": b["session_id"]})
+                wa = _result(await client.call_tool("read_word", {
+                    "addr": 0x20001000, "session_id": a["session_id"]}))
+                wb = _result(await client.call_tool("read_word", {
+                    "addr": 0x20001000, "session_id": b["session_id"]}))
+                sessions = _result(await client.call_tool("list_sessions", {}))
+                # Resources: the sessions list + per-session status template.
+                sess_doc = json.loads(
+                    (await client.read_resource("halu://sessions")
+                     ).contents[0].text)
+                status_doc = json.loads(
+                    (await client.read_resource(
+                        f"halu://session/{a['session_id']}/status")
+                     ).contents[0].text)
+                await client.call_tool("shutdown_emulation",
+                                       {"session_id": a["session_id"]})
+                await client.call_tool("shutdown_emulation",
+                                       {"session_id": b["session_id"]})
+                return wa, wb, sessions, sess_doc, status_doc
+
+        wa, wb, sessions, sess_doc, status_doc = asyncio.run(go())
+        assert wa == 0xAAAAAAAA and wb == 0x55555555   # independent
+        assert len(sessions) == 2
+        assert {s["session_id"] for s in sess_doc} == {
+            s["session_id"] for s in sessions}
+        assert status_doc["active"] is True

--- a/test/pytest/mcp_server/test_session.py
+++ b/test/pytest/mcp_server/test_session.py
@@ -1,0 +1,512 @@
+# Copyright 2026 Christopher Wright
+
+"""Tests for HalucinatorSession — the long-lived emulation handle that
+backs the MCP server.
+
+These tests exercise the session against the real arm32 multi_arch test
+firmware (small, fast, ships in the repo) on the unicorn backend.
+Backend fixtures + helpers in test/pytest/helpers/arm_helpers are
+already used by test_live_feature_matrix; we drive the same primitives
+here at the MCP-session layer instead."""
+from __future__ import annotations
+
+import os
+import struct
+from pathlib import Path
+
+import pytest
+
+from halucinator.mcp import HalucinatorSession, SessionError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ARM32_DIR = REPO_ROOT / "test" / "multi_arch" / "arm32"
+
+
+def _arm32_configs():
+    return [
+        str(ARM32_DIR / "test_uart_config.yaml"),
+        str(ARM32_DIR / "test_uart_addrs.yaml"),
+        str(ARM32_DIR / "test_uart_memory.yaml"),
+    ]
+
+
+def _arm32_firmware_present() -> bool:
+    return (ARM32_DIR / "firmware" / "test_uart.bin").exists()
+
+
+pytestmark = pytest.mark.skipif(
+    not _arm32_firmware_present(),
+    reason="arm32 test firmware not built",
+)
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch):
+    """Spin up a HalucinatorSession against the arm32 firmware. The
+    session changes cwd to the firmware dir because the YAML file
+    paths are relative ('firmware/test_uart.bin')."""
+    monkeypatch.chdir(ARM32_DIR)
+    sess = HalucinatorSession()
+    yield sess
+    sess.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+class TestStartEmulation:
+    def test_starts_and_reports_metadata(self, session):
+        info = session.start(_arm32_configs(), emulator="unicorn",
+                             target_name="mcp_test",
+                             start_periph_server=False)
+        assert info["emulator"] == "unicorn"
+        assert info["arch"] == "cortex-m3"
+        assert info["entry_addr"] == 0x08000113
+        assert info["init_sp"] == 0x20080000
+        assert info["intercepts"] >= 3  # uart_init/write/read
+        # The PC was just initialised to entry_addr (Thumb bit kept).
+        assert info["pc"] in (0x08000113, 0x08000112)
+
+    def test_double_start_raises(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        with pytest.raises(SessionError, match="already active"):
+            session.start(_arm32_configs(), emulator="unicorn",
+                          target_name="mcp_test")
+
+    def test_unsupported_backend_raises(self, session):
+        with pytest.raises(SessionError, match="not supported"):
+            session.start(_arm32_configs(), emulator="qemu")
+
+    def test_missing_config_raises(self, session):
+        with pytest.raises(SessionError, match="not found"):
+            session.start(["/no/such/path.yaml"], emulator="unicorn")
+
+    def test_empty_configs_raises(self, session):
+        with pytest.raises(SessionError, match="at least one"):
+            session.start([], emulator="unicorn")
+
+
+# ---------------------------------------------------------------------------
+# Pre-active guards
+# ---------------------------------------------------------------------------
+
+class TestInactiveGuards:
+    @pytest.mark.parametrize("op", [
+        lambda s: s.read_register("pc"),
+        lambda s: s.write_register("pc", 0),
+        lambda s: s.read_memory(0x100, 16),
+        lambda s: s.write_memory(0x100, b"\x00"),
+        lambda s: s.set_breakpoint(0x100),
+        lambda s: s.list_intercepts(),
+        lambda s: s.list_breakpoints(),
+        lambda s: s.list_memory_regions(),
+        lambda s: s.lookup_symbol("foo"),
+    ])
+    def test_inactive_session_raises(self, session, op):
+        with pytest.raises(SessionError, match="No active emulation"):
+            op(session)
+
+    def test_status_inactive_returns_inactive_flag(self, session):
+        assert session.status() == {"active": False}
+
+
+# ---------------------------------------------------------------------------
+# Memory + register access
+# ---------------------------------------------------------------------------
+
+class TestMemoryAndRegisters:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_read_register_pc_matches_entry(self):
+        # Entry address from the YAML, low bit may be cleared by unicorn
+        # when ARM enters Thumb state.
+        pc = self.session.read_register("pc")
+        assert pc & ~1 == 0x08000112
+
+    def test_write_then_read_register(self):
+        self.session.write_register("r0", 0xDEADBEEF)
+        assert self.session.read_register("r0") == 0xDEADBEEF
+
+    def test_read_registers_returns_full_set(self):
+        regs = self.session.read_registers()
+        assert "pc" in regs and "sp" in regs
+        assert all(isinstance(v, int) for v in regs.values())
+
+    def test_write_then_read_memory_in_ram(self):
+        addr = 0x20001000
+        payload = b"halucinator"
+        ok = self.session.write_memory(addr, payload)
+        assert ok is True
+        roundtrip = self.session.read_memory(addr, len(payload))
+        assert roundtrip == payload
+
+    def test_read_memory_size_validation(self):
+        with pytest.raises(SessionError, match="size must be"):
+            self.session.read_memory(0x20001000, 0)
+        with pytest.raises(SessionError, match="size must be"):
+            self.session.read_memory(0x20001000, 0x10001)
+
+    def test_write_memory_validation(self):
+        with pytest.raises(SessionError, match="must not be empty"):
+            self.session.write_memory(0x20001000, b"")
+        with pytest.raises(SessionError, match="must be <= 65536"):
+            self.session.write_memory(0x20001000, b"\x00" * 0x10001)
+
+    def test_read_memory_returns_firmware_bytes_at_entry(self):
+        # The firmware ELF/.bin has been loaded into flash @ 0x08000000;
+        # reading 4 bytes at the entry yields a non-zero word (function
+        # prologue).
+        word = self.session.read_memory(0x08000110, 4)
+        assert word != b"\x00\x00\x00\x00"
+
+
+# ---------------------------------------------------------------------------
+# Breakpoints
+# ---------------------------------------------------------------------------
+
+class TestBreakpoints:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_set_then_list(self):
+        bp_id = self.session.set_breakpoint(0x08000200)
+        bps = self.session.list_breakpoints()
+        assert {"bp_id": bp_id, "addr": 0x08000200} in bps
+
+    def test_remove_then_listed_empty(self):
+        bp_id = self.session.set_breakpoint(0x08000200)
+        ok = self.session.remove_breakpoint(bp_id)
+        assert ok is True
+        assert self.session.list_breakpoints() == []
+
+    def test_intercepts_loaded_from_yaml(self):
+        intercepts = self.session.list_intercepts()
+        functions = {i["function"] for i in intercepts}
+        assert {"uart_init", "uart_write", "uart_read"}.issubset(functions)
+
+
+# ---------------------------------------------------------------------------
+# Symbol lookup
+# ---------------------------------------------------------------------------
+
+class TestSymbolLookup:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_lookup_symbol_known(self):
+        addr = self.session.lookup_symbol("uart_init")
+        assert addr is not None and addr != 0
+
+    def test_lookup_symbol_unknown_returns_none(self):
+        assert self.session.lookup_symbol("definitely_not_a_real_symbol") is None
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+
+class TestShutdown:
+    def test_shutdown_inactive_session(self, session):
+        out = session.shutdown()
+        assert out["was_active"] is False
+
+    def test_shutdown_then_start_again(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        session.shutdown()
+        info = session.start(_arm32_configs(), emulator="unicorn",
+                             target_name="mcp_test",
+                             start_periph_server=False)
+        assert info["arch"] == "cortex-m3"
+
+
+# ---------------------------------------------------------------------------
+# cont / step (shorter timeout — the firmware will hit the uart_init
+# intercept within a handful of instructions of entry).
+# ---------------------------------------------------------------------------
+
+class TestExecution:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        # cont() needs the peripheral_server up because the firmware's
+        # uart_write bp_handler publishes via UARTPublisher.write() over
+        # zmq. step() doesn't, so this is the one place we pay the
+        # zmq-bind cost.
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=True,
+                      rx_port=15555, tx_port=15556)
+        self.session = session
+
+    def test_cont_blocking_hits_uart_init(self):
+        # Multi_arch arm32 firmware: _start -> main -> uart_init ->
+        # uart_write (×N) -> uart_read. uart_read's handler blocks
+        # in UARTPublisher.read(block=True) until input arrives, so
+        # we pre-load enough fake bytes for the firmware's first read
+        # to satisfy. That lets the dispatch worker return cleanly
+        # (no leaked thread between tests).
+        from halucinator.peripheral_models.uart import UARTPublisher
+        # Pre-load every plausible uart id so the firmware's blocking
+        # uart_read is satisfied no matter which peripheral id it polls —
+        # otherwise the handler parks in UARTPublisher.read(block=True) and
+        # cont() times out. We can't read r0 to discover the id mid-run: the
+        # running-guard contract rejects backend queries while a worker is in
+        # flight, by design.
+        for uart_id in range(8):
+            UARTPublisher.rx_buffers[uart_id].extend(b"x" * 256)
+        result = self.session.cont(blocking=True, timeout=5.0)
+        assert result["state"] in ("hal_bp", "stopped", "debug_bp", "timeout")
+        intercepts = self.session.list_intercepts()
+        total_hits = sum(i["hit_count"] for i in intercepts)
+        assert total_hits >= 1, "no intercepts fired — firmware didn't progress"
+        # If it still timed out, the worker may be parked in a blocking
+        # handler. Under the running-guard contract, stop() before touching
+        # state; this settles the worker so pytest teardown sees clean
+        # cross-test global state.
+        if result["state"] == "timeout":
+            self.session.stop()
+
+    def test_step_advances_pc(self):
+        pc_before = self.session.read_register("pc") & ~1
+        self.session.step()
+        pc_after = self.session.read_register("pc") & ~1
+        assert pc_after != pc_before
+
+
+# ---------------------------------------------------------------------------
+# Analysis helpers — disassembly, watchpoints, strings, call args
+# ---------------------------------------------------------------------------
+
+class TestWatchpoints:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_set_list_remove(self):
+        bp_id = self.session.set_watchpoint(0x20001000, write=True)
+        assert {"bp_id": bp_id, "addr": 0x20001000} in \
+            self.session.list_watchpoints()
+        assert self.session.remove_watchpoint(bp_id) is True
+        assert self.session.list_watchpoints() == []
+
+    def test_requires_read_or_write(self):
+        with pytest.raises(SessionError, match="reads, writes"):
+            self.session.set_watchpoint(0x20001000, write=False, read=False)
+
+
+class TestReadString:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_reads_nul_terminated(self):
+        addr = 0x20001000
+        self.session.write_memory(addr, b"halucinator\x00trailing")
+        assert self.session.read_string(addr) == "halucinator"
+
+    def test_max_len_validation(self):
+        with pytest.raises(SessionError, match="max_len"):
+            self.session.read_string(0x20001000, max_len=0)
+
+
+class TestGetArgs:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_reads_register_args(self):
+        for i in range(4):
+            self.session.write_register(f"r{i}", 0x1000 + i)
+        assert self.session.get_args(4) == [0x1000, 0x1001, 0x1002, 0x1003]
+
+    def test_count_validation(self):
+        with pytest.raises(SessionError, match="count must be"):
+            self.session.get_args(17)
+
+
+class TestDisassemble:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        pytest.importorskip("capstone")
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_disassembles_at_pc(self):
+        insns = self.session.disassemble(count=4)
+        assert 1 <= len(insns) <= 4
+        first = insns[0]
+        # PC starts at the entry (Thumb bit cleared for disassembly).
+        assert first["addr"] == 0x08000112
+        assert first["mnemonic"]
+        assert len(first["bytes"]) == first["size"] * 2  # hex chars
+
+    def test_explicit_addr(self):
+        insns = self.session.disassemble(addr=0x08000112, count=1)
+        assert insns and insns[0]["addr"] == 0x08000112
+
+    def test_count_validation(self):
+        with pytest.raises(SessionError, match="count must be"):
+            self.session.disassemble(count=0)
+
+    def test_x86_capstone_mapping(self, monkeypatch):
+        # x86 is a supported unicorn arch; disassemble must have a capstone
+        # mapping for it (regression: _capstone used to raise on x86). Decode
+        # x86 bytes laid into RAM with the arch overridden to x86.
+        monkeypatch.setattr(self.session.config.machine, "arch", "x86")
+        # 0x90 nop ; 0xb8 imm32 (mov eax, 1) — exercises a 1-byte and a
+        # 5-byte instruction, which the widened over-read must cover.
+        self.session.write_memory(0x20001000, b"\x90\xb8\x01\x00\x00\x00")
+        insns = self.session.disassemble(addr=0x20001000, count=2)
+        assert insns[0]["mnemonic"] == "nop"
+        assert insns[1]["mnemonic"] == "mov"
+        assert insns[1]["size"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Word read/write — endianness derived from the target arch, plus size param
+# ---------------------------------------------------------------------------
+
+class TestWordEndianness:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_little_endian_default(self):
+        # arm32/cortex-m3 is little-endian.
+        assert self.session.byteorder() == "little"
+        self.session.write_word(0x20001000, 0x11223344)
+        assert self.session.read_memory(0x20001000, 4) == b"\x44\x33\x22\x11"
+        assert self.session.read_word(0x20001000) == 0x11223344
+
+    def test_big_endian_arch(self, monkeypatch):
+        # Pretend the same session is a big-endian target: the bytes laid
+        # down in memory must be MSB-first and round-trip back.
+        monkeypatch.setattr(self.session.config.machine, "arch", "mips")
+        assert self.session.byteorder() == "big"
+        self.session.write_word(0x20001000, 0x11223344)
+        assert self.session.read_memory(0x20001000, 4) == b"\x11\x22\x33\x44"
+        assert self.session.read_word(0x20001000) == 0x11223344
+
+    def test_size_param(self):
+        self.session.write_word(0x20001000, 0xABCD, size=2)
+        assert self.session.read_memory(0x20001000, 2) == b"\xcd\xab"
+        self.session.write_word(0x20001008, 0x1122334455667788, size=8)
+        assert self.session.read_word(0x20001008, size=8) == 0x1122334455667788
+
+    def test_invalid_size_rejected(self):
+        with pytest.raises(SessionError, match="size must be"):
+            self.session.read_word(0x20001000, size=3)
+        with pytest.raises(SessionError, match="size must be"):
+            self.session.write_word(0x20001000, 0, size=0)
+
+    def test_oversized_value_masked_not_overflow(self):
+        # A value wider than *size* wraps instead of raising OverflowError.
+        self.session.write_word(0x20001000, 0x1_0000_00AB, size=4)
+        assert self.session.read_word(0x20001000) == 0x0000_00AB
+
+
+# ---------------------------------------------------------------------------
+# Concurrency contract — backend queries are rejected while a non-blocking
+# cont() worker is in flight; get_status stays available (and skips the PC).
+# ---------------------------------------------------------------------------
+
+class TestRunningGuard:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_query_rejected_while_running(self):
+        import threading
+        # Simulate an in-flight non-blocking cont by parking a live worker
+        # thread — deterministic, no dependence on firmware timing.
+        ev = threading.Event()
+        worker = threading.Thread(target=ev.wait, daemon=True)
+        worker.start()
+        self.session._running = True
+        self.session._worker = worker
+        try:
+            for op in (
+                lambda: self.session.read_register("pc"),
+                lambda: self.session.read_memory(0x20001000, 4),
+                lambda: self.session.write_register("r0", 0),
+                lambda: self.session.disassemble(count=1),
+                lambda: self.session.set_breakpoint(0x08000200),
+                lambda: self.session.read_word(0x20001000),
+            ):
+                with pytest.raises(SessionError, match="running"):
+                    op()
+            # get_status must stay callable and not touch the backend PC.
+            st = self.session.status()
+            assert st["running"] is True
+            assert st["pc"] is None
+        finally:
+            ev.set()
+            worker.join(timeout=1.0)
+            self.session._running = False
+            self.session._worker = None
+
+    def test_stop_keeps_running_when_worker_survives_join(self):
+        # A firmware that ignores emu_stop leaves the worker thread alive after
+        # stop()'s join times out. stop() must NOT declare the engine idle
+        # (that would let assert_idle pass and race the live engine), and
+        # _snapshot_run must not read the backend PC.
+        import threading
+        ev = threading.Event()
+        worker = threading.Thread(target=ev.wait, daemon=True)
+        worker.start()
+        self.session._running = True
+        self.session._worker = worker
+        try:
+            snap = self.session.stop()       # join(2s) times out; worker alive
+            assert snap["running"] is True    # still running, not cleared
+            assert snap["pc"] is None         # backend not touched
+            with pytest.raises(SessionError, match="running"):
+                self.session.read_register("pc")
+        finally:
+            ev.set()
+            worker.join(timeout=1.0)
+            self.session._running = False
+            self.session._worker = None
+
+
+# ---------------------------------------------------------------------------
+# step() guards against an exited firmware (mirrors cont()'s guard)
+# ---------------------------------------------------------------------------
+
+class TestStepExitedGuard:
+    @pytest.fixture(autouse=True)
+    def _activate(self, session):
+        session.start(_arm32_configs(), emulator="unicorn",
+                      target_name="mcp_test", start_periph_server=False)
+        self.session = session
+
+    def test_step_after_exit_raises(self):
+        self.session._exited = True
+        try:
+            with pytest.raises(SessionError, match="exited"):
+                self.session.step()
+        finally:
+            self.session._exited = False

--- a/test/pytest/mcp_server/test_worker.py
+++ b/test/pytest/mcp_server/test_worker.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Christopher Wright
+
+"""Tests for the per-session worker subprocess (_worker.py).
+
+Spawns ``python -m halucinator.mcp._worker`` and drives it over JSON-RPC,
+exactly as the SessionManager will. The worker needs the halucinator runtime
+(unicorn/avatar2 imports) but NOT the MCP SDK, so this runs on every
+interpreter — it's the manager<->worker contract under test, in isolation.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_SRC = str(REPO_ROOT / "src")
+ARM32_DIR = REPO_ROOT / "test" / "multi_arch" / "arm32"
+_FW_PRESENT = (ARM32_DIR / "firmware" / "test_uart.bin").exists()
+
+pytestmark = pytest.mark.skipif(
+    not _FW_PRESENT, reason="arm32 test firmware not built")
+
+
+def _configs():
+    return ["test_uart_config.yaml", "test_uart_addrs.yaml",
+            "test_uart_memory.yaml"]
+
+
+class _Worker:
+    """Minimal manager-side stand-in: line-delimited JSON-RPC over pipes."""
+
+    def __init__(self, cwd, capture_stdout_extra=False):
+        # The worker runs from a different cwd, so hand it an ABSOLUTE import
+        # path (mirrors what the SessionManager does): prepend src/ so the
+        # child finds halucinator even when it isn't pip-installed (the 3.9
+        # baseline drives the tree via PYTHONPATH=src, which is relative).
+        env = dict(os.environ)
+        env["PYTHONPATH"] = _SRC + os.pathsep + env.get("PYTHONPATH", "")
+        self.proc = subprocess.Popen(
+            [sys.executable, "-m", "halucinator.mcp._worker"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, cwd=str(cwd), env=env,
+        )
+        self._id = 0
+
+    def call(self, method, **params):
+        self._id += 1
+        req = {"id": self._id, "method": method, "params": params}
+        self.proc.stdin.write((json.dumps(req) + "\n").encode())
+        self.proc.stdin.flush()
+        line = self.proc.stdout.readline()
+        assert line, "worker closed the pipe without responding"
+        # Every stdout line MUST be a valid JSON frame (stdout discipline).
+        resp = json.loads(line)
+        assert resp["id"] == self._id
+        return resp
+
+    def close(self):
+        try:
+            self.proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self.proc.wait(timeout=15)
+        except Exception:
+            self.proc.kill()
+
+
+def test_worker_roundtrip_and_bytes_hex():
+    w = _Worker(ARM32_DIR)
+    try:
+        r = w.call("start", config_paths=_configs(), emulator="unicorn",
+                   target_name="wtest", start_periph_server=False)
+        assert r["ok"] is True, r
+        assert r["result"]["arch"] == "cortex-m3"
+
+        r = w.call("read_register", name="pc")
+        assert r["ok"] and (r["result"] & ~1) == 0x08000112
+
+        # Raw memory crosses the wire as hex in both directions, byte-for-byte
+        # (no endianness — that's write_word's job).
+        r = w.call("write_memory", addr=0x20001000, data="11223344")
+        assert r["ok"] and r["result"] is True
+        r = w.call("read_memory", addr=0x20001000, size=4)
+        assert r["ok"] and r["result"] == "11223344"
+
+        # write_word DOES apply target endianness (little on cortex-m3).
+        r = w.call("write_word", addr=0x20001000, value=0x11223344)
+        assert r["ok"] and r["result"] is True
+        r = w.call("read_memory", addr=0x20001000, size=4)
+        assert r["ok"] and r["result"] == "44332211"
+        r = w.call("read_word", addr=0x20001000)
+        assert r["ok"] and r["result"] == 0x11223344
+
+        r = w.call("shutdown")
+        assert r["ok"]
+    finally:
+        w.close()
+
+
+def test_worker_large_frame_roundtrip():
+    # A 64 KiB read_memory result is ~128 KiB of hex — larger than the OS pipe
+    # buffer. Exercises the worker's buffered-writer (no short-write drop) and
+    # the manager-side framing loop (accumulate across multiple reads).
+    w = _Worker(ARM32_DIR)
+    try:
+        r = w.call("start", config_paths=_configs(), emulator="unicorn",
+                   target_name="wbig", start_periph_server=False)
+        assert r["ok"] is True, r
+        payload = bytes(range(256)) * 256  # 65536 bytes, into RAM
+        r = w.call("write_memory", addr=0x20002000, data=payload.hex())
+        assert r["ok"] and r["result"] is True
+        r = w.call("read_memory", addr=0x20002000, size=len(payload))
+        assert r["ok"], r
+        assert bytes.fromhex(r["result"]) == payload   # nothing dropped
+        w.call("shutdown")
+    finally:
+        w.close()
+
+
+def test_worker_error_propagation():
+    w = _Worker(ARM32_DIR)
+    try:
+        # Querying before start -> SessionError surfaces with type + message.
+        r = w.call("read_register", name="pc")
+        assert r["ok"] is False
+        assert r["error"]["type"] == "SessionError"
+        assert "No active emulation" in r["error"]["message"]
+
+        # Unknown/disallowed methods are rejected, not executed.
+        r = w.call("__class__")
+        assert r["ok"] is False and "disallowed" in r["error"]["message"]
+        r = w.call("definitely_not_a_method")
+        assert r["ok"] is False
+    finally:
+        w.close()
+
+
+def test_worker_stdout_clean_with_peripheral_server():
+    # With the peripheral server running (it logs heavily and prints), every
+    # stdout line must still parse as a JSON frame — the worker redirects all
+    # non-frame output to stderr. _Worker.call asserts each line is JSON.
+    w = _Worker(ARM32_DIR)
+    try:
+        r = w.call("start", config_paths=_configs(), emulator="unicorn",
+                   target_name="wtest_periph", start_periph_server=True,
+                   rx_port=16555, tx_port=16556)
+        assert r["ok"] is True, r
+        r = w.call("status")
+        assert r["ok"] and r["result"]["active"] is True
+        r = w.call("shutdown")
+        assert r["ok"]
+    finally:
+        w.close()


### PR DESCRIPTION
## halucinator-mcp — multi-session MCP server

Exposes a HALucinator emulation as LLM-callable tools over the Model Context
Protocol, so an MCP client (Claude Desktop, Claude Code, custom clients) can
drive a firmware emulation interactively: load YAML configs, read/write
registers and memory, set breakpoints/watchpoints, disassemble, inject IRQs,
look up symbols, and step/continue execution.

### Highlights
- **Multi-session**: `SessionManager` supervises one worker subprocess per
  session over a line-delimited JSON-RPC pipe — required because HALucinator
  keeps process-global state (intercept LUTs, `peripheral_server` zmq
  sockets); also gives crash isolation and a hard-kill path for wedged
  firmware. Every tool takes an optional `session_id`.
- **Backends**: in-process `unicorn` and `ghidra` (v1).
- **Transport**: stdio (default) and streamable-HTTP (`--http`) with
  bearer-token auth and a loud warning on non-loopback bind without a token.
- **Hardened** against an adversarial review (large-frame pipe writes,
  raw-fd framing reads with deadlines, stop()/port-free races, websocket
  auth default-deny, x86 capstone mapping).
- `mcp[cli]` kept in the `[mcp]` extra (Python 3.10+), out of core so the 3.9
  baseline still builds. CI installs the extra and smoke-tests the entry point.

### Tests
`test/pytest/mcp_server/` — server / manager / worker / codec / session
(SDK-dependent tests self-skip on 3.9).

### Note on the diff
This branch is stacked on the post-30-32 integration base (PRs #30 / #32), so its
diff currently also shows those changes. It will rebase cleanly onto `master`
once they land; **draft** until then. The MCP feature itself is contained in
`src/halucinator/mcp/` and `test/pytest/mcp_server/`.

