### PR TITLE
main: re-enter cont() after an async IRQ in the in-process dispatch loop

### DIFF
--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -1063,6 +1063,22 @@ def _in_process_dispatch_loop(backend: "HalBackend") -> None:
         pc = backend.read_register("pc") & ~1  # mask Thumb bit on ARM
         bp_id = intercepts.addr2bp_lut.get(pc)
         if bp_id is None:
+            # An asynchronous IRQ (e.g. a TimerModel tick injected from a
+            # background thread) breaks out of emu_start via a cross-thread
+            # emu_stop(). On cortex-m3 the IRQ is applied and the CPU is now
+            # mid-ISR at a PC that is not a registered breakpoint — that is
+            # NOT "ran off the rails", it is normal interrupt-driven
+            # execution. Re-enter cont() so the ISR (and the periodic
+            # control loop it drives) keeps running, instead of exiting.
+            # We only do this when an IRQ controller is configured and the
+            # PC lands in mapped code; a genuine runaway (unmapped fetch)
+            # still surfaces as a UcError from cont().
+            if getattr(backend, "_irq_controller", None) is not None:
+                try:
+                    backend.cont()
+                    continue
+                except Exception:  # noqa: BLE001 — real fault: let it surface
+                    raise
             log.info("%s stopped at 0x%x with no handler; exiting",
                      type(backend).__name__, pc)
             return


### PR DESCRIPTION
## main: re-enter `cont()` after an async IRQ in the in-process dispatch loop

A small, gated fix to `_in_process_dispatch_loop` so **interrupt-driven firmware
runs on the in-process (unicorn) backend**.

### The problem
An asynchronous IRQ — e.g. a `TimerModel` tick injected from a background thread —
breaks out of `emu_start` via a cross-thread `emu_stop()`. The CPU is then parked
**mid-ISR at a PC that isn't a registered breakpoint**. The dispatch loop treats
that as "stopped with no handler" and `return`s, ending the emulation exactly
when the periodic control loop fires.

### The fix
Re-enter `cont()` in that case so the ISR (and the loop it drives) keeps running:

```python
if bp_id is None:
    if getattr(backend, "_irq_controller", None) is not None:
        try:
            backend.cont()
            continue
        except Exception:
            raise
    log.info("%s stopped at 0x%x with no handler; exiting", ...)
    return
```

- **Gated** on `backend._irq_controller is not None` → configs without an IRQ
  controller behave exactly as before (fully backward-compatible).
- A genuine runaway (unmapped fetch) still surfaces as a `UcError` from `cont()`.

### Why
This is what lets bare-metal **interrupt-driven** rehosts run on the unicorn
backend — e.g. an STM32 self-balancing robot whose control loop is driven by a
TIM2 tick. Without it, the firmware boots but the emulation exits at the first
injected IRQ.

Standalone, based on `master` (the in-process loop + `_irq_controller` already
exist there). +16 lines, one file.
