### PR TITLE
IRQ framework consolidation: shared in-process mixin, x86 deliverer, backend dedup

### DIFF
--- a/src/halucinator/backends/ghidra_backend.py
+++ b/src/halucinator/backends/ghidra_backend.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from .hal_backend import (
     ABI_MIXINS, ARM32HalMixin, HalBackend, MemoryRegion,
 )
+from .irq.in_process import InProcessIrqMixin
 
 log = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ _LANGUAGE_MAP: Dict[str, str] = {
 }
 
 
-class GhidraBackend(ARM32HalMixin, HalBackend):
+class GhidraBackend(InProcessIrqMixin, ARM32HalMixin, HalBackend):
     """
     In-process emulation backend via Ghidra's PCode EmulatorHelper.
     """
@@ -92,19 +93,11 @@ class GhidraBackend(ARM32HalMixin, HalBackend):
         # chunks so the synthetic exception frame setup is
         # single-threaded — Ghidra's setContextRegister can only run
         # while the emulator is in STOPPED state.
-        self._pending_irqs: List[int] = []
+        # In-process IRQ state (queue + HAL_DET_TICK) — see InProcessIrqMixin.
+        self._init_in_process_irq()
 
         # Arch-specific ABI binding.
-        abi_cls = ABI_MIXINS.get(arch, ARM32HalMixin)
-        self._abi = abi_cls
-        if abi_cls is not ARM32HalMixin:
-            for method_name in ("get_arg", "set_args", "get_ret_addr",
-                                "set_ret_addr", "execute_return",
-                                "read_string"):
-                method = getattr(abi_cls, method_name, None)
-                if method is not None:
-                    setattr(self, method_name,
-                            method.__get__(self, type(self)))
+        self._bind_abi(arch)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -450,6 +443,17 @@ class GhidraBackend(ARM32HalMixin, HalBackend):
         if self._emulator is not None:
             self._emulator.setHalt(True)
 
+    def _request_break(self) -> None:
+        """Thread-safe stop of the running emulator (InProcessIrqMixin
+        primitive): ask run() to break so the dispatch thread drains the
+        pending-IRQ queue."""
+        if self._emulator is None:
+            return
+        try:
+            self._emulator.setHalt(True)
+        except Exception:  # noqa: BLE001
+            pass
+
     def step(self) -> None:
         if self._emulator is None:
             raise RuntimeError("Call GhidraBackend.init() first")
@@ -461,9 +465,12 @@ class GhidraBackend(ARM32HalMixin, HalBackend):
     # Ghidra's PCode emulator doesn't model that transition, so we mirror
     # the unicorn trick: catch the fetch at an EXC_RETURN address and
     # unwind the frame manually on the dispatch side.
-    _EXC_RETURN_THREAD_MSP = 0xFFFFFFF9
-    _EXC_RETURN_MASK = 0xFFFFFFF0
-    _EXC_RETURN_MAGIC = 0xFFFFFFF0
+    # EXC_RETURN constants + frame decode now live in InProcessIrqMixin.
+
+    # Ghidra prefers the shadow-write path whenever the controller carries
+    # shadow addresses (it sidesteps Sleigh banked-register quirks). See
+    # InProcessIrqMixin._apply_pending_irq.
+    _prefer_shadow_irq = True
 
     def set_vtor(self, vtor: int) -> None:
         """Remember the vector-table base so inject_irq can find ISRs."""
@@ -598,32 +605,14 @@ class GhidraBackend(ARM32HalMixin, HalBackend):
         except Exception:  # noqa: BLE001
             pass
 
-    def _apply_pending_irq(self, irq_num: int) -> None:
-        """Synthesise an exception entry for a queued IRQ. Must run
-        on the dispatch thread, while the Ghidra emulator is STOPPED
-        — setContextRegister and writeRegister both require the
-        emulator to be paused."""
+    def _apply_cortex_m_fallback(self, irq_num: int) -> None:
+        """Cortex-M (and un-migrated arch) fallback: push the 8-word
+        exception frame and vector to vector[16+N]. Called by
+        InProcessIrqMixin._apply_pending_irq (which handles the
+        shadow-preference and arm/arm64/mips/ppc routing). Must run on the
+        dispatch thread while the Ghidra emulator is STOPPED — writeRegister
+        requires the emulator paused."""
         if self._emulator is None:
-            return
-        # If the IrqController carries shadow-write addresses,
-        # prefer them over the per-arch synthetic exception entry
-        # — the shadow path bypasses Ghidra's banked-register
-        # quirks (which keep arm/arm64 unreliable). The firmware
-        # globals live at known offsets in our test corpus.
-        ctrl = getattr(self, "_irq_controller", None)
-        if (ctrl is not None
-            and getattr(ctrl, "irq_fired_addr", None) is not None
-            and getattr(ctrl, "irq_number_addr", None) is not None):
-            self._apply_pending_irq_shadow_write(irq_num)
-            return
-        if self.arch == "arm":
-            self._apply_pending_irq_armv7a(irq_num)
-            return
-        if self.arch == "arm64":
-            self._apply_pending_irq_arm64(irq_num)
-            return
-        if self.arch in ("mips", "powerpc", "powerpc:MPC8XX", "ppc64"):
-            self._apply_pending_irq_shadow_write(irq_num)
             return
         vtor = getattr(self, "_vtor", 0)
         isr_slot = vtor + (16 + irq_num) * 4
@@ -692,55 +681,15 @@ class GhidraBackend(ARM32HalMixin, HalBackend):
             "return=0x%x", irq_num, irq_simple, return_pc,
         )
 
-    def _apply_pending_irq_shadow_write(self, irq_num: int) -> None:
-        """Deliver an IRQ via shadow-write — same pattern as the
-        unicorn MIPS / PPC paths. Bypass any synthetic exception
-        entry and just write the post-ack flag + number directly
-        into the firmware's globals; main's polling loop sees
-        them on its next iteration."""
-        ctrl = getattr(self, "_irq_controller", None)
-        if ctrl is None:
-            return
-        irq_number_addr = getattr(ctrl, "irq_number_addr", None)
-        irq_fired_addr = getattr(ctrl, "irq_fired_addr", None)
-        if irq_number_addr is None or irq_fired_addr is None:
-            log.warning(
-                "GhidraBackend.inject_irq(%d): %s controller has no "
-                "irq_fired_addr/irq_number_addr — IRQ won't deliver",
-                irq_num, self.arch)
-            return
-        try:
-            self.write_memory(int(irq_number_addr), 1,
-                              int(irq_num).to_bytes(4, "big"),
-                              4, raw=True)
-            self.write_memory(int(irq_fired_addr), 1,
-                              (1).to_bytes(4, "big"),
-                              4, raw=True)
-            log.info(
-                "GhidraBackend.inject_irq(%d): %s shadow write -> "
-                "irq_number@0x%x irq_fired@0x%x",
-                irq_num, self.arch, irq_number_addr, irq_fired_addr)
-        except Exception as exc:  # noqa: BLE001
-            log.warning(
-                "GhidraBackend.inject_irq(%d): %s shadow write failed: %r",
-                irq_num, self.arch, exc)
-
     def _maybe_handle_exc_return(self, pc: int) -> bool:
         """If PC now points at an EXC_RETURN magic value (as happens
         when an ISR does `bx lr`), pop the exception frame we pushed in
         inject_irq and resume pre-interrupt state. Returns True if
         handled."""
-        if self.arch != "cortex-m3":
+        decoded = self._decode_exc_return_frame(pc)
+        if decoded is None:
             return False
-        if (pc & self._EXC_RETURN_MASK) != self._EXC_RETURN_MAGIC:
-            return False
-        sp = self.read_register("sp")
-        try:
-            import struct
-            raw = self.read_memory(sp, 1, 32, raw=True)
-            frame = struct.unpack("<8I", bytes(raw))
-        except Exception:  # noqa: BLE001
-            return False
+        sp, frame = decoded
         # On exc_return Ghidra has already faulted on the
         # 0xFFFFFFFx fetch — the emulator is in FAULT state, which
         # rejects setContextRegister. Use the raw writeRegister path

--- a/src/halucinator/backends/hal_backend.py
+++ b/src/halucinator/backends/hal_backend.py
@@ -53,6 +53,26 @@ class HalBackend(ABC):
     Concrete implementations: Avatar2Backend, QEMUBackend, UnicornBackend.
     """
 
+    def _bind_abi(self, arch: str) -> None:
+        """Bind the arch-specific ABI mixin's helpers onto this instance.
+
+        ARM32 stays the default via class inheritance, so the backend is
+        usable without __init__ (e.g. in unit tests); any other arch has its
+        ``get_arg``/``set_args``/``get_ret_addr``/``set_ret_addr``/
+        ``execute_return``/``read_string`` overridden by the mixin's bound
+        methods. Shared by every backend that selects an ABI at init time.
+        """
+        abi_cls = ABI_MIXINS.get(arch, ARM32HalMixin)
+        self._abi = abi_cls
+        if abi_cls is not ARM32HalMixin:
+            for method_name in ("get_arg", "set_args", "get_ret_addr",
+                                "set_ret_addr", "execute_return",
+                                "read_string"):
+                method = getattr(abi_cls, method_name, None)
+                if method is not None:
+                    setattr(self, method_name,
+                            method.__get__(self, type(self)))
+
     # ------------------------------------------------------------------
     # Memory operations  (must implement)
     # ------------------------------------------------------------------

--- a/src/halucinator/backends/irq/delivery.py
+++ b/src/halucinator/backends/irq/delivery.py
@@ -27,15 +27,19 @@ the same shape; they are intentionally not implemented here yet.
 from __future__ import annotations
 
 import logging
+import struct
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from halucinator import hal_log
+
 if TYPE_CHECKING:
     from halucinator.backends.hal_backend import HalBackend
 
 log = logging.getLogger(__name__)
+hlog = hal_log.getHalLogger()
 
 
 class DeliveryModel(Enum):
@@ -404,6 +408,122 @@ class ShadowExceptionDeliverer(ExceptionDeliverer):
 
 
 # ---------------------------------------------------------------------------
+# x86 / i386 (synthesised PC interrupt frame) — for in-process unicorn
+# ---------------------------------------------------------------------------
+
+_EFLAGS_IF = 1 << 9   # interrupt-enable flag
+
+
+class X86ExceptionDeliverer(ExceptionDeliverer):
+    """Synthesised x86/i386 PC interrupt entry for in-process unicorn
+    (replaces ``X86PicController.deliver``). Unicorn's x86 model does not
+    take hardware interrupts, so we build the hardware interrupt frame
+    (EIP/CS/EFLAGS on the stack) and vector to the connected clock ISR —
+    either directly or through a once-assembled VxWorks-style intEnt/intExit
+    stub.
+
+    Delivery data comes from the ``DeliveryPlan``: ``isr_addr`` (the connected
+    clock ISR, typically learned at run time via ``sysClkConnect``) plus the
+    kernel stub fields in ``extra`` (``int_ent``/``int_exit``/``stub_addr``/
+    ``isr_arg``). The assembled-stub cache lives on the backend
+    (``_x86_stub_*``), not the deliverer, so a single deliverer instance is
+    stateless across backends. ``num`` is unused (a single clock tick)."""
+
+    arch = "x86"
+
+    def deliver(self, backend: "HalBackend", num: int,
+                plan: DeliveryPlan) -> bool:
+        setattr(backend, "_last_delivered_irq", int(num))
+        isr_addr = plan.isr_addr
+        if isr_addr is None:
+            log.warning("x86_pic: tick fired but no clock ISR known yet "
+                        "(sysClkConnect not seen, no isr_addr configured) "
+                        "— dropping")
+            return False
+        eflags = backend.read_register("eflags")
+        if not (eflags & _EFLAGS_IF):
+            # Interrupts masked (cli). The firmware will re-enable; the next
+            # tick will land. Dropping a masked tick matches real edge-PIC
+            # behaviour closely enough for the clock.
+            log.debug("x86_pic: IF=0 (interrupts masked) — tick dropped")
+            return False
+
+        eip = backend.read_register("eip")
+        cs = backend.read_register("cs")
+        esp = backend.read_register("esp")
+
+        target = self._ensure_stub(backend, plan)
+        if target is None:
+            target = isr_addr
+
+        # Build the hardware interrupt frame the handler/iret expects:
+        #   [esp]   = EIP   (return address)
+        #   [esp+4] = CS
+        #   [esp+8] = EFLAGS
+        esp -= 12
+        backend.write_memory(esp, 4, eip & 0xFFFFFFFF)
+        backend.write_memory(esp + 4, 4, cs & 0xFFFFFFFF)
+        backend.write_memory(esp + 8, 4, eflags & 0xFFFFFFFF)
+        backend.write_register("esp", esp)
+        # Mask IF for the duration of the handler (the stub's cli does this on
+        # hardware; set it now so a re-entrant tick is dropped by the IF check
+        # above until the handler's iret restores it).
+        backend.write_register("eflags", eflags & ~_EFLAGS_IF)
+        backend.write_register("eip", target)
+        hlog.info("x86_pic: delivering IRQ -> stub/ISR 0x%08x "
+                  "(interrupted eip=0x%08x, frame@0x%08x)",
+                  target, eip, esp)
+        return True
+
+    @staticmethod
+    def _ensure_stub(backend: "HalBackend",
+                     plan: DeliveryPlan) -> Optional[int]:
+        """Assemble the VxWorks-style interrupt stub in guest RAM once.
+
+        Returns the stub entry EIP, or None when no kernel int_ent/int_exit
+        are configured (caller then vectors at the ISR directly with a bare
+        iret frame). The once-only cache lives on the backend."""
+        int_ent = plan.extra.get("int_ent")
+        int_exit = plan.extra.get("int_exit")
+        isr_addr = plan.isr_addr
+        stub_addr = plan.extra.get("stub_addr", 0x7000)
+        isr_arg = plan.extra.get("isr_arg", 0)
+        if int_ent is None or int_exit is None:
+            return None
+        if getattr(backend, "_x86_stub_written", False):
+            return getattr(backend, "_x86_stub_entry", None)
+        if isr_addr is None:
+            return None
+        base = stub_addr
+        code = bytearray()
+        # cli
+        code += b"\xfa"
+        # call intEnt   (rel32 from end of this instruction)
+        code += b"\xe8" + struct.pack("<i", int_ent - (base + len(code) + 5))
+        # push <isr_arg>
+        code += b"\x68" + struct.pack("<I", isr_arg & 0xFFFFFFFF)
+        # call <isr>
+        code += b"\xe8" + struct.pack("<i", isr_addr - (base + len(code) + 5))
+        # add esp, 4
+        code += b"\x83\xc4\x04"
+        # jmp intExit
+        code += b"\xe9" + struct.pack("<i", int_exit - (base + len(code) + 5))
+        if not backend.write_memory(base, 1, bytes(code)):
+            log.warning("x86_pic: could not write interrupt stub at 0x%08x; "
+                        "falling back to direct ISR vector", base)
+            # Don't retry the stub write on every tick.
+            backend._x86_stub_written = True
+            backend._x86_stub_entry = None
+            return None
+        backend._x86_stub_written = True
+        backend._x86_stub_entry = base
+        log.info("x86_pic: assembled interrupt stub @ 0x%08x "
+                 "(intEnt=0x%x isr=0x%x intExit=0x%x, %d bytes)",
+                 base, int_ent, isr_addr, int_exit, len(code))
+        return base
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
@@ -414,6 +534,7 @@ _DELIVERER_CLASSES = {
     "powerpc": ShadowExceptionDeliverer,
     "powerpc:MPC8XX": ShadowExceptionDeliverer,
     "ppc64": ShadowExceptionDeliverer,
+    "x86": X86ExceptionDeliverer,
 }
 
 
@@ -432,5 +553,6 @@ __all__ = [
     "ArmExceptionDeliverer",
     "Arm64ExceptionDeliverer",
     "ShadowExceptionDeliverer",
+    "X86ExceptionDeliverer",
     "build_exception_deliverer",
 ]

--- a/src/halucinator/backends/irq/in_process.py
+++ b/src/halucinator/backends/irq/in_process.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Christopher Wright
+"""Shared in-process IRQ delivery machinery.
+
+Backends whose CPU model does not take hardware exceptions (UnicornBackend,
+GhidraBackend) must synthesise the interrupt entry on the dispatch thread.
+This mixin owns the parts that are identical across those backends:
+
+- the cross-thread pending-IRQ queue (``_pending_irqs``),
+- the deterministic-tick policy (``HAL_DET_TICK``) and its double-tick guard,
+- the ``_apply_pending_irq`` arch dispatcher,
+- the SHADOW delivery path (endianness-correct, via ``ShadowExceptionDeliverer``),
+- ``_resolve_delivery_plan`` (new ``irq_delivery`` config vs legacy controller),
+- ``in_process_irq_active`` (the predicate main's dispatch loop uses to
+  re-enter ``cont()`` after an async IRQ lands the CPU mid-ISR).
+
+Backends provide a few primitives: ``arch``, ``_request_break`` (thread-safe
+stop of the running emulator), and ``_apply_cortex_m_fallback`` (the
+Cortex-M frame push, which uses each backend's native register/memory API).
+A backend whose register model differs (Ghidra banks LR/SPSR under Sleigh
+names) overrides ``_apply_pending_irq_armv7a`` / ``_apply_pending_irq_arm64``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import struct
+from typing import Callable, List, Optional
+
+log = logging.getLogger(__name__)
+
+
+class InProcessIrqMixin:
+    # Backends that deliver via a firmware-side shadow write (Ghidra) set
+    # this True to prefer the shadow path whenever the controller carries
+    # shadow addresses, even for arm/arm64 (it sidesteps banked-register
+    # quirks). Unicorn leaves it False and uses the per-arch entries.
+    _prefer_shadow_irq: bool = False
+
+    # -- Cortex-M EXC_RETURN -----------------------------------------------
+    # A PC whose top nibble matches EXC_RETURN_MAGIC is an ISR doing `bx lr`.
+    _EXC_RETURN_THREAD_MSP = 0xFFFFFFF9
+    _EXC_RETURN_MASK = 0xFFFFFFF0
+    _EXC_RETURN_MAGIC = 0xFFFFFFF0
+
+    def _decode_exc_return_frame(self, pc: int):
+        """If *pc* is a Cortex-M EXC_RETURN magic value, read and unpack the
+        8-word exception frame pushed at SP. Returns ``(sp, frame)`` where
+        ``frame`` is (r0,r1,r2,r3,r12,lr,pc,cpsr), or ``None`` if this isn't
+        an exc-return. The register write-back and any emulator restart are
+        backend-specific (register banking / FAULT-state differ), so callers
+        apply those themselves."""
+        if self.arch != "cortex-m3":
+            return None
+        if (pc & self._EXC_RETURN_MASK) != self._EXC_RETURN_MAGIC:
+            return None
+        sp = self.read_register("sp")
+        try:
+            frame = struct.unpack(
+                "<8I", bytes(self.read_memory(sp, 1, 32, raw=True)))
+        except Exception:  # noqa: BLE001
+            return None
+        return sp, frame
+
+    # -- init --------------------------------------------------------------
+    def _init_in_process_irq(self) -> None:
+        """Initialise the pending-IRQ queue and deterministic-tick config.
+        Call once from the backend ``__init__``."""
+        # Pending IRQ injected from another thread (peripheral_server zmq
+        # handler / TimerModel). The run loop drains the queue before
+        # re-entering the CPU so the synthetic exception frame is set up
+        # single-threaded.
+        self._pending_irqs: List[int] = []
+        # HAL_DET_TICK="<irq>:<chunks>" drives the system-clock IRQ from
+        # instruction count in the run loop instead of the wall-clock timer
+        # thread, for reproducible scheduling.
+        self._det_irq: Optional[int] = None
+        self._det_period: int = 0
+        self._det_chunks: int = 0
+        _det = os.environ.get("HAL_DET_TICK")
+        if _det:
+            try:
+                _di, _dp = _det.split(":", 1)
+                self._det_irq = int(_di, 0)
+                self._det_period = max(1, int(_dp, 0))
+            except Exception:  # noqa: BLE001
+                self._det_irq = None
+
+    # -- primitives the backend must provide -------------------------------
+    def _request_break(self) -> None:
+        """Ask the running emulator to stop (thread-safe). Backend-specific
+        (Unicorn: uc.emu_stop(); Ghidra: emulator.setHalt(True))."""
+        raise NotImplementedError
+
+    def _apply_cortex_m_fallback(self, irq_num: int) -> None:
+        """Push the Cortex-M 8-word exception frame and vector to
+        vector[16+N]. Backend-specific (native register/memory API)."""
+        raise NotImplementedError
+
+    # -- deterministic tick ------------------------------------------------
+    def _det_suppress(self, irq_num: int) -> bool:
+        """True when this IRQ is the deterministic-tick IRQ (already driven
+        from instruction count in the run loop) and so a wall-clock-thread
+        injection of it should be dropped to avoid double-ticking."""
+        return self._det_irq is not None and int(irq_num) == self._det_irq
+
+    # -- delivery-plan resolution -----------------------------------------
+    def _resolve_delivery_plan(self, build_legacy: Callable):
+        """Return the attached DeliveryPlan (new ``irq_delivery`` config) or,
+        when none was set, a plan built from the legacy controller fields via
+        ``build_legacy(ctrl)``."""
+        plan = getattr(self, "_delivery_plan", None)
+        if plan is not None:
+            return plan
+        ctrl = getattr(self, "_irq_controller", None)
+        return build_legacy(ctrl)
+
+    # -- the shared dispatcher --------------------------------------------
+    def _apply_pending_irq(self, irq_num: int) -> None:
+        """Set up the synthetic exception entry for a pended IRQ. Must run on
+        the dispatch thread (between run chunks) — mutating PC/SP is only
+        safe while the CPU is not running."""
+        arch = self.arch
+        if self._prefer_shadow_irq:
+            ctrl = getattr(self, "_irq_controller", None)
+            if (ctrl is not None
+                    and getattr(ctrl, "irq_fired_addr", None) is not None
+                    and getattr(ctrl, "irq_number_addr", None) is not None):
+                self._apply_pending_irq_shadow(irq_num)
+                return
+        if arch == "arm":
+            self._apply_pending_irq_armv7a(irq_num)
+            return
+        if arch == "arm64":
+            self._apply_pending_irq_arm64(irq_num)
+            return
+        if arch in ("mips", "powerpc", "powerpc:MPC8XX", "ppc64"):
+            self._apply_pending_irq_shadow(irq_num)
+            return
+        if arch == "x86":
+            # x86 delivery lives in X86ExceptionDeliverer; the configured
+            # X86PicController.deliver is a thin shim over it that carries the
+            # runtime-learned clock ISR. Runs on the dispatch thread here, so
+            # mutating EIP/ESP is safe.
+            ctrl = getattr(self, "_irq_controller", None)
+            if ctrl is not None and hasattr(ctrl, "deliver"):
+                ctrl.deliver(self)
+            else:
+                log.warning("inject_irq(%d): x86 has no X86PicController "
+                            "configured; tick dropped", irq_num)
+            return
+        # Cortex-M (and any un-migrated arch): backend-provided frame push.
+        self._apply_cortex_m_fallback(irq_num)
+
+    # -- shared SHADOW delivery -------------------------------------------
+    def _apply_pending_irq_shadow(self, irq_num: int) -> None:
+        """Deliver via shadow-write: write the firmware's post-ack globals
+        (irq_number, irq_fired) directly; the main polling loop picks them up
+        next iteration. Endianness follows the backend's ``write_memory``."""
+        from halucinator.backends.irq.delivery import (
+            DeliveryModel, DeliveryPlan, ShadowExceptionDeliverer)
+
+        def _legacy(ctrl):
+            return DeliveryPlan(
+                model=DeliveryModel.SHADOW,
+                irq_fired_addr=(getattr(ctrl, "irq_fired_addr", None)
+                                if ctrl else None),
+                irq_number_addr=(getattr(ctrl, "irq_number_addr", None)
+                                 if ctrl else None),
+            )
+        ShadowExceptionDeliverer().deliver(self, irq_num,
+                                           self._resolve_delivery_plan(_legacy))
+
+    # -- per-arch entries the backend provides/overrides -------------------
+    def _apply_pending_irq_armv7a(self, irq_num: int) -> None:
+        raise NotImplementedError
+
+    def _apply_pending_irq_arm64(self, irq_num: int) -> None:
+        raise NotImplementedError
+
+    # -- dispatch-loop predicate ------------------------------------------
+    def in_process_irq_active(self) -> bool:
+        """True when an IRQ controller is configured, so main's dispatch loop
+        re-enters ``cont()`` after an async IRQ landed the CPU mid-ISR at a
+        PC with no registered breakpoint (normal interrupt-driven execution,
+        not a derail)."""
+        return getattr(self, "_irq_controller", None) is not None

--- a/src/halucinator/backends/irq/x86_pic.py
+++ b/src/halucinator/backends/irq/x86_pic.py
@@ -60,22 +60,15 @@ scheduler reschedule lives in `intExit`.
 from __future__ import annotations
 
 import logging
-import struct
 import threading
 from typing import TYPE_CHECKING, List, Optional
 
 from . import IrqController
-from halucinator import hal_log
 
 if TYPE_CHECKING:
     from halucinator.backends.hal_backend import HalBackend
 
 log = logging.getLogger(__name__)
-hlog = hal_log.getHalLogger()
-
-# EFLAGS bits.
-_EFLAGS_IF = 1 << 9   # interrupt-enable flag
-_EFLAGS_RESERVED = 0x2  # bit1 is always 1
 
 
 class X86PicController(IrqController):
@@ -105,8 +98,6 @@ class X86PicController(IrqController):
         self.stub_addr: int = stub_addr
         self.isr_arg: int = isr_arg
         self.vector: int = vector
-        self._stub_written: bool = False
-        self._stub_entry: Optional[int] = None
         # Re-entrancy guard: don't nest a tick inside the clock ISR.
         self._in_isr: bool = False
         self._lock = threading.Lock()
@@ -157,92 +148,25 @@ class X86PicController(IrqController):
     # Delivery — runs on the dispatch thread (single-threaded CPU state)
     # ------------------------------------------------------------------
 
-    def _ensure_stub(self, backend: "HalBackend") -> Optional[int]:
-        """Assemble the VxWorks-style interrupt stub in guest RAM once.
-
-        Returns the stub entry EIP, or None when no kernel int_ent/
-        int_exit are configured (caller then vectors at the ISR
-        directly with a bare iret frame).
-        """
-        if self.int_ent is None or self.int_exit is None:
-            return None
-        if self._stub_written:
-            return self._stub_entry
-        if self.isr_addr is None:
-            return None
-        base = self.stub_addr
-        code = bytearray()
-        # cli
-        code += b"\xfa"
-        # call intEnt   (rel32 from end of this instruction)
-        code += b"\xe8" + struct.pack("<i", self.int_ent - (base + len(code) + 5))
-        # push <isr_arg>
-        code += b"\x68" + struct.pack("<I", self.isr_arg & 0xFFFFFFFF)
-        # call <isr>
-        code += b"\xe8" + struct.pack("<i", self.isr_addr - (base + len(code) + 5))
-        # add esp, 4
-        code += b"\x83\xc4\x04"
-        # jmp intExit
-        code += b"\xe9" + struct.pack("<i", self.int_exit - (base + len(code) + 5))
-        if not backend.write_memory(base, 1, bytes(code)):
-            log.warning("x86_pic: could not write interrupt stub at "
-                        "0x%08x; falling back to direct ISR vector", base)
-            self.int_ent = None
-            self.int_exit = None
-            return None
-        self._stub_written = True
-        self._stub_entry = base
-        log.info("x86_pic: assembled interrupt stub @ 0x%08x "
-                 "(intEnt=0x%x isr=0x%x intExit=0x%x, %d bytes)",
-                 base, self.int_ent, self.isr_addr, self.int_exit, len(code))
-        return base
-
     def deliver(self, backend: "HalBackend") -> bool:
-        """Synthesise the CPU interrupt entry. Must run single-threaded.
+        """Deliver a queued tick. Thin shim over ``X86ExceptionDeliverer`` —
+        the exception-entry logic now lives in the deliverer (mirroring how
+        ``ArmVicController`` delegates to ``ArmExceptionDeliverer``). This
+        entry point stays because the in-process dispatch loop calls it; it
+        builds a plan from this controller's live fields (``isr_addr`` is
+        learned at run time via ``register_clock_isr``) and delegates.
 
-        Returns True if the entry was set up (EIP now points at the
-        handler), False if it was suppressed (interrupts masked, no ISR,
-        or already inside the ISR)."""
-        if self.isr_addr is None:
-            log.warning("x86_pic: tick fired but no clock ISR known yet "
-                        "(sysClkConnect not seen, no isr_addr configured) "
-                        "— dropping")
-            return False
-        with self._lock:
-            eflags = backend.read_register("eflags")
-            if not (eflags & _EFLAGS_IF):
-                # Interrupts masked (cli). The firmware will re-enable;
-                # the next tick will land. Dropping a masked tick matches
-                # real edge-PIC behaviour closely enough for the clock.
-                log.debug("x86_pic: IF=0 (interrupts masked) — tick dropped")
-                return False
-
-            eip = backend.read_register("eip")
-            cs = backend.read_register("cs")
-            esp = backend.read_register("esp")
-
-            target = self._ensure_stub(backend)
-            if target is None:
-                target = self.isr_addr
-
-            # Build the hardware interrupt frame the handler/iret expects:
-            #   [esp]   = EIP   (return address)
-            #   [esp+4] = CS
-            #   [esp+8] = EFLAGS
-            esp -= 12
-            backend.write_memory(esp, 4, eip & 0xFFFFFFFF)
-            backend.write_memory(esp + 4, 4, cs & 0xFFFFFFFF)
-            backend.write_memory(esp + 8, 4, eflags & 0xFFFFFFFF)
-            backend.write_register("esp", esp)
-            # Mask IF for the duration of the handler (the stub's cli does
-            # this on hardware; set it now so a re-entrant tick is dropped
-            # by the IF check above until the handler's iret restores it).
-            backend.write_register("eflags", eflags & ~_EFLAGS_IF)
-            backend.write_register("eip", target)
-            hlog.info("x86_pic: delivering IRQ -> stub/ISR 0x%08x "
-                      "(interrupted eip=0x%08x, frame@0x%08x)",
-                      target, eip, esp)
-            return True
+        Returns True if the entry was set up, False if suppressed (IRQs
+        masked or no ISR known)."""
+        from .delivery import (
+            DeliveryModel, DeliveryPlan, X86ExceptionDeliverer)
+        plan = DeliveryPlan(
+            model=DeliveryModel.FRAME,
+            isr_addr=self.isr_addr,
+            extra={"int_ent": self.int_ent, "int_exit": self.int_exit,
+                   "stub_addr": self.stub_addr, "isr_arg": self.isr_arg},
+        )
+        return X86ExceptionDeliverer().deliver(backend, 0, plan)
 
     def on_isr_return(self) -> None:
         """Clear the in-ISR guard. Called by the backend when the

--- a/src/halucinator/backends/qemu_backend.py
+++ b/src/halucinator/backends/qemu_backend.py
@@ -856,16 +856,7 @@ class QEMUBackend(ARM32HalMixin, HalBackend):
         # Override the class-level ARM32 ABI helpers with the arch-specific
         # mixin's methods. ARM32 remains the default via inheritance so the
         # class is usable without __init__ (e.g. in unit tests).
-        abi_cls = ABI_MIXINS.get(arch, ARM32HalMixin)
-        self._abi = abi_cls
-        if abi_cls is not ARM32HalMixin:
-            for method_name in ("get_arg", "set_args", "get_ret_addr",
-                                "set_ret_addr", "execute_return",
-                                "read_string"):
-                method = getattr(abi_cls, method_name, None)
-                if method is not None:
-                    setattr(self, method_name,
-                            method.__get__(self, type(self)))
+        self._bind_abi(arch)
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/src/halucinator/backends/renode_backend.py
+++ b/src/halucinator/backends/renode_backend.py
@@ -158,16 +158,7 @@ class RenodeBackend(ARM32HalMixin, HalBackend):
         self._machine_started: bool = False
 
         # Arch-specific ABI binding (same pattern as QEMUBackend).
-        abi_cls = ABI_MIXINS.get(arch, ARM32HalMixin)
-        self._abi = abi_cls
-        if abi_cls is not ARM32HalMixin:
-            for method_name in ("get_arg", "set_args", "get_ret_addr",
-                                "set_ret_addr", "execute_return",
-                                "read_string"):
-                method = getattr(abi_cls, method_name, None)
-                if method is not None:
-                    setattr(self, method_name,
-                            method.__get__(self, type(self)))
+        self._bind_abi(arch)
 
     def set_initial_state(self, pc: Optional[int] = None,
                           sp: Optional[int] = None) -> None:

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -17,6 +17,7 @@ import struct
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from .hal_backend import ABI_MIXINS, ARM32HalMixin, ARMHalMixin, HalBackend, MemoryRegion
+from .irq.in_process import InProcessIrqMixin
 
 log = logging.getLogger(__name__)
 
@@ -227,7 +228,7 @@ def _reg_map_for_arch(arch: str) -> Dict[str, int]:
 # UnicornBackend
 # ---------------------------------------------------------------------------
 
-class UnicornBackend(ARMHalMixin, HalBackend):
+class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
     """
     In-process emulation backend using unicorn-engine.
 
@@ -310,10 +311,9 @@ class UnicornBackend(ARMHalMixin, HalBackend):
             _os.environ.get("HAL_MMU_FLAT_FALLBACK") == "1")
         self._mmu_flat_count: Dict[int, int] = {}
         self._bp_callbacks: Dict[int, Callable] = {}  # bp_id → callback
-        # Pending IRQ injected from another thread (peripheral_server zmq
-        # handler). cont() drains the queue before re-entering emu_start
-        # so the synthetic exception frame is set up single-threaded.
-        self._pending_irqs: List[int] = []
+        # In-process IRQ state: the cross-thread pending-IRQ queue and the
+        # HAL_DET_TICK deterministic-tick config (see InProcessIrqMixin).
+        self._init_in_process_irq()
         # x86: when _intr_hook resolves a far control transfer (#GP from a
         # missing GDT), it stashes the resume EIP here so cont() re-enters
         # emu_start instead of aborting on the UcError. None when idle.
@@ -341,16 +341,7 @@ class UnicornBackend(ARMHalMixin, HalBackend):
         # Bind the arch-specific ABI mixin onto the instance (ARM32 stays the
         # default via inheritance so existing arm/cortex-m callers are
         # unchanged).
-        abi_cls = ABI_MIXINS.get(arch, ARM32HalMixin)
-        self._abi = abi_cls
-        if abi_cls is not ARM32HalMixin:
-            for method_name in ("get_arg", "set_args", "get_ret_addr",
-                                "set_ret_addr", "execute_return",
-                                "read_string"):
-                method = getattr(abi_cls, method_name, None)
-                if method is not None:
-                    setattr(self, method_name,
-                            method.__get__(self, type(self)))
+        self._bind_abi(arch)
 
     # ------------------------------------------------------------------
     # Initialisation
@@ -580,23 +571,9 @@ class UnicornBackend(ARMHalMixin, HalBackend):
                     self.dump_pc_sample()
             self._uc.hook_add(unicorn.UC_HOOK_CODE, _pc_sample)
 
-        # HAL_DET_TICK="<irq>:<chunks>" -- drive the system clock IRQ DETERMINISTICALLY from
-        # instruction count (one tick every <chunks> emu_start chunks in cont()) instead of the
-        # wall-clock timer thread. Wall-clock ticks fire at nondeterministic instruction
-        # boundaries, so run-state/scan scheduling becomes timing-fragile (any bp-handler overhead
-        # perturbs it). Tying the tick to instruction count makes scheduling reproducible
-        # regardless of handler overhead -> the run-drive stays stable and can be observed.
-        self._det_irq = None
-        self._det_period = 0
-        self._det_chunks = 0
-        _det = _os.environ.get("HAL_DET_TICK")
-        if _det:
-            try:
-                _di, _dp = _det.split(":")
-                self._det_irq = int(_di, 0)
-                self._det_period = max(1, int(_dp, 0))
-            except Exception:  # noqa: BLE001
-                self._det_irq = None
+        # HAL_DET_TICK deterministic system-clock tick is parsed in
+        # _init_in_process_irq() (InProcessIrqMixin); cont() consumes
+        # self._det_irq / _det_period / _det_chunks below.
 
         # Diagnostic: HAL_LAST_PC=1 keeps a ring of the last basic-block start PCs
         # (low per-block overhead) so that on a UcError the code path leading INTO
@@ -1834,10 +1811,7 @@ class UnicornBackend(ARMHalMixin, HalBackend):
     # with LR holding one of these, cortex-m normally pops the exception
     # frame and resumes. Unicorn doesn't model that transition, so we
     # catch the invalid fetch and unwind manually.
-    _EXC_RETURN_THREAD_MSP = 0xFFFFFFF9
-    _EXC_RETURN_MASK = 0xFFFFFFF0
-    _EXC_RETURN_MAGIC = 0xFFFFFFF0  # any PC matching this top nibble is
-                                     # an exception-return attempt
+    # EXC_RETURN constants + frame decode now live in InProcessIrqMixin.
 
     # The avatar2/QEMU path implements these by writing to the halucinator-irq
     # controller MMIO region. Unicorn doesn't model a NVIC/GIC, so IRQ
@@ -1853,6 +1827,22 @@ class UnicornBackend(ARMHalMixin, HalBackend):
 
     def irq_enable_bp(self, irq_num: int = 1) -> None:
         return None
+
+    @property
+    def arch(self) -> str:
+        """Alias for arch_name, so the shared InProcessIrqMixin can read a
+        uniform ``arch`` attribute across backends."""
+        return self.arch_name
+
+    def _request_break(self) -> None:
+        """Thread-safe stop of the running emulator (InProcessIrqMixin
+        primitive). Unicorn raises if not currently running — ignore."""
+        if self._uc is None:
+            return
+        try:
+            self._uc.emu_stop()
+        except Exception:  # noqa: BLE001
+            pass
 
     def inject_irq(self, irq_num: int) -> None:
         """Deliver an external IRQ.
@@ -1935,65 +1925,12 @@ class UnicornBackend(ARMHalMixin, HalBackend):
         except Exception:  # noqa: BLE001 — uc raises if not running
             pass
 
-    def _apply_pending_irq(self, irq_num: int) -> None:
-        """Set up the synthetic exception entry for a pended IRQ.
-        Must run on the dispatch thread (between emu_start chunks)
-        — Unicorn isn't safe against PC/SP writes mid-run."""
+    def _apply_cortex_m_fallback(self, irq_num: int) -> None:
+        """Cortex-M (and any un-migrated arch) fallback: push the 8-word
+        exception frame on the main stack and vector to vector[16+N].
+        Called by InProcessIrqMixin._apply_pending_irq. Must run on the
+        dispatch thread — Unicorn isn't safe against PC/SP writes mid-run."""
         if self._uc is None:
-            return
-        if self.arch_name == "arm":
-            # A-profile ARM IRQ delivery. Preferred path: the refactored
-            # ExceptionDeliverer + DeliveryPlan (set via main._wire_irq).
-            # It subsumes both the ArmVicController.deliver synth path and
-            # the built-in _apply_pending_irq_armv7a GIC path (proven
-            # equivalent in test_arm_deliverer_equivalence.py). Only the
-            # FRAME/TRAMPOLINE models are handled by ArmExceptionDeliverer;
-            # SHADOW (ghidra) and the unconfigured case fall through to the
-            # legacy logic below.
-            from halucinator.backends.irq.delivery import DeliveryModel
-            deliverer = getattr(self, "_exception_deliverer", None)
-            plan = getattr(self, "_delivery_plan", None)
-            if (deliverer is not None and plan is not None
-                    and plan.model in (DeliveryModel.FRAME,
-                                       DeliveryModel.TRAMPOLINE)):
-                deliverer.deliver(self, irq_num, plan)
-                return
-            # Legacy: if the configured controller synthesises the
-            # exception itself (ArmVicController), route through it;
-            # otherwise the built-in ARMv7-A/GIC entry (VBAR+0x18 +
-            # GICC_IAR shadow).
-            ctrl = getattr(self, "_irq_controller", None)
-            if ctrl is not None and hasattr(ctrl, "deliver"):
-                # deliver() returns False when CPSR.I masks IRQs — like the
-                # x86_pic path we simply drop that tick (the next periodic
-                # tick lands once the firmware re-enables IRQs). We do NOT
-                # re-queue, which would busy-spin this chunk re-applying a
-                # tick that can never enter.
-                ctrl.deliver(self, irq_num)
-                return
-            self._apply_pending_irq_armv7a(irq_num)
-            return
-        if self.arch_name == "arm64":
-            self._apply_pending_irq_arm64(irq_num)
-            return
-        if self.arch_name == "mips":
-            self._apply_pending_irq_mips(irq_num)
-            return
-        if self.arch_name in ("powerpc", "powerpc:MPC8XX", "ppc64"):
-            self._apply_pending_irq_ppc(irq_num)
-            return
-        if self.arch_name == "x86":
-            # x86 PC interrupt delivery is owned entirely by the
-            # configured X86PicController (backends/irq/x86_pic.py): it
-            # synthesises the CPU interrupt frame and vectors to the
-            # VxWorks interrupt stub. This runs on the dispatch thread
-            # (here), so it is safe to mutate EIP/ESP.
-            ctrl = getattr(self, "_irq_controller", None)
-            if ctrl is not None and hasattr(ctrl, "deliver"):
-                ctrl.deliver(self)
-            else:
-                log.warning("inject_irq(%d): x86 has no X86PicController "
-                            "configured; tick dropped", irq_num)
             return
 
         # Vector table offset: caller plumbs it in via set_vtor(); fall
@@ -2043,43 +1980,42 @@ class UnicornBackend(ARMHalMixin, HalBackend):
     _ARM_CPSR_T    = 0x20   # Thumb
 
     def _apply_pending_irq_armv7a(self, irq_num: int) -> None:
-        """Synthesise an ARMv7-A IRQ exception entry (legacy GIC path).
-
-        Thin wrapper over the shared ``ArmExceptionDeliverer``: builds a
-        FRAME ``DeliveryPlan`` from the vector base (``_vtor``) and the
-        configured GIC's ``gicc_base`` (for the GICC_IAR shadow), then
-        delegates. The only behaviour this wrapper adds over the deliverer
-        is the legacy *masked-IRQ re-queue*: when delivery is suppressed
-        (CPSR.I=1) it re-queues the tick and stops the run so the firmware
-        can unmask, rather than dropping it (the ArmVicController path
-        drops). That policy difference is intentionally preserved here.
-        """
+        """A-profile ARM IRQ delivery (Unicorn). Preferred path: the
+        ExceptionDeliverer + DeliveryPlan set via main._wire_irq (subsumes
+        the ArmVicController synth path and the legacy GIC path, proven
+        equivalent in test_arm_deliverer_equivalence.py). Falls back to the
+        legacy ArmVicController.deliver, then the built-in ARMv7-A/GIC entry
+        (VBAR+0x18 + GICC_IAR shadow). Only the legacy GIC path adds the
+        masked-IRQ re-queue (CPSR.I=1 -> re-queue + stop so the firmware can
+        unmask); the deliverer / ArmVicController paths drop the tick."""
         from halucinator.backends.irq.delivery import (
             ArmExceptionDeliverer, DeliveryModel, DeliveryPlan)
+        deliverer = getattr(self, "_exception_deliverer", None)
+        plan = getattr(self, "_delivery_plan", None)
+        if (deliverer is not None and plan is not None
+                and plan.model in (DeliveryModel.FRAME,
+                                   DeliveryModel.TRAMPOLINE)):
+            deliverer.deliver(self, irq_num, plan)
+            return
         ctrl = getattr(self, "_irq_controller", None)
+        if ctrl is not None and hasattr(ctrl, "deliver"):
+            # deliver() returns False when CPSR.I masks IRQs — drop that tick
+            # (the next periodic tick lands once firmware re-enables IRQs); do
+            # NOT re-queue, which would busy-spin re-applying an un-enterable
+            # tick.
+            ctrl.deliver(self, irq_num)
+            return
         gicc_base = getattr(ctrl, "gicc_base", None) if ctrl else None
         vbar = getattr(self, "_vtor", 0)
-        plan = DeliveryPlan(model=DeliveryModel.FRAME, vector_base=vbar,
-                            gicc_base=gicc_base)
-        delivered = ArmExceptionDeliverer().deliver(self, irq_num, plan)
+        lplan = DeliveryPlan(model=DeliveryModel.FRAME, vector_base=vbar,
+                             gicc_base=gicc_base)
+        delivered = ArmExceptionDeliverer().deliver(self, irq_num, lplan)
         if not delivered:
-            # IRQs masked — re-queue and let the firmware unmask itself;
-            # otherwise we'd nest exceptions.
+            # IRQs masked — re-queue and let the firmware unmask itself.
             self._pending_irqs.insert(0, irq_num)
-            self._uc.emu_stop()
+            self._request_break()
             return
         log.info("inject_irq(%d): ARMv7-A entry @ 0x%x", irq_num, vbar + 0x18)
-
-    def _resolve_delivery_plan(self, build_legacy):
-        """Return the attached DeliveryPlan (new `irq_delivery` config) or,
-        when none was set, a plan built from the legacy controller fields
-        via ``build_legacy(ctrl)``. Centralises the new-vs-legacy choice so
-        each per-arch wrapper stays a one-liner."""
-        plan = getattr(self, "_delivery_plan", None)
-        if plan is not None:
-            return plan
-        ctrl = getattr(self, "_irq_controller", None)
-        return build_legacy(ctrl)
 
     def _apply_pending_irq_arm64(self, irq_num: int) -> None:
         """AArch64 IRQ entry — thin wrapper over Arm64ExceptionDeliverer."""
@@ -2098,53 +2034,14 @@ class UnicornBackend(ARMHalMixin, HalBackend):
         Arm64ExceptionDeliverer().deliver(self, irq_num,
                                           self._resolve_delivery_plan(_legacy))
 
-    def _apply_pending_irq_mips(self, irq_num: int) -> None:
-        """MIPS IRQ delivery — thin wrapper over ShadowExceptionDeliverer.
-
-        Unicorn's MIPS model doesn't take CP0 exceptions reliably, so the
-        shadow deliverer writes the firmware's post-ack globals directly."""
-        from halucinator.backends.irq.delivery import (
-            DeliveryModel, DeliveryPlan, ShadowExceptionDeliverer)
-
-        def _legacy(ctrl):
-            return DeliveryPlan(
-                model=DeliveryModel.SHADOW,
-                irq_fired_addr=getattr(ctrl, "irq_fired_addr", None) if ctrl else None,
-                irq_number_addr=getattr(ctrl, "irq_number_addr", None) if ctrl else None,
-            )
-        ShadowExceptionDeliverer().deliver(self, irq_num,
-                                           self._resolve_delivery_plan(_legacy))
-
-    def _apply_pending_irq_ppc(self, irq_num: int) -> None:
-        """PowerPC IRQ delivery — thin wrapper over ShadowExceptionDeliverer
-        (same SHADOW pattern as MIPS; Unicorn doesn't model the OpenPIC /
-        SRR0/SRR1 entry reliably for our use-case)."""
-        from halucinator.backends.irq.delivery import (
-            DeliveryModel, DeliveryPlan, ShadowExceptionDeliverer)
-
-        def _legacy(ctrl):
-            return DeliveryPlan(
-                model=DeliveryModel.SHADOW,
-                irq_fired_addr=getattr(ctrl, "irq_fired_addr", None) if ctrl else None,
-                irq_number_addr=getattr(ctrl, "irq_number_addr", None) if ctrl else None,
-            )
-        ShadowExceptionDeliverer().deliver(self, irq_num,
-                                           self._resolve_delivery_plan(_legacy))
-
     def _maybe_handle_exc_return(self, addr: int) -> bool:
         """Called from the invalid-fetch hook. If the fetch address looks
         like an EXC_RETURN magic value, pop the exception frame and
         restore pre-interrupt state. Returns True when handled."""
-        if self.arch_name != "cortex-m3":
+        decoded = self._decode_exc_return_frame(addr)
+        if decoded is None:
             return False
-        if (addr & self._EXC_RETURN_MASK) != self._EXC_RETURN_MAGIC:
-            return False
-        import struct
-        sp = self.read_register("sp")
-        try:
-            frame = struct.unpack("<8I", bytes(self._uc.mem_read(sp, 32)))
-        except Exception:
-            return False
+        sp, frame = decoded
         self.write_register("r0", frame[0])
         self.write_register("r1", frame[1])
         self.write_register("r2", frame[2])

--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -1092,10 +1092,10 @@ def _in_process_dispatch_loop(backend: "HalBackend") -> None:
             # NOT "ran off the rails", it is normal interrupt-driven
             # execution. Re-enter cont() so the ISR (and the periodic
             # control loop it drives) keeps running, instead of exiting.
-            # We only do this when an IRQ controller is configured and the
-            # PC lands in mapped code; a genuine runaway (unmapped fetch)
-            # still surfaces as a UcError from cont().
-            if getattr(backend, "_irq_controller", None) is not None:
+            # We only do this when the backend reports an in-process IRQ is
+            # active (an IRQ controller is configured); a genuine runaway
+            # (unmapped fetch) still surfaces as a UcError from cont().
+            if getattr(backend, "in_process_irq_active", lambda: False)():
                 try:
                     backend.cont()
                     continue

--- a/test/pytest/backends/irq/test_shadow_arm64_deliverers.py
+++ b/test/pytest/backends/irq/test_shadow_arm64_deliverers.py
@@ -77,4 +77,4 @@ class TestFactory:
         assert build_exception_deliverer("arm64").arch == "arm64"
         assert build_exception_deliverer("arm").arch == "arm"
         assert build_exception_deliverer("cortex-m3") is None
-        assert build_exception_deliverer("x86") is None
+        assert build_exception_deliverer("x86").arch == "x86"

--- a/test/pytest/backends/irq/test_x86_deliverer_equivalence.py
+++ b/test/pytest/backends/irq/test_x86_deliverer_equivalence.py
@@ -1,0 +1,135 @@
+"""Proof that x86 PC interrupt delivery collapses to ONE implementation.
+
+Like ``test_arm_deliverer_equivalence.py``, this does not re-test "does x86
+IRQ delivery work" (``test_controllers`` covers ``X86PicController``). It
+checks the *refactor claim*: that the new ``X86ExceptionDeliverer``
+reproduces, byte-for-byte, the CPU-state mutations of the pre-refactor
+``X86PicController.deliver`` — so the delivery logic can move out of the
+controller and the controller becomes a thin shim.
+
+We compare the *ordered sequence* of register writes and memory writes,
+which is the entire observable effect of delivery on a backend.
+"""
+from __future__ import annotations
+
+from halucinator.backends.irq.x86_pic import X86PicController
+from halucinator.backends.irq.delivery import (
+    DeliveryModel,
+    DeliveryPlan,
+    X86ExceptionDeliverer,
+)
+
+_EFLAGS_IF = 1 << 9
+
+
+class _StatefulBackend:
+    """Records ordered register/memory writes; reflects writes into reads.
+    Unlike the ARM mock, ``write_memory`` values may be int (frame words) or
+    bytes (the assembled stub), so nothing is masked — values are stored and
+    compared as-is."""
+
+    def __init__(self, regs=None, mem=None):
+        self._regs = dict(regs or {})
+        self._mem = dict(mem or {})
+        self.reg_writes: list = []
+        self.mem_writes: list = []
+
+    def read_register(self, name):
+        return self._regs.get(name, 0)
+
+    def write_register(self, name, value):
+        self._regs[name] = value & 0xFFFFFFFF
+        self.reg_writes.append((name, value & 0xFFFFFFFF))
+
+    def read_memory(self, addr, size, num_words=1, raw=False):
+        return self._mem.get(addr, 0)
+
+    def write_memory(self, addr, size, value, num_words=1, raw=False):
+        self._mem[addr] = value
+        self.mem_writes.append((addr, size, value))
+        return True
+
+
+_ISR = 0x00410E50
+_INT_ENT = 0x00436240
+_INT_EXIT = 0x004362D0
+_STUB = 0x7000
+_ESP = 0x00500000
+_EIP = 0x00408123
+_CS = 0x08
+
+
+def _regs(if_set=True):
+    eflags = 0x00000002 | (_EFLAGS_IF if if_set else 0)
+    return {"eflags": eflags, "eip": _EIP, "cs": _CS, "esp": _ESP}
+
+
+def _run_pair(*, ctrl_kwargs, plan, regs):
+    """Run the real controller and the new deliverer against two identical
+    fresh backends; return both plus their return values."""
+    b_old = _StatefulBackend(regs=dict(regs))
+    b_new = _StatefulBackend(regs=dict(regs))
+    old_ret = X86PicController(**ctrl_kwargs).deliver(b_old)
+    new_ret = X86ExceptionDeliverer().deliver(b_new, 0, plan)
+    return b_old, b_new, old_ret, new_ret
+
+
+class TestMatchesX86PicController:
+    def test_direct_isr_path(self):
+        """No int_ent/int_exit -> both push the iret frame and vector at the
+        ISR directly."""
+        b_old, b_new, ro, rn = _run_pair(
+            ctrl_kwargs=dict(isr_addr=_ISR),
+            plan=DeliveryPlan(model=DeliveryModel.FRAME, isr_addr=_ISR),
+            regs=_regs(),
+        )
+        assert ro is True and rn is True
+        assert b_old.reg_writes == b_new.reg_writes
+        assert b_old.mem_writes == b_new.mem_writes
+        # landed at the ISR, IF masked, frame pushed at esp-12
+        assert b_new.reg_writes[-1] == ("eip", _ISR)
+        assert b_new.mem_writes == [
+            (_ESP - 12, 4, _EIP), (_ESP - 8, 4, _CS),
+            (_ESP - 4, 4, _regs()["eflags"]),
+        ]
+
+    def test_stub_path_assembles_once_and_vectors_at_stub(self):
+        """int_ent/int_exit set -> both assemble the intEnt/intExit stub in
+        guest RAM (identical bytes) and vector at the stub entry."""
+        b_old, b_new, ro, rn = _run_pair(
+            ctrl_kwargs=dict(isr_addr=_ISR, int_ent=_INT_ENT,
+                             int_exit=_INT_EXIT, stub_addr=_STUB, isr_arg=0),
+            plan=DeliveryPlan(model=DeliveryModel.FRAME, isr_addr=_ISR,
+                              extra={"int_ent": _INT_ENT, "int_exit": _INT_EXIT,
+                                     "stub_addr": _STUB, "isr_arg": 0}),
+            regs=_regs(),
+        )
+        assert ro is True and rn is True
+        assert b_old.reg_writes == b_new.reg_writes
+        assert b_old.mem_writes == b_new.mem_writes
+        assert b_new.reg_writes[-1] == ("eip", _STUB)
+        # first mem write is the stub blob (bytes) at the stub base
+        assert b_new.mem_writes[0][0] == _STUB
+        assert isinstance(b_new.mem_writes[0][2], (bytes, bytearray))
+
+    def test_masked_irqs_suppressed_identically(self):
+        """IF=0 -> both suppress with no state mutation."""
+        b_old, b_new, ro, rn = _run_pair(
+            ctrl_kwargs=dict(isr_addr=_ISR),
+            plan=DeliveryPlan(model=DeliveryModel.FRAME, isr_addr=_ISR),
+            regs=_regs(if_set=False),
+        )
+        assert ro is False and rn is False
+        assert b_old.reg_writes == b_new.reg_writes == []
+        assert b_old.mem_writes == b_new.mem_writes == []
+
+    def test_no_isr_dropped_identically(self):
+        """isr_addr unknown -> both drop with no state mutation."""
+        b_old, b_new, ro, rn = _run_pair(
+            ctrl_kwargs=dict(isr_addr=None),
+            plan=DeliveryPlan(model=DeliveryModel.FRAME, isr_addr=None),
+            regs=_regs(),
+        )
+        assert ro is False and rn is False
+        assert b_old.reg_writes == b_new.reg_writes == []
+        assert b_old.mem_writes == b_new.mem_writes == []


### PR DESCRIPTION
Consolidates the half-migrated in-process interrupt path (the `IrqController`
= *make-pending* vs `ExceptionDeliverer`/`DeliveryPlan` = *how-the-CPU-enters*
split) so the in-process backends share one implementation instead of
hand-rolling each arch. Behaviour-preserving; net de-duplication.

## What changed

- **`InProcessIrqMixin`** (`backends/irq/in_process.py`) — owns the pending-IRQ
  queue, the chunked-`cont` drain, the `_apply_pending_irq` dispatcher,
  delivery-plan resolution, `HAL_DET_TICK`, and the shared endianness-aware
  SHADOW path. `UnicornBackend` and `GhidraBackend` are reparented onto it
  (behaviour-preserving for Unicorn). **This unblocks Ghidra:** its four
  hand-rolled deliver methods are deleted and it inherits the
  equivalence-tested delivery — which also fixes its hardcoded big-endian
  shadow-write bug. Ghidra keeps its banked arm/arm64 register writes (Sleigh
  `lr_irq`/`spsr_irq` can't go through the generic deliverer) as override
  hooks. `main.py`'s post-IRQ dispatch reentry now goes through a backend
  predicate.

- **`X86ExceptionDeliverer`** (`backends/irq/delivery.py`) — x86 delivery moves
  out of `X86PicController` into a deliverer + a thin controller shim (mirrors
  `arm_vic`); the interrupt-stub cache moves to backend attrs. Proven
  byte-identical to the old controller via `test_x86_deliverer_equivalence.py`
  **before** the in-process path was flipped to it.

- **Dedup** — extract `HalBackend._bind_abi()` (was copy-pasted across four
  backends); move the `_EXC_RETURN_*` constants and the Cortex-M exc-return
  frame decode into the mixin, keeping each backend's native register-write
  primitive.

## Validation
- backend suite **261 passed**, Ghidra suite **29 passed**, full non-QEMU
  **28901 passed / 0 failed** — all matching baseline (this is a refactor).
- `multi_arch_irq` end-to-end (real firmware): **x86** and **cortex_m**
  in-process delivery pass; cortex_m also passes on qemu/avatar2.
- The x86 and ARM migrations were each gated behind an equivalence test that
  proves byte-identical CPU state before the live path was switched.

## Dependencies / merge order
Based directly on current `master`; **standalone**. No dependency on the other
open PRs (#33/#46/#47) — verified by merge-tree: zero file overlap except
`renode_backend.py` with #46 at non-overlapping lines, which auto-merges.
Mergeable in any order.

## Follow-up (not in this PR)
Fully unifying Ghidra's arm/arm64 onto the shared `ArmExceptionDeliverer` needs
a Ghidra register-aliasing layer (`write_register("lr"/"spsr")` → banked names
by CPSR mode) — tracked separately.

Draft for review of the approach before final polish.
