### PR TITLE
snapshot/restore: whole-machine checkpoints across all backends

### DIFF
--- a/doc/snapshot_restore.md
+++ b/doc/snapshot_restore.md
@@ -1,0 +1,218 @@
+# State snapshot / restore
+
+Save the complete state of an emulation — guest CPU + RAM, host-side
+peripheral-model state — and restore it later: milliseconds later in the same
+process (in-memory checkpoints, boot-once-experiment-forever), or days later in
+a different process (persistent checkpoints that survive crashes and reboots).
+
+Motivating workflows:
+
+* **Deep-gate iteration.** Rehosting a firmware whose interesting behavior is
+  minutes of boot away (large RTOS images) means every model tweak
+  costs a full re-boot. Snapshot once at a marker, then restore-and-experiment
+  in ~1–2 s per attempt. (`diagnostics/snapshot_lab.py` prototyped this
+  in-process; this feature is its generalized, supported form.)
+* **Fast resume.** A harness restores a known-good checkpoint before
+  every input. This needs the fast in-memory path (`snapshot_is_fast()`).
+* **Surviving process death.** A snapshot persisted to disk restores into a
+  freshly started emulator with the same config — work is never lost to a
+  crash, reboot, or closed session.
+
+## Architecture: three layers, one coordinator
+
+Machine state is spread across three places; each layer owns
+`save_state()`/`restore_state()` for its slice, and a coordinator composes
+them:
+
+| Layer | State | Where implemented |
+|---|---|---|
+| 1 | Guest CPU + RAM (+ device state the emulator models natively) | `HalBackend.save_state` (generic fallback), specialized per backend (`UnicornBackend` native fast path) |
+| 2 | Python host-side peripheral-model state: uart rx buffers, gpio pins, interrupt maps, cached bp-handler instances, `hal_stats` | `snapshot/peripheral_registry.py` |
+| 3 | External device processes (zmq peripheral server clients) | `snapshot/device_layer.py` (HAL side) + `external_devices/snapshotable.py` (device side) |
+
+The coordinator (`snapshot/system_snapshot.py`) bundles the layers into a
+`SystemSnapshot` and restores them together (backend, then peripherals, then
+devices), reporting per-layer failure via `RestoreResult`.
+
+### Layer 3 — external devices
+
+zmq PUB/SUB has **no membership** — HALucinator cannot enumerate connected
+device processes. Layer 3 is therefore a cooperative, opt-in protocol with a
+collection window (`DeviceLayer(timeout=...)`): on save, HAL broadcasts
+`Peripheral.SnapshotDevices.save` and whoever answers within the window is in
+the snapshot; on restore, every device *captured in the snapshot* must ack
+within the window or the restore fails (all-or-nothing — the machine cannot
+come back whole without them). Stateless devices (display-only terminals,
+bridges whose live sockets can't be checkpointed anyway) simply don't
+participate. Device authors opt in with
+`external_devices.snapshotable.SnapshotableDevice(ioserver, device_id,
+get_state, set_state)`; `device_id` must be stable across restarts.
+
+Layer 3 is opt-in per call (`system_snapshot(..., device_layer=DeviceLayer())`)
+because the window costs a full timeout on every save — fine for disk
+checkpoints, wrong for per-input restores.
+
+### Layer 1 — backend guest state
+
+* **Generic fallback** (`HalBackend.save_state`): enumerate `list_registers()`
+  + read every writable, non-`emulate` `MemoryRegion`. Works on any backend
+  that exposes the read/write primitives. Registers are captured tolerantly (a
+  name a given stub can't read/write is skipped with a warning, since register
+  sets vary across GDB stubs); memory is strict (a failed region read raises).
+  `emulate=`-backed MMIO regions are skipped — they are Layer-2 state, not RAM.
+* **Unicorn native** (`UnicornBackend.save_state`): `uc.context_save()` plus a
+  bulk copy of every mapped page. A handful of milliseconds; byte-identical
+  round-trip; `snapshot_is_fast() == True`.
+* **Portable form** (`save_state(portable=True)`): plain-python capture for
+  disk persistence — see “Portability” below.
+
+**Per-backend Layer-1 support:**
+
+| Backend | Path | Fidelity | Fast | Verified |
+|---|---|---|---|---|
+| Unicorn | native + portable | full (CPU incl. banked/CP15/VFP + RAM) | ✅ | unit + e2e (local) |
+| Ghidra | generic reg+RAM | CPU regs + RAM | — | live round-trip (Docker) |
+| QEMU | generic reg+RAM | CPU regs + RAM (guest); QEMU-internal core devices not captured | — | live round-trip (Docker) |
+| LibAFL-QEMU | generic reg+RAM (via QEMUBackend) | same as QEMU | — | live round-trip (Docker) |
+| Renode | generic reg+RAM | CPU regs + RAM (register writes need `start`) | — | live round-trip, memory (Docker) |
+| Avatar2 | generic reg+RAM | CPU regs + RAM (guest) | — | live round-trip (Docker) |
+
+All six backends' live round-trips pass inside the CI Docker image (real
+qemu-system-arm / libafl-qemu / renode / ghidra). Note: QEMU's GDB-RSP memory
+transfer is chunked (a whole-region read exceeds the stub's packet size and
+returns E22 otherwise).
+
+For the QEMU/Renode families the generic path captures the guest CPU + RAM;
+peripheral state lives in Layer 2 (Python models). Emulator-*internal* core
+devices that aren't forwarded to Python (e.g. an in-QEMU interrupt controller)
+are not captured by the generic path — a native `savevm`/`Save` override is a
+possible future enhancement (see roadmap).
+
+### Layer 2 — peripheral registry
+
+`PeripheralRegistry` discovers every Layer-2 state holder live at snapshot
+time (nothing hard-coded): all `@peripheral_model` classes, every cached
+bp-handler instance (`intercepts.initalized_classes`), and the global
+`hal_stats.stats`. Two capture strategies:
+
+1. **Explicit** `save_state()`/`restore_state()` on the model (uart, gpio,
+   interrupts) — knows exactly which fields are state; restores IN PLACE so
+   external aliases stay valid.
+2. **Generic deep-copy** for everything else — every mutable container
+   attribute is deep-copied and restored in place (`SnapshotableModel` mixin
+   exposes this as an opt-in default).
+
+## Failure contract
+
+The contract everywhere is *whole or nothing*:
+
+* `save_state` **raises `SnapshotError`** rather than returning a partial
+  snapshot — possessing a `Snapshot`/`SystemSnapshot` means it is complete.
+* `restore_state` **validates before mutating** (`backend_type` +
+  `SNAPSHOT_VERSION`) and returns `False` with the guest untouched on
+  mismatch. A bad snapshot can never half-corrupt a machine.
+* `system_restore` stops at the first layer that refuses and names it in
+  `RestoreResult.layer` — the caller gets a clear “inconsistent, re-init”
+  signal instead of a silently half-restored machine.
+* Disk writes are atomic (temp file + `os.replace`) — a failed save never
+  leaves a partial file.
+
+Take snapshots with the guest **stopped** so the layers are mutually
+consistent.
+
+**Layer-3 restore is atomic in *reporting*, not in *effect*.** Backend and
+peripheral (Layers 1–2) restore is truly all-or-nothing — nothing external is
+touched until every in-process layer succeeds. But external devices (Layer 3)
+mutate their *own* real state when they apply a restore, and there is no
+cross-device rollback: if device A acks ok and device B then fails, A has
+already moved. `system_restore` reports the failure (`layer="devices"`) so the
+caller knows the fleet is inconsistent and must **re-drive the restore** (it
+is idempotent — re-applying the same states heals A and retries B) or re-init.
+Order is chosen to minimize this window: the fragile external layer restores
+**last**, after the in-process layers have already succeeded. Building true
+two-phase prepare/commit across arbitrary device processes is out of scope.
+
+## Portability: the process-local-context discovery
+
+The fast unicorn path stores a native `UcContext`. Empirical finding
+(2026-07-16, unicorn 2.1.4): a `UcContext` **pickles without complaint and
+then SIGBUSes when restored in a different process** — same unicorn build,
+same CPU model, same memory map. The blob embeds process-local pointers.
+(Same-process pickle round-trips work, which makes this a nasty silent trap —
+hence `save_snapshot_file` hard-rejects native contexts.)
+
+Disk persistence therefore requires the **portable form**, which enumerates
+architectural state into plain python values: the general register file, plus
+the per-architecture system state — A-profile ARM banked registers, a curated
+CP15 set and VFP/NEON; M-profile ARM system registers (MSP/PSP/PRIMASK/
+BASEPRI/FAULTMASK/CONTROL) and VFP. Other architectures capture the general
+register file only; see `_capture_portable_regs` in
+`backends/unicorn_backend.py` for the exact per-arch inventory.
+
+Every system register read/write is individually guarded, so a register a
+given CPU model doesn't implement is simply skipped (absent from the
+snapshot, skipped on restore) — the same portable capture works from ARM926
+up to cortex-a15 without per-model branching.
+
+**Machine fingerprint.** A portable snapshot records the arch, CPU model, and
+mapped memory layout it was taken on. `restore_state` compares this against
+the live backend **before any write** and refuses a mismatch — so restoring a
+snapshot onto a different machine config fails cleanly instead of half-writing
+memory that doesn't line up.
+
+## Disk format
+
+See the module docstring of `snapshot/persist.py`, which defines it:
+`save_snapshot_file(payload, path)` / `load_snapshot_file(path) -> (payload,
+header)`, one gzip stream over a pickled `(header, payload)` tuple, header
+validated before the payload is returned, atomic write via `os.replace`.
+
+## Usage
+
+```python
+from halucinator.snapshot import (
+    system_snapshot, system_restore,
+    save_snapshot_file, load_snapshot_file,
+)
+
+# In-memory checkpoint (fast path — iterative / experiment loops):
+snap = system_snapshot(backend)                    # guest stopped
+... run, mutate, crash ...
+result = system_restore(backend, snap)
+assert result.ok, result.message
+
+# Persistent checkpoint (survives the process):
+snap = system_snapshot(backend, portable=True)
+save_snapshot_file(snap, "boot.halsnap")
+
+# ... later, in a NEW process started with the SAME config (same memory
+# regions mapped, same handlers installed -- otherwise the machine
+# fingerprint check refuses the restore):
+snap, header = load_snapshot_file("boot.halsnap")
+result = system_restore(backend, snap)
+```
+
+CLI (in-process unicorn backend):
+
+```bash
+# boot once to main, checkpoint, exit:
+halucinator -c machine.yaml -c addrs.yaml --emulator unicorn \
+    --snapshot-at main --snapshot-out boot.halsnap
+# any number of later runs skip the boot entirely:
+halucinator -c machine.yaml -c addrs.yaml --emulator unicorn \
+    --restore boot.halsnap
+```
+
+MCP session tools: `save_snapshot` (no path → fast in-memory snapshot_id,
+path → portable .halsnap), `restore_snapshot(snapshot_id|path)`,
+`list_snapshots`, `delete_snapshot`. Take checkpoints while stopped; a
+restore also revives a session whose firmware had run off the rails.
+
+## Tests
+
+`test/pytest/snapshot/` covers the backend, registry, coordinator and
+persistence layers, including a fresh-process round-trip:
+
+```bash
+PYTHONPATH=src:test/pytest/helpers python3 -m pytest test/pytest/snapshot/
+```

--- a/src/halucinator/backends/avatar2_backend.py
+++ b/src/halucinator/backends/avatar2_backend.py
@@ -36,6 +36,10 @@ class Avatar2Backend(HalBackend):
         """
         self.target = target
         self.config = config
+        # Mirror every added region here too, so the generic snapshot path
+        # (HalBackend.save_state) has the writable-region list it needs.
+        # Without this, save_state raised "no writable regions" on avatar2.
+        self._regions: List[MemoryRegion] = []
 
     def attach(self, target: Any) -> None:
         """Attach this backend to an existing avatar2 QemuTarget."""
@@ -113,6 +117,7 @@ class Avatar2Backend(HalBackend):
             qemu_name=region.qemu_name,
             qemu_properties=region.qemu_properties,
         )
+        self._regions.append(region)
 
     # ------------------------------------------------------------------
     # Optional: inject IRQ via avatar2 QMP monitor

--- a/src/halucinator/backends/hal_backend.py
+++ b/src/halucinator/backends/hal_backend.py
@@ -6,8 +6,67 @@ Layer 2: HalTarget (below) adds ABI-aware helpers built on top of these primitiv
 """
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+
+log = logging.getLogger(__name__)
+
+
+def log_snapshot_mismatch(backend: "HalBackend", snap: "Snapshot",
+                          field_name: str) -> None:
+    """Log why ``restore_state`` refused a snapshot (incompatible field)."""
+    log.error("%s.restore_state: refusing snapshot — %s mismatch "
+              "(snapshot=%r, expected=%r)",
+              backend.__class__.__name__, field_name,
+              getattr(snap, field_name, None),
+              (backend.__class__.__name__ if field_name == "backend_type"
+               else backend.SNAPSHOT_VERSION))
+
+
+# ---------------------------------------------------------------------------
+# Snapshot types (Layer 1 — see halucinator.snapshot for the coordinator)
+# ---------------------------------------------------------------------------
+
+class SnapshotError(RuntimeError):
+    """Raised by ``save_state`` when a complete snapshot cannot be captured.
+
+    Save is all-or-nothing: rather than return a half-captured ``Snapshot``
+    (which would silently corrupt the guest on restore), the backend raises
+    and the partial capture is discarded.
+    """
+
+
+@dataclass
+class Snapshot:
+    """A Layer-1 backend checkpoint.
+
+    Tagged with ``backend_type`` (the concrete backend class name) and a schema
+    ``version`` so ``restore_state`` can reject an incompatible snapshot and
+    return ``False`` instead of corrupting the guest. ``data`` is backend-
+    private (generic fallback: ``{"regs": ..., "mem": ...}``; Unicorn native:
+    a ``UcContext`` + region blobs). A snapshot may own resources, so it is a
+    context manager and exposes :meth:`release`.
+    """
+
+    backend_type: str
+    version: int
+    data: Any = None
+    _released: bool = field(default=False, repr=False)
+
+    def release(self) -> None:
+        """Free any resources this snapshot holds. Idempotent."""
+        if self._released:
+            return
+        self.data = None
+        self._released = True
+
+    def __enter__(self) -> "Snapshot":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.release()
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +257,118 @@ class HalBackend(ABC):
             return list(abi.REGISTERS)
         # Fallback — conservative ARM32 set.
         return [f"r{i}" for i in range(13)] + ["sp", "lr", "pc"]
+
+    # ------------------------------------------------------------------
+    # Snapshot / restore  (Layer 1)
+    #
+    # The generic implementation below dumps every writable memory region
+    # plus the full register file and restores them via the primitive
+    # read/write methods — universal but slow. Fast backends (Unicorn)
+    # override save_state/restore_state with a native path; the coordinator
+    # in halucinator.snapshot bundles this with Layer-2 peripheral state.
+    # ------------------------------------------------------------------
+
+    SNAPSHOT_VERSION = 1
+
+    def can_snapshot(self) -> bool:
+        """Whether this backend can produce a snapshot. Always True for the
+        generic fallback; a backend with no usable path overrides to False."""
+        return True
+
+    def snapshot_is_fast(self) -> bool:
+        """Hint for the consumer: is save/restore cheap enough for an
+        inner loop? The generic register+RAM dump is not — override to True on
+        a native ms-scale path (Unicorn)."""
+        return False
+
+    def _snapshot_regions(self) -> List["MemoryRegion"]:
+        """Writable regions the generic snapshot must capture.
+
+        Skips read-only flash (never changes) AND ``emulate=``-backed MMIO
+        regions: those are forwarded to a Python peripheral model, so their
+        state is Layer 2 — reading them here would invoke the model's
+        hw_read (not real RAM) and double-capture what the peripheral
+        registry already owns."""
+        regions = getattr(self, "_regions", None) or []
+        return [r for r in regions
+                if "w" in r.permissions and not getattr(r, "emulate", None)]
+
+    def save_state(self, portable: bool = False) -> "Snapshot":
+        """Capture registers + writable RAM via the primitive read methods.
+
+        ``portable=True`` requests a snapshot made of plain python values,
+        safe to pickle and restore in a different process (what disk
+        persistence needs). The generic path here is ALWAYS portable — the
+        flag exists for backends whose fast path holds process-local native
+        handles (unicorn's context blob) and must capture differently.
+
+        Raises :class:`SnapshotError` if there is nothing to capture (no
+        writable regions) so a caller never gets an empty, useless snapshot.
+
+        Registers are captured tolerantly: a name in ``list_registers()`` that
+        a given backend's stub can't actually read (register sets vary across
+        GDB stubs / emulators) is skipped with a warning rather than aborting
+        the whole snapshot. Memory is strict — a failed region read raises,
+        because missing RAM means the snapshot is not a faithful resume point.
+        """
+        regions = self._snapshot_regions()
+        if not regions:
+            raise SnapshotError(
+                f"{self.__class__.__name__}.save_state: no writable memory "
+                f"regions to capture")
+        regs = {}
+        for name in self.list_registers():
+            try:
+                regs[name] = self.read_register(name)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("%s.save_state: register %r not readable; "
+                            "skipped (%s)", self.__class__.__name__, name, exc)
+        try:
+            mem = [(r.base_addr,
+                    bytes(self.read_memory(r.base_addr, 1, r.size, raw=True)))
+                   for r in regions]
+        except Exception as exc:  # noqa: BLE001
+            raise SnapshotError(
+                f"{self.__class__.__name__}.save_state failed reading "
+                f"memory: {exc!r}") from exc
+        return Snapshot(backend_type=self.__class__.__name__,
+                        version=self.SNAPSHOT_VERSION,
+                        data={"regs": regs, "mem": mem})
+
+    def restore_state(self, snap: "Snapshot") -> bool:
+        """Restore a snapshot produced by :meth:`save_state`.
+
+        Validates ``backend_type`` and ``version`` BEFORE touching any state,
+        returning ``False`` (no mutation) on mismatch rather than corrupting
+        the guest. Returns ``True`` once registers + memory are restored, and
+        ``False`` if a memory write reports failure (a half-restore must be
+        reported, not silently swallowed — that is the whole-or-nothing
+        contract the coordinator relies on).
+        """
+        if snap.backend_type != self.__class__.__name__:
+            log_snapshot_mismatch(self, snap, "backend_type")
+            return False
+        if snap.version != self.SNAPSHOT_VERSION:
+            log_snapshot_mismatch(self, snap, "version")
+            return False
+        data = snap.data or {}
+        for name, value in data.get("regs", {}).items():
+            # Tolerant, symmetric with save_state: a register this stub won't
+            # accept a write for is skipped with a warning, not fatal.
+            try:
+                self.write_register(name, value)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("%s.restore_state: register %r not writable; "
+                            "skipped (%s)", self.__class__.__name__, name, exc)
+        for base, blob in data.get("mem", []):
+            # write_memory returns False on a rejected write (unmapped/prot);
+            # propagate it so the caller knows the machine is now inconsistent.
+            if self.write_memory(base, 1, blob, len(blob), raw=True) is False:
+                log.error("%s.restore_state: write_memory(0x%x, %d bytes) "
+                          "failed; machine is now half-restored",
+                          self.__class__.__name__, base, len(blob))
+                return False
+        return True
 
     # ------------------------------------------------------------------
     # Convenience wrappers (implemented once, reused by all backends)

--- a/src/halucinator/backends/qemu_backend.py
+++ b/src/halucinator/backends/qemu_backend.py
@@ -590,17 +590,37 @@ class _GDBClient:
     # Memory access
     # ------------------------------------------------------------------
 
+    # GDB RSP bounds a single m/M transfer by the negotiated packet size; a
+    # too-large read/write is rejected (E22). Chunk at a conservative size so
+    # arbitrary-length transfers (e.g. snapshotting a whole RAM region) work
+    # regardless of the stub's PacketSize.
+    _MEM_CHUNK = 1024
+
     def read_memory(self, addr: int, length: int) -> bytes:
-        resp = self._cmd(f"m{addr:x},{length:x}".encode())
-        if resp.startswith(b"E"):
-            raise OSError(f"GDB read_memory error: {resp!r}")
-        return bytes.fromhex(resp.decode())
+        out = bytearray()
+        off = 0
+        while off < length:
+            n = min(self._MEM_CHUNK, length - off)
+            resp = self._cmd(f"m{addr + off:x},{n:x}".encode())
+            if resp.startswith(b"E"):
+                raise OSError(f"GDB read_memory error: {resp!r}")
+            chunk = bytes.fromhex(resp.decode())
+            if not chunk:
+                raise OSError(
+                    f"GDB read_memory short read at 0x{addr + off:x}")
+            out += chunk
+            off += len(chunk)
+        return bytes(out)
 
     def write_memory(self, addr: int, data: bytes) -> None:
-        hex_data = data.hex()
-        resp = self._cmd(f"M{addr:x},{len(data):x}:{hex_data}".encode())
-        if resp != b"OK":
-            raise OSError(f"GDB write_memory error: {resp!r}")
+        off = 0
+        while off < len(data):
+            chunk = data[off:off + self._MEM_CHUNK]
+            resp = self._cmd(
+                f"M{addr + off:x},{len(chunk):x}:{chunk.hex()}".encode())
+            if resp != b"OK":
+                raise OSError(f"GDB write_memory error: {resp!r}")
+            off += len(chunk)
 
     # ------------------------------------------------------------------
     # Execution control

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -418,6 +418,7 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         if self.arch_name == "arm":
             import os as _os
             model_name = _os.environ.get("HAL_ARM_CPU_MODEL", "UC_CPU_ARM_926")
+            self._cpu_model_name = model_name  # recorded in snapshot fingerprint
             model = getattr(arm_const, model_name, None)
             if model is not None:
                 try:
@@ -456,6 +457,18 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
                 log.debug(
                     "UnicornBackend: PPB auto-map skipped (%s)", exc,
                 )
+            # SCB->ICSR (0xE000ED04): a write with PENDSVSET (bit28) requests a
+            # PendSV — the RTOS context switch. Nothing else models the NVIC, so
+            # watch that write and queue PendSV (exception 14, as irq -2).
+            self._pendsv_pending = False
+
+            def _icsr_write(uc, access, addr, size, value, ud):  # noqa: ANN001
+                if value & (1 << 28):
+                    self._pendsv_pending = True
+                if value & (1 << 27):            # PENDSVCLR
+                    self._pendsv_pending = False
+            self._uc.hook_add(unicorn.UC_HOOK_MEM_WRITE, _icsr_write,
+                              begin=0xE000ED04, end=0xE000ED07)
 
         # Global hook to detect breakpoint hits and stop execution
         self._uc.hook_add(
@@ -1425,6 +1438,366 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         if self._uc is not None:
             self._map_region(region)
 
+    # ------------------------------------------------------------------
+    # Snapshot / restore  (Layer 1, native fast path)
+    #
+    # unicorn's context_save() captures the full CPU context and mem_regions()
+    # + mem_read give a bulk copy of every mapped page, so save/restore is a
+    # handful of milliseconds — the generalized form of diagnostics/
+    # snapshot_lab.py. This is the fast checkpoint an iterative loop wants.
+    #
+    # PORTABLE form (save_state(portable=True)): a raw uc context blob embeds
+    # process-local pointers — restoring one in a different process SIGBUSes
+    # (verified: same unicorn build, same CPU model, byte-identical config).
+    # The portable form therefore enumerates architectural state explicitly
+    # (general regs + A-profile banked regs + curated CP15 set, or M-profile
+    # system regs) into plain python values, which is what disk persistence
+    # (snapshot/persist.py) requires. Slightly slower; still ~ms.
+    # ------------------------------------------------------------------
+
+    # A-profile banked modes visited by the portable capture/restore dance.
+    # "sys" (0x1f) shares sp/lr with usr and has no SPSR; fiq additionally
+    # banks r8-r12.
+    _ARM_BANKED_MODES = (
+        (0x11, "fiq"), (0x12, "irq"), (0x13, "svc"),
+        (0x17, "abt"), (0x1b, "und"), (0x1f, "sys"),
+    )
+    # Curated CP15 system registers, as (crn, crm, opc1, opc2) for
+    # UC_ARM_REG_CP_REG. Covers the ARMv5/ARM926 MMU set PLUS the v6/v7 regs
+    # that later A-profile CPU models (cortex-a*) implement — VBAR (relocated
+    # vector base), TTBR1 + the LPAE memory-attribute regs, and the thread-ID
+    # (TPIDR*) regs an RTOS uses. Reads/writes are per-register guarded, so a
+    # model that doesn't implement one simply skips it (absent from the dict).
+    # Restore order matters: SCTLR (the MMU enable) is written LAST so
+    # translation state (TTBR/DACR/attrs) is in place before the M bit flips.
+    _CP15_PORTABLE = (
+        ("ttbr0",      (2, 0, 0, 0)),
+        ("ttbr1",      (2, 0, 0, 1)),   # v6+
+        ("ttbcr",      (2, 0, 0, 2)),
+        ("dacr",       (3, 0, 0, 0)),
+        ("dfsr",       (5, 0, 0, 0)),
+        ("ifsr",       (5, 0, 0, 1)),
+        ("dfar",       (6, 0, 0, 0)),
+        ("ifar",       (6, 0, 0, 2)),   # v6+
+        ("prrr_mair0", (10, 2, 0, 0)),  # PRRR / MAIR0 (v6+/v7)
+        ("nmrr_mair1", (10, 2, 0, 1)),  # NMRR / MAIR1 (v6+/v7)
+        ("vbar",       (12, 0, 0, 0)),  # v7: relocated exception vector base
+        ("fcseidr",    (13, 0, 0, 0)),
+        ("contextidr", (13, 0, 0, 1)),
+        ("tpidrurw",   (13, 0, 0, 2)),  # v6+ user RW thread-id
+        ("tpidruro",   (13, 0, 0, 3)),  # v6+ user RO thread-id
+        ("tpidrprw",   (13, 0, 0, 4)),  # v6+ priv thread-id
+        ("cpacr",      (1, 0, 0, 2)),   # coprocessor (VFP) access control
+        ("sctlr",      (1, 0, 0, 0)),
+    )
+    # M-profile system registers (arm_const name suffixes).
+    _M_PROFILE_SYSREGS = ("MSP", "PSP", "PRIMASK", "BASEPRI",
+                          "FAULTMASK", "CONTROL")
+    # VFP/NEON registers captured on FP-capable cores (guarded — a core
+    # without VFP raises on the read and the reg is skipped). d0-d31 covers
+    # s0-s31 (aliased low halves); FPSCR is the status/control word; FPEXC
+    # carries the VFP EN bit (bit 30). FPEXC is ESSENTIAL: unicorn's
+    # context_save() does not preserve it, so without capturing/restoring it a
+    # restored A-profile machine comes back with VFP disabled and the first
+    # VFP instruction (e.g. `vpush {d8,d9}`) traps as UC_ERR_INSN_INVALID.
+    _VFP_DREGS = tuple(f"UC_ARM_REG_D{i}" for i in range(32))
+    _VFP_CTRL = ("FPEXC", "FPSCR")
+
+    def can_snapshot(self) -> bool:
+        return self._uc is not None
+
+    def snapshot_is_fast(self) -> bool:
+        return True
+
+    def _is_arm_profile_a(self) -> bool:
+        arch_str, mode_str, *_ = _ARCH_MAP.get(
+            self.arch_name, ("arm", "thumb", True, False, 4))
+        return arch_str == "arm" and mode_str != "thumb"
+
+    def _is_arm_profile_m(self) -> bool:
+        arch_str, mode_str, *_ = _ARCH_MAP.get(
+            self.arch_name, ("arm", "thumb", True, False, 4))
+        return arch_str == "arm" and mode_str == "thumb"
+
+    def _capture_banked_regs(self) -> Dict[str, Dict[str, int]]:
+        """A-profile: visit each banked mode via raw CPSR writes and read its
+        sp/lr/spsr (+ r8-r12 for fiq). CPSR is always restored, even if a
+        mode read fails."""
+        uc = self._uc
+        cpsr_id = arm_const.UC_ARM_REG_CPSR
+        orig = uc.reg_read(cpsr_id)
+        banked: Dict[str, Dict[str, int]] = {}
+        try:
+            for mode_bits, tag in self._ARM_BANKED_MODES:
+                uc.reg_write(cpsr_id, (orig & ~0x1F) | mode_bits)
+                entry = {"sp": uc.reg_read(arm_const.UC_ARM_REG_SP),
+                         "lr": uc.reg_read(arm_const.UC_ARM_REG_LR)}
+                if tag != "sys":  # sys/usr have no SPSR
+                    entry["spsr"] = uc.reg_read(arm_const.UC_ARM_REG_SPSR)
+                if tag == "fiq":
+                    for i in range(8, 13):
+                        entry[f"r{i}"] = uc.reg_read(
+                            getattr(arm_const, f"UC_ARM_REG_R{i}"))
+                banked[tag] = entry
+        finally:
+            uc.reg_write(cpsr_id, orig)
+        return banked
+
+    def _restore_banked_regs(self, banked: Dict[str, Dict[str, int]]) -> None:
+        """Inverse of _capture_banked_regs. Caller restores the final CPSR."""
+        uc = self._uc
+        cpsr_id = arm_const.UC_ARM_REG_CPSR
+        orig = uc.reg_read(cpsr_id)
+        try:
+            for mode_bits, tag in self._ARM_BANKED_MODES:
+                entry = banked.get(tag)
+                if not entry:
+                    continue
+                uc.reg_write(cpsr_id, (orig & ~0x1F) | mode_bits)
+                uc.reg_write(arm_const.UC_ARM_REG_SP, entry["sp"])
+                uc.reg_write(arm_const.UC_ARM_REG_LR, entry["lr"])
+                if "spsr" in entry:
+                    uc.reg_write(arm_const.UC_ARM_REG_SPSR, entry["spsr"])
+                for i in range(8, 13):
+                    if f"r{i}" in entry:
+                        uc.reg_write(getattr(arm_const, f"UC_ARM_REG_R{i}"),
+                                     entry[f"r{i}"])
+        finally:
+            uc.reg_write(cpsr_id, orig)
+
+    def _capture_cp15(self) -> Dict[str, int]:
+        """Read the curated CP15 set. Registers the CPU model doesn't
+        implement are skipped (absent from the dict, skipped on restore)."""
+        out: Dict[str, int] = {}
+        for name, (crn, crm, opc1, opc2) in self._CP15_PORTABLE:
+            try:
+                out[name] = self._uc.reg_read(
+                    arm_const.UC_ARM_REG_CP_REG,
+                    (15, 0, 0, crn, crm, opc1, opc2))
+            except Exception:  # noqa: BLE001 — not implemented on this model
+                continue
+        return out
+
+    def _restore_cp15(self, cp15: Dict[str, int]) -> None:
+        # _CP15_PORTABLE order is the restore order (SCTLR last).
+        for name, (crn, crm, opc1, opc2) in self._CP15_PORTABLE:
+            if name not in cp15:
+                continue
+            try:
+                self._uc.reg_write(
+                    arm_const.UC_ARM_REG_CP_REG,
+                    (15, 0, 0, crn, crm, opc1, opc2, cp15[name]))
+            except Exception:  # noqa: BLE001
+                log.warning("restore_state: CP15 %s not writable on this "
+                            "CPU model; skipped", name)
+
+    def _capture_vfp(self) -> Dict[str, int]:
+        """Read the VFP/NEON register file. On a core without VFP the reads
+        raise and the register is skipped (absent from the dict), so this is
+        a no-op on ARM926 and captures the full FP state on cortex-a*/FPU-M."""
+        out: Dict[str, int] = {}
+        for i, dname in enumerate(self._VFP_DREGS):
+            rid = getattr(arm_const, dname, None)
+            if rid is None:
+                continue
+            try:
+                out[f"d{i}"] = self._uc.reg_read(rid)
+            except Exception:  # noqa: BLE001 — no VFP on this model
+                continue
+        for suffix in self._VFP_CTRL:
+            rid = getattr(arm_const, f"UC_ARM_REG_{suffix}", None)
+            if rid is None:
+                continue
+            try:
+                out[suffix.lower()] = self._uc.reg_read(rid)
+            except Exception:  # noqa: BLE001
+                continue
+        return out
+
+    def _restore_vfp(self, vfp: Dict[str, int]) -> None:
+        for i, dname in enumerate(self._VFP_DREGS):
+            key = f"d{i}"
+            if key not in vfp:
+                continue
+            rid = getattr(arm_const, dname, None)
+            if rid is None:
+                continue
+            try:
+                self._uc.reg_write(rid, vfp[key])
+            except Exception:  # noqa: BLE001
+                log.warning("restore_state: VFP %s not writable; skipped", key)
+        for suffix in self._VFP_CTRL:
+            if suffix.lower() not in vfp:
+                continue
+            rid = getattr(arm_const, f"UC_ARM_REG_{suffix}", None)
+            if rid is not None:
+                try:
+                    self._uc.reg_write(rid, vfp[suffix.lower()])
+                except Exception:  # noqa: BLE001
+                    pass
+
+    def _capture_portable_regs(self) -> Dict[str, Any]:
+        """Architectural state as plain python values — safe to pickle and
+        restore in a different process (unlike a raw uc context blob)."""
+        uc = self._uc
+        state: Dict[str, Any] = {
+            "regs": {name: uc.reg_read(rid)
+                     for name, rid in self._reg_map.items()},
+        }
+        if self._is_arm_profile_a():
+            state["banked"] = self._capture_banked_regs()
+            state["cp15"] = self._capture_cp15()
+            state["vfp"] = self._capture_vfp()
+        elif self._is_arm_profile_m():
+            sysregs: Dict[str, int] = {}
+            for suffix in self._M_PROFILE_SYSREGS:
+                rid = getattr(arm_const, f"UC_ARM_REG_{suffix}", None)
+                if rid is None:
+                    continue
+                try:
+                    sysregs[suffix.lower()] = uc.reg_read(rid)
+                except Exception:  # noqa: BLE001
+                    continue
+            state["m_sysregs"] = sysregs
+            state["vfp"] = self._capture_vfp()  # FPU-equipped M-profile
+        else:
+            # Non-ARM: the arch reg map covers the visible register file but
+            # NOT hidden system state (x86 segment descriptors/MSRs, MIPS
+            # cp0, ...). Good enough for flat-model targets; be honest here.
+            # Route via hal_log: the shipped logging.cfg leaves this module's
+            # logger inheriting root=ERROR, so a plain log.warning here is
+            # discarded by default -- and a silently lossy snapshot is
+            # exactly what the caller needs told about.
+            from halucinator import hal_log
+            hal_log.getHalLogger().warning(
+                "save_state(portable=True) on %s captures the general "
+                "register file only — hidden system state is not yet "
+                "enumerated for this arch", self.arch_name)
+        return state
+
+    def _restore_portable_regs(self, state: Dict[str, Any]) -> None:
+        uc = self._uc
+        regs: Dict[str, int] = state.get("regs", {})
+        # System state first (CP15 translation regs before SCTLR, banked
+        # modes before the final CPSR), then the general file with CPSR
+        # first (mode/T bit context) and PC last.
+        if "cp15" in state:
+            self._restore_cp15(state["cp15"])
+        if "vfp" in state:
+            self._restore_vfp(state["vfp"])
+        if "banked" in state:
+            self._restore_banked_regs(state["banked"])
+        for suffix_l, value in state.get("m_sysregs", {}).items():
+            rid = getattr(arm_const, f"UC_ARM_REG_{suffix_l.upper()}", None)
+            if rid is None:
+                continue
+            try:
+                uc.reg_write(rid, value)
+            except Exception:  # noqa: BLE001
+                log.warning("restore_state: m-profile %s not writable; "
+                            "skipped", suffix_l)
+        ordered = sorted(regs,
+                         key=lambda n: (0 if n == "cpsr" else
+                                        2 if n == "pc" else 1))
+        for name in ordered:
+            try:
+                uc.reg_write(self._reg_map[name], regs[name])
+            except Exception:  # noqa: BLE001 — read-only alias on this model
+                log.debug("restore_state: register %s not writable; skipped",
+                          name)
+
+    def _machine_fingerprint(self) -> Dict[str, Any]:
+        """Identifies the machine config a snapshot was taken on: arch, CPU
+        model, and the mapped memory layout. A portable snapshot restored onto
+        a DIFFERENT config (wrong --emulator machine.yaml, different CPU model)
+        would half-mutate before failing; comparing this fingerprint rejects
+        the mismatch cleanly before any write."""
+        return {
+            "arch": self.arch_name,
+            "cpu_model": getattr(self, "_cpu_model_name", None),
+            "regions": sorted((base, end)
+                              for (base, end, _p) in self._uc.mem_regions()),
+        }
+
+    def save_state(self, portable: bool = False) -> "Snapshot":
+        from .hal_backend import Snapshot, SnapshotError
+        if self._uc is None:
+            raise SnapshotError(
+                "UnicornBackend.save_state: engine not initialised "
+                "(call init() first)")
+        try:
+            # bytes(): unicorn's mem_write requires bytes (rejects the
+            # bytearray mem_read returns), so this conversion is load-bearing
+            # on the restore path, not merely defensive.
+            mem = [(base, bytes(self._uc.mem_read(base, end - base + 1)))
+                   for (base, end, _perm) in self._uc.mem_regions()]
+            if portable:
+                data: Dict[str, Any] = {"portable": True,
+                                        "fingerprint": self._machine_fingerprint(),
+                                        **self._capture_portable_regs()}
+            else:
+                data = {"context": self._uc.context_save()}
+            data["mem"] = mem
+        except SnapshotError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise SnapshotError(
+                f"UnicornBackend.save_state failed: {exc!r}") from exc
+        return Snapshot(backend_type=self.__class__.__name__,
+                        version=self.SNAPSHOT_VERSION,
+                        data=data)
+
+    def restore_state(self, snap: "Snapshot") -> bool:
+        from .hal_backend import log_snapshot_mismatch
+        if snap.backend_type != self.__class__.__name__:
+            log_snapshot_mismatch(self, snap, "backend_type")
+            return False
+        if snap.version != self.SNAPSHOT_VERSION:
+            log_snapshot_mismatch(self, snap, "version")
+            return False
+        if self._uc is None:
+            log.error("UnicornBackend.restore_state: engine not initialised")
+            return False
+        data = snap.data or {}
+        # Validate the machine fingerprint BEFORE any write (validate-before-
+        # mutate). A portable snapshot from a different arch/CPU/memory map
+        # can't be applied coherently — reject it whole rather than half-write.
+        fp = data.get("fingerprint")
+        if fp is not None:
+            current = self._machine_fingerprint()
+            if fp != current:
+                log.error("UnicornBackend.restore_state: snapshot machine "
+                          "fingerprint %r != current %r; refusing (restore "
+                          "with the same config the snapshot was taken on)",
+                          fp, current)
+                return False
+        try:
+            for base, blob in data.get("mem", []):
+                self._uc.mem_write(base, blob)
+            if data.get("portable"):
+                self._restore_portable_regs(data)
+            else:
+                context = data.get("context")
+                if context is not None:
+                    self._uc.context_restore(context)
+        except Exception as exc:  # noqa: BLE001
+            log.error("UnicornBackend.restore_state failed: %r", exc)
+            return False
+        # After a restore we are logically stopped at the snapshot PC, as if we
+        # had just hit a breakpoint there. Reset the transient breakpoint
+        # bookkeeping so a following continue_past_breakpoint() arms its
+        # one-shot skip for THIS pc, not a stale address left over from the
+        # pre-restore run. Otherwise, when the snapshot sits on a breakpoint
+        # (e.g. a loop snapshotting at a marker breakpoint), the marker
+        # re-triggers immediately and the resumed run is silently skipped —
+        # a nasty source of flaky, order-dependent execution.
+        self._skip_bp_once = None
+        try:
+            self._bp_hit_addr = self.read_register("pc") & 0xFFFFFFFE
+        except Exception:  # noqa: BLE001
+            self._bp_hit_addr = None
+        return True
+
     def read_memory(self, addr: int, size: int, num_words: int = 1,
                     raw: bool = False) -> Union[int, bytes]:
         total = size * num_words
@@ -1949,19 +2322,43 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
                         "unmapped; no handler installed", irq_num, isr_slot)
             return
 
-        # Push the 8-word exception frame.
-        regs = {name: self.read_register(name) for name in
-                ("r0", "r1", "r2", "r3", "r12", "lr", "pc", "cpsr")}
-        sp = self.read_register("sp") - 32
-        frame = (regs["r0"], regs["r1"], regs["r2"], regs["r3"],
-                 regs["r12"], regs["lr"], regs["pc"], regs["cpsr"])
+        # Take the exception the way ARMv7-M hardware does — PSP-aware, so a
+        # preemptive RTOS (mbed RTX etc.) can context-switch. Push the 8-word
+        # frame onto the ACTIVE stack (PSP when in a thread with CONTROL.SPSEL,
+        # else MSP), set LR to the matching EXC_RETURN (…F1 handler/MSP,
+        # …F9 thread/MSP, …FD thread/PSP), then enter handler mode (IPSR = the
+        # exception number) so the handler runs on MSP. If the active SP isn't
+        # writable (early boot / a mid-switch window), real hardware wouldn't
+        # take the interrupt either — drop this delivery rather than crash.
         import struct
-        self._uc.mem_write(sp, struct.pack("<8I", *frame))
-        self.write_register("sp", sp)
-        self.write_register("lr", self._EXC_RETURN_THREAD_MSP)
+        from unicorn import arm_const as _A
+        exc_num = (16 + irq_num) & 0x1FF
+        ipsr = self._uc.reg_read(_A.UC_ARM_REG_IPSR) & 0x1FF
+        control = self._uc.reg_read(_A.UC_ARM_REG_CONTROL)
+        in_thread = ipsr == 0
+        use_psp = in_thread and bool(control & 2)          # SPSEL
+        active = _A.UC_ARM_REG_PSP if use_psp else _A.UC_ARM_REG_MSP
+        xpsr = self._uc.reg_read(_A.UC_ARM_REG_XPSR)
+        frame = struct.pack("<8I",
+                            self.read_register("r0"), self.read_register("r1"),
+                            self.read_register("r2"), self.read_register("r3"),
+                            self.read_register("r12"), self.read_register("lr"),
+                            self.read_register("pc"), xpsr)
+        sp = self._uc.reg_read(active) - 32     # RTOS/thread stacks are 8-aligned
+        try:
+            self._uc.mem_write(sp, frame)
+        except Exception:  # noqa: BLE001 — unmapped/invalid SP: skip this tick
+            log.debug("inject_irq(%d): SP 0x%x not writable, dropping delivery",
+                      irq_num, sp)
+            return
+        self._uc.reg_write(active, sp)
+        exc_ret = (0xFFFFFFF1 if not in_thread
+                   else 0xFFFFFFFD if use_psp else 0xFFFFFFF9)
+        self.write_register("lr", exc_ret)
+        self._uc.reg_write(_A.UC_ARM_REG_IPSR, exc_num)    # -> handler mode (MSP)
         self.write_register("pc", isr_addr & ~1)  # Thumb bit goes in CPSR.T
-        log.info("inject_irq(%d): entering ISR @ 0x%x (vector 0x%x)",
-                 irq_num, isr_addr, isr_slot)
+        log.info("inject_irq(%d): exc %d @ 0x%x (exc_return %#x)",
+                 irq_num, exc_num, isr_addr, exc_ret)
 
     def set_vtor(self, vtor: int) -> None:
         """Remember the vector-table base so inject_irq can find ISRs."""
@@ -2035,23 +2432,45 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
                                           self._resolve_delivery_plan(_legacy))
 
     def _maybe_handle_exc_return(self, addr: int) -> bool:
-        """Called from the invalid-fetch hook. If the fetch address looks
-        like an EXC_RETURN magic value, pop the exception frame and
-        restore pre-interrupt state. Returns True when handled."""
-        decoded = self._decode_exc_return_frame(addr)
-        if decoded is None:
+        """Called from the invalid-fetch hook. If the fetch address is an
+        EXC_RETURN magic value, pop the exception frame from the stack the
+        EXC_RETURN selects (MSP or PSP), restore thread/handler mode + SPSEL,
+        and resume. PSP-aware so an RTOS context switch (PendSV returning via
+        …FD to the switched-in thread's PSP) lands on the new thread."""
+        if self.arch_name != "cortex-m3":
             return False
-        sp, frame = decoded
+        if (addr & self._EXC_RETURN_MASK) != self._EXC_RETURN_MAGIC:
+            return False
+        import struct
+        from unicorn import arm_const as _A
+        return_psp = bool(addr & 0x4)          # EXC_RETURN bit2: return stack
+        return_thread = bool(addr & 0x8)       # bit3: return mode
+        active = _A.UC_ARM_REG_PSP if return_psp else _A.UC_ARM_REG_MSP
+        sp = self._uc.reg_read(active)
+        try:
+            frame = struct.unpack("<8I", bytes(self._uc.mem_read(sp, 32)))
+        except Exception:                      # noqa: BLE001
+            return False
         self.write_register("r0", frame[0])
         self.write_register("r1", frame[1])
         self.write_register("r2", frame[2])
         self.write_register("r3", frame[3])
         self.write_register("r12", frame[4])
         self.write_register("lr", frame[5])
+        self._uc.reg_write(active, sp + 32)
+        self.write_register("cpsr", frame[7])  # restores flags + IPSR (0=thread)
+        if return_thread:
+            self._uc.reg_write(_A.UC_ARM_REG_IPSR, 0)
+            control = self._uc.reg_read(_A.UC_ARM_REG_CONTROL)
+            control = (control | 2) if return_psp else (control & ~2)
+            self._uc.reg_write(_A.UC_ARM_REG_CONTROL, control)
         self.write_register("pc", frame[6])
-        self.write_register("cpsr", frame[7])
-        self.write_register("sp", sp + 32)
-        log.info("exc_return: popped frame, resuming at 0x%x", frame[6])
+        log.info("exc_return %#x: popped from %s, resuming at 0x%x",
+                 addr, "PSP" if return_psp else "MSP", frame[6])
+        # A PendSV requested from the handler we're leaving tail-chains here.
+        if return_thread and getattr(self, "_pendsv_pending", False):
+            self._pendsv_pending = False
+            self._pending_irqs.append(-2)      # -2 -> exception 14 (PendSV)
         # Unicorn needs to restart from the restored PC; stop the current
         # emu_start so our dispatch loop re-issues cont() at the new PC.
         self._uc.emu_stop()

--- a/src/halucinator/external_devices/ioserver.py
+++ b/src/halucinator/external_devices/ioserver.py
@@ -82,18 +82,28 @@ class IOServer(Thread):
             if self.rx_socket in socks and socks[self.rx_socket] == zmq.POLLIN:
                 msg = self.rx_socket.recv_string()
                 log.debug("Received: %s", str(msg))
-                topic, data = decode_zmq_msg(msg)
-                if self.packet_log:
-                    self.packet_log.write(
-                        "Sent, %i, %s, %s\n" % (
-                            time.time(),
-                            topic,
-                            binascii.hexlify(data["frame"]),
+                # One malformed message or a raising handler must NOT kill the
+                # rx thread — that would silently take the whole device
+                # offline for every topic. Log and keep serving.
+                try:
+                    topic, data = decode_zmq_msg(msg)
+                    if self.packet_log:
+                        self.packet_log.write(
+                            "Sent, %i, %s, %s\n" % (
+                                time.time(),
+                                topic,
+                                binascii.hexlify(data["frame"]),
+                            )
                         )
-                    )
-                    self.packet_log.flush()
-                method = self.handlers[topic]
-                method(self, data)
+                        self.packet_log.flush()
+                    method = self.handlers.get(topic)
+                    if method is None:
+                        log.warning("IOServer: no handler for topic %s", topic)
+                        continue
+                    method(self, data)
+                except Exception:  # noqa: BLE001
+                    log.exception("IOServer: handler for a message raised; "
+                                  "dropping it and continuing")
         log.debug("IO Server Stopped")
 
     def shutdown(self) -> None:

--- a/src/halucinator/external_devices/snapshotable.py
+++ b/src/halucinator/external_devices/snapshotable.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Christopher Wright
+
+"""Device-side opt-in for Layer-3 snapshots (see snapshot/device_layer.py).
+
+An external device process that holds machine state participates by wiring a
+``SnapshotableDevice`` onto its :class:`IOServer`:
+
+    from halucinator.external_devices.ioserver import IOServer
+    from halucinator.external_devices.snapshotable import SnapshotableDevice
+
+    class MyBridge:
+        def get_state(self):        # -> yaml-safe dict
+            return {"sessions": self.sessions, "counter": self.counter}
+        def set_state(self, state): # inverse, restore in place
+            self.sessions = state["sessions"]
+            self.counter = state["counter"]
+
+    ioserver = IOServer(...)
+    bridge = MyBridge()
+    SnapshotableDevice(ioserver, "my-bridge", bridge.get_state, bridge.set_state)
+    ioserver.start()
+
+``device_id`` must be unique per fleet and STABLE across process restarts —
+it is the key the restore contract checks, so a renamed device makes old
+snapshots unrestorable (by design: that's a missing device).
+
+State must be yaml-safe (it travels ``encode_zmq_msg`` and is pickled into
+snapshot files). ``set_state`` runs on the IOServer rx thread; synchronize
+with the device's own threads as needed. A ``set_state`` that raises acks
+``ok: false`` so the HAL side fails the restore loudly instead of resuming
+against a half-restored fleet.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict
+
+log = logging.getLogger(__name__)
+
+
+SAVE_TOPIC = "Peripheral.SnapshotDevices.save"
+RESTORE_TOPIC = "Peripheral.SnapshotDevices.restore"
+STATE_TOPIC = "Peripheral.SnapshotDevices.state"
+RESTORED_TOPIC = "Peripheral.SnapshotDevices.restored"
+
+
+class _SnapshotDispatcher:
+    """One per IOServer. ``register_topic`` stores a single handler per topic,
+    so N SnapshotableDevices on one IOServer would clobber each other's
+    save/restore handlers — all but the last silently never answering. The
+    dispatcher owns the two topic registrations once and fans each message
+    out to every device, keyed by a unique device_id."""
+
+    def __init__(self, ioserver: Any) -> None:
+        self.ioserver = ioserver
+        self.devices: Dict[str, "SnapshotableDevice"] = {}
+        ioserver.register_topic(SAVE_TOPIC, self._on_save)
+        ioserver.register_topic(RESTORE_TOPIC, self._on_restore)
+
+    @classmethod
+    def for_ioserver(cls, ioserver: Any) -> "_SnapshotDispatcher":
+        disp = getattr(ioserver, "_snapshot_dispatcher", None)
+        if disp is None:
+            disp = cls(ioserver)
+            ioserver._snapshot_dispatcher = disp
+        return disp
+
+    def add(self, device: "SnapshotableDevice") -> None:
+        if device.device_id in self.devices:
+            raise ValueError(
+                f"duplicate snapshot device_id {device.device_id!r} on this "
+                "IOServer; device_id must be unique per fleet")
+        self.devices[device.device_id] = device
+
+    def _on_save(self, _ioserver: Any, msg: Dict[str, Any]) -> None:
+        for dev in list(self.devices.values()):
+            dev._handle_save(msg)
+
+    def _on_restore(self, _ioserver: Any, msg: Dict[str, Any]) -> None:
+        for dev in list(self.devices.values()):
+            dev._handle_restore(msg)
+
+
+class SnapshotableDevice:
+    """Answers the HAL side's Layer-3 save/restore protocol for one device."""
+
+    # Re-exported as class attrs for callers/tests that referenced them here.
+    SAVE_TOPIC = SAVE_TOPIC
+    RESTORE_TOPIC = RESTORE_TOPIC
+    STATE_TOPIC = STATE_TOPIC
+    RESTORED_TOPIC = RESTORED_TOPIC
+
+    def __init__(self, ioserver: Any, device_id: str,
+                 get_state: Callable[[], Dict[str, Any]],
+                 set_state: Callable[[Dict[str, Any]], Any]) -> None:
+        self.ioserver = ioserver
+        self.device_id = device_id
+        self.get_state = get_state
+        self.set_state = set_state
+        # Register via the shared per-IOServer dispatcher, not directly, so a
+        # second device on the same IOServer doesn't clobber the first.
+        _SnapshotDispatcher.for_ioserver(ioserver).add(self)
+
+    def _send(self, topic: str, payload: Dict[str, Any]) -> bool:
+        """Send a protocol reply, containing any serialization/transport
+        failure. A raw exception here would escape the IOServer rx loop and
+        kill the whole device thread (it answers ALL topics), so a single
+        bad-state device must never take itself fully offline."""
+        try:
+            self.ioserver.send_msg(topic, payload)
+            return True
+        except Exception:  # noqa: BLE001
+            log.exception("SnapshotableDevice[%s]: sending %s failed (state "
+                          "not yaml-safe?); staying absent rather than "
+                          "killing the device", self.device_id, topic)
+            return False
+
+    def _handle_save(self, msg: Dict[str, Any]) -> None:
+        snap_id = msg.get("snapshot_id")
+        if snap_id is None:
+            log.error("SnapshotableDevice[%s]: malformed save %r",
+                      self.device_id, msg)
+            return
+        try:
+            state = self.get_state()
+        except Exception:  # noqa: BLE001
+            log.exception("SnapshotableDevice[%s]: get_state failed; "
+                          "not answering (device will be absent from the "
+                          "snapshot)", self.device_id)
+            return
+        self._send(STATE_TOPIC,
+                   {"snapshot_id": snap_id, "device_id": self.device_id,
+                    "state": state})
+
+    def _handle_restore(self, msg: Dict[str, Any]) -> None:
+        snap_id = msg.get("snapshot_id")
+        states = msg.get("states") or {}
+        if snap_id is None:
+            log.error("SnapshotableDevice[%s]: malformed restore %r",
+                      self.device_id, msg)
+            return
+        if self.device_id not in states:
+            return  # this restore doesn't involve us
+        ok = True
+        try:
+            self.set_state(states[self.device_id])
+        except Exception:  # noqa: BLE001
+            log.exception("SnapshotableDevice[%s]: set_state failed",
+                          self.device_id)
+            ok = False
+        self._send(RESTORED_TOPIC,
+                   {"snapshot_id": snap_id, "device_id": self.device_id,
+                    "ok": ok})

--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -290,12 +290,24 @@ def emulate_binary(
     gdb_server_port: Optional[int] = None,
     print_qemu_command: Optional[bool] = None,
     emulator: str = "avatar2",
+    snapshot_at: Optional[str] = None,
+    snapshot_out: Optional[str] = None,
+    snapshot_include_devices: bool = False,
+    restore: Optional[str] = None,
 ) -> None:  # pylint: disable=too-many-arguments,too-many-locals
     """
     Start emulation of the firmware.
 
     emulator: backend to use - "avatar2" (default), "qemu", or "unicorn".
+    snapshot_at/snapshot_out/restore: whole-machine checkpointing, in-process
+    backends only (see doc/snapshot_restore.md).
     """
+
+    if (snapshot_at or restore) and emulator != "unicorn":
+        log.error("--snapshot-at/--restore need the in-process unicorn "
+                  "backend (--emulator unicorn); %r can't snapshot yet",
+                  emulator)
+        sys.exit(-1)
 
     # Non-avatar2 backends go through the new HalBackend factory path.
     if emulator != "avatar2":
@@ -313,6 +325,10 @@ def emulate_binary(
             qemu_args=qemu_args,
             gdb_server_port=gdb_server_port,
             print_qemu_command=print_qemu_command,
+            snapshot_at=snapshot_at,
+            snapshot_out=snapshot_out,
+            snapshot_include_devices=snapshot_include_devices,
+            restore=restore,
         )
 
     # Legacy avatar2 path - unchanged behaviour.
@@ -456,6 +472,10 @@ def _emulate_with_backend(
     qemu_args: Optional[str] = None,
     gdb_server_port: Optional[int] = None,
     print_qemu_command: Optional[bool] = None,
+    snapshot_at: Optional[str] = None,
+    snapshot_out: Optional[str] = None,
+    snapshot_include_devices: bool = False,
+    restore: Optional[str] = None,
 ) -> None:
     """
     Non-avatar2 emulation entry point using the HalBackend abstraction.
@@ -486,6 +506,9 @@ def _emulate_with_backend(
     if emulator == "unicorn":
         return _emulate_with_unicorn_backend(
             config, target_name=target_name, rx_port=rx_port, tx_port=tx_port,
+            snapshot_at=snapshot_at, snapshot_out=snapshot_out,
+            snapshot_include_devices=snapshot_include_devices,
+            restore=restore,
         )
     if emulator == "renode":
         return _emulate_with_renode_backend(
@@ -950,11 +973,29 @@ def _instantiate_peripheral(name: str, memory: Any, db_path: str) -> Any:
     return cls(memory.name, memory.base_addr, memory.size, **kwargs)
 
 
+def _resolve_snapshot_addr(spec: str, config: Any) -> int:
+    """--snapshot-at accepts a hex/decimal address or a symbol name."""
+    try:
+        return int(spec, 0)
+    except ValueError:
+        pass
+    addr = config.get_addr_for_symbol(spec)
+    if addr is None:
+        log.error("--snapshot-at: %r is neither an address nor a known "
+                  "symbol", spec)
+        sys.exit(-1)
+    return addr
+
+
 def _emulate_with_unicorn_backend(
     config: Any,
     target_name: Optional[str],
     rx_port: int,
     tx_port: int,
+    snapshot_at: Optional[str] = None,
+    snapshot_out: Optional[str] = None,
+    snapshot_include_devices: bool = False,
+    restore: Optional[str] = None,
 ) -> None:
     """
     In-process emulation via unicorn-engine. No subprocess, no GDB/QMP -
@@ -963,6 +1004,11 @@ def _emulate_with_unicorn_backend(
     Considerably faster than the QEMU paths for short-running firmware
     that doesn't need full hardware peripheral timing, but only supports
     ARM at the moment (UnicornBackend._ARCH_MAP).
+
+    snapshot_at/snapshot_out: run until PC reaches the given address or
+    symbol, write a portable whole-machine snapshot, and exit (the
+    boot-once workflow). restore: load a .halsnap before running, so
+    execution resumes from the checkpoint instead of the reset vector.
     """
     from halucinator.backends.hal_backend import MemoryRegion
     from halucinator.backends.unicorn_backend import UnicornBackend
@@ -1063,26 +1109,88 @@ def _emulate_with_unicorn_backend(
 
     signal.signal(signal.SIGINT, _sigint)
 
+    # Snapshot/restore wiring (doc/snapshot_restore.md). Restore runs after
+    # intercept registration + peripheral-server start so the restored
+    # Layer-2 state lands on the same live objects the run will use.
+    if restore:
+        from halucinator.backends.hal_backend import Snapshot as _BSnap
+        from halucinator.backends.hal_backend import SnapshotError
+        from halucinator.snapshot import (DeviceLayer, SystemSnapshot,
+                                          load_snapshot_file, system_restore)
+        try:
+            snap, _header = load_snapshot_file(restore)
+            if isinstance(snap, _BSnap):  # backend-only snapshot file
+                snap = SystemSnapshot(backend=snap, peripherals={})
+            result = system_restore(backend, snap, device_layer=DeviceLayer())
+        except SnapshotError as exc:
+            # A corrupt/incompatible/wrong-arch file: fail cleanly, don't dump
+            # a raw traceback and leak the backend + peripheral server.
+            hal_log.getHalLogger().error("--restore %s: %s", restore, exc)
+            _shutdown()
+            sys.exit(-1)
+        if not result.ok:
+            hal_log.getHalLogger().error(
+                "--restore %s failed at layer %s: %s",
+                restore, result.layer, result.message)
+            _shutdown()
+            sys.exit(-1)
+        hal_log.getHalLogger().info(
+            "Restored snapshot %s; resuming at pc=0x%08x",
+            restore, backend.regs.pc)
+
+    snapshot_addr: Optional[int] = None
+    on_snapshot = None
+    if snapshot_at:
+        snapshot_addr = _resolve_snapshot_addr(snapshot_at, config)
+        out_path = snapshot_out or os.path.join(outdir, "snapshot.halsnap")
+        backend.set_breakpoint(snapshot_addr)
+        log.info("Will snapshot to %s when PC reaches 0x%08x",
+                 out_path, snapshot_addr)
+
+        def on_snapshot(b: "HalBackend") -> None:
+            from halucinator.snapshot import (DeviceLayer, save_snapshot_file,
+                                              system_snapshot)
+            # Only poll external devices when asked — the collection window
+            # costs a full timeout on every save, wasted if there are none.
+            dl = DeviceLayer() if snapshot_include_devices else None
+            snap = system_snapshot(b, portable=True, device_layer=dl)
+            p = save_snapshot_file(snap, out_path)
+            hal_log.getHalLogger().info(
+                "Snapshot written: %s (%d bytes) at pc=0x%08x — restore "
+                "with --restore %s", p, p.stat().st_size, b.regs.pc, p)
+
     log.info("Letting Unicorn Run (direct backend)")
     try:
-        _in_process_dispatch_loop(backend)
+        _in_process_dispatch_loop(backend, snapshot_at=snapshot_addr,
+                                  on_snapshot=on_snapshot)
     except KeyboardInterrupt:
         pass
     finally:
         _shutdown()
 
 
-def _in_process_dispatch_loop(backend: "HalBackend") -> None:
+def _in_process_dispatch_loop(backend: "HalBackend",
+                              snapshot_at: Optional[int] = None,
+                              on_snapshot: Optional[Any] = None) -> None:
     """
     Drive any in-process HalBackend (UnicornBackend, GhidraBackend, and
     anything else whose cont() blocks until a breakpoint fires). Read
     PC after each halt, dispatch to the registered bp_handler, and
     resume. Exits cleanly when cont() returns at an address that has
     no registered handler - i.e. the firmware ran off the rails.
+
+    snapshot_at/on_snapshot: --snapshot-at support — when PC first halts at
+    *snapshot_at*, call on_snapshot(backend) and return (snapshot-then-exit,
+    the boot-once workflow). Checked before intercept dispatch, so a
+    snapshot address that is also an intercept snapshots instead of running
+    the handler.
     """
     backend.cont()  # blocks until first breakpoint
     while True:
         pc = backend.read_register("pc") & ~1  # mask Thumb bit on ARM
+        if snapshot_at is not None and pc == (snapshot_at & ~1):
+            on_snapshot(backend)
+            return
         bp_id = intercepts.addr2bp_lut.get(pc)
         if bp_id is None:
             # An asynchronous IRQ (e.g. a TimerModel tick injected from a
@@ -1532,6 +1640,37 @@ def main() -> None:
         help="Just print the QEMU Command",
     )
     parser.add_argument(
+        "--snapshot-at",
+        default=None,
+        metavar="ADDR|SYMBOL",
+        help="Run until PC reaches this address (0x… or decimal) or symbol, "
+        "write a portable whole-machine snapshot, and exit. In-process "
+        "backends only (--emulator unicorn). See doc/snapshot_restore.md",
+    )
+    parser.add_argument(
+        "--snapshot-out",
+        default=None,
+        metavar="PATH",
+        help="Where --snapshot-at writes the snapshot "
+        "(default: tmp/<name>/snapshot.halsnap)",
+    )
+    parser.add_argument(
+        "--snapshot-include-devices",
+        action="store_true",
+        default=False,
+        help="Also capture external zmq device state in --snapshot-at "
+        "(costs a ~1s collection window; off by default since most "
+        "snapshots have no external devices)",
+    )
+    parser.add_argument(
+        "--restore",
+        default=None,
+        metavar="PATH",
+        help="Restore a .halsnap snapshot after setup, so execution resumes "
+        "from the checkpoint instead of the reset vector. Use the same "
+        "config files the snapshot was taken with",
+    )
+    parser.add_argument(
         "-q",
         "--qemu_args",
         nargs=argparse.REMAINDER,
@@ -1578,6 +1717,10 @@ def main() -> None:
         gdb_server_port=args.gdb_server_port,
         print_qemu_command=args.print_qemu_command,
         emulator=emulator,
+        snapshot_at=args.snapshot_at,
+        snapshot_out=args.snapshot_out,
+        snapshot_include_devices=args.snapshot_include_devices,
+        restore=args.restore,
     )
 
 

--- a/src/halucinator/mcp/server.py
+++ b/src/halucinator/mcp/server.py
@@ -252,6 +252,48 @@ def build_server(name: str = "halucinator", max_sessions: int = 4,
         return manager.call(session_id, "inject_irq", irq_num=irq_num)
 
     # ------------------------------------------------------------------
+    # Snapshot / restore (whole-machine checkpoints)
+    # ------------------------------------------------------------------
+
+    @mcp.tool()
+    def save_snapshot(path: Optional[str] = None,
+                      include_devices: bool = False,
+                      session_id: Optional[str] = None) -> Dict[str, Any]:
+        """Checkpoint the whole machine (guest CPU+RAM + python peripheral
+        state). Take it while stopped.
+
+        Without *path*: fast in-memory checkpoint — returns a snapshot_id
+        valid for this session only. With *path*: writes a portable .halsnap
+        file that survives the session (restore it here or in a future
+        session started from the same configs). include_devices=True also
+        polls external zmq device processes for their state (costs ~1s)."""
+        return manager.call(session_id, "save_snapshot", path=path,
+                            include_devices=include_devices)
+
+    @mcp.tool()
+    def restore_snapshot(snapshot_id: Optional[str] = None,
+                         path: Optional[str] = None,
+                         session_id: Optional[str] = None) -> Dict[str, Any]:
+        """Rewind the machine to a checkpoint: *snapshot_id* from an
+        in-memory save_snapshot, or *path* to a .halsnap file (exactly one).
+        Returns {ok, layer, message, pc}; on ok the machine resumes from the
+        snapshot's PC with cont()/step()."""
+        return manager.call(session_id, "restore_snapshot",
+                            snapshot_id=snapshot_id, path=path)
+
+    @mcp.tool()
+    def list_snapshots(session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """In-memory snapshot ids held by this session."""
+        return manager.call(session_id, "list_snapshots")
+
+    @mcp.tool()
+    def delete_snapshot(snapshot_id: str,
+                        session_id: Optional[str] = None) -> bool:
+        """Free an in-memory snapshot."""
+        return manager.call(session_id, "delete_snapshot",
+                            snapshot_id=snapshot_id)
+
+    # ------------------------------------------------------------------
     # Symbol + memory layout introspection
     # ------------------------------------------------------------------
 

--- a/src/halucinator/mcp/session.py
+++ b/src/halucinator/mcp/session.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import uuid
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -91,6 +92,9 @@ class HalucinatorSession:
     _last_run: _RunResult = field(default_factory=_RunResult)
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _worker: Optional[threading.Thread] = None
+    # In-memory checkpoints (snapshot_id -> SystemSnapshot). Live only as
+    # long as this worker process — use save_snapshot(path=...) to persist.
+    _snapshots: Dict[str, Any] = field(default_factory=dict)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -344,6 +348,12 @@ class HalucinatorSession:
         self.debug_breakpoints.clear()
         self.watchpoints.clear()
         self._intercept_addr_to_bp.clear()
+        for snap in self._snapshots.values():
+            try:
+                snap.release()
+            except Exception:  # noqa: BLE001
+                pass
+        self._snapshots.clear()
         self._running = False
         self._exited = False
         self._last_run = _RunResult()
@@ -649,6 +659,105 @@ class HalucinatorSession:
                 raise SessionError(str(exc)) from None
             except Exception as exc:  # noqa: BLE001
                 raise SessionError(f"inject_irq failed: {exc}") from None
+        return True
+
+    # ------------------------------------------------------------------
+    # Snapshot / restore (see doc/snapshot_restore.md)
+    # ------------------------------------------------------------------
+
+    def save_snapshot(self, path: Optional[str] = None,
+                      include_devices: bool = False,
+                      device_timeout: float = 1.0) -> Dict[str, Any]:
+        """Checkpoint the whole machine (guest CPU+RAM + peripheral models,
+        optionally external zmq devices).
+
+        Without *path*: fast in-memory checkpoint, returns a snapshot_id
+        (lives only as long as this session's worker). With *path*: portable
+        snapshot written to a .halsnap file that survives the process.
+        """
+        self.assert_active()
+        self.assert_idle()
+        from ..backends.hal_backend import SnapshotError
+        from ..snapshot import (DeviceLayer, save_snapshot_file,
+                                system_snapshot)
+        device_layer = (DeviceLayer(timeout=device_timeout)
+                        if include_devices else None)
+        with self._lock:
+            try:
+                snap = system_snapshot(self.backend, portable=bool(path),
+                                       device_layer=device_layer)
+            except (SnapshotError, RuntimeError) as exc:
+                raise SessionError(f"save_snapshot failed: {exc}") from None
+        pc = self.backend.read_register("pc")
+        if path:
+            try:
+                out = save_snapshot_file(snap, path)
+            except SnapshotError as exc:
+                raise SessionError(str(exc)) from None
+            finally:
+                snap.release()
+            return {"kind": "file", "path": str(out),
+                    "bytes": out.stat().st_size, "pc": pc,
+                    "devices": len(snap.devices)}
+        snap_id = f"snap-{uuid.uuid4().hex[:8]}"
+        self._snapshots[snap_id] = snap
+        return {"kind": "memory", "snapshot_id": snap_id, "pc": pc,
+                "devices": len(snap.devices)}
+
+    def restore_snapshot(self, snapshot_id: Optional[str] = None,
+                         path: Optional[str] = None,
+                         device_timeout: float = 1.0) -> Dict[str, Any]:
+        """Restore a checkpoint made by save_snapshot — *snapshot_id* for an
+        in-memory one, *path* for a .halsnap file (exactly one required)."""
+        self.assert_active()
+        self.assert_idle()
+        if bool(snapshot_id) == bool(path):
+            raise SessionError(
+                "restore_snapshot needs exactly one of snapshot_id / path")
+        from ..backends.hal_backend import Snapshot, SnapshotError
+        from ..snapshot import (DeviceLayer, SystemSnapshot,
+                                load_snapshot_file, system_restore)
+        if path:
+            try:
+                snap, _header = load_snapshot_file(path)
+            except SnapshotError as exc:
+                raise SessionError(str(exc)) from None
+            if isinstance(snap, Snapshot):  # backend-only file
+                snap = SystemSnapshot(backend=snap, peripherals={})
+        else:
+            snap = self._snapshots.get(snapshot_id)
+            if snap is None:
+                raise SessionError(
+                    f"no such snapshot: {snapshot_id!r} "
+                    f"(have: {sorted(self._snapshots) or 'none'})")
+        with self._lock:
+            result = system_restore(self.backend, snap,
+                                    device_layer=DeviceLayer(
+                                        timeout=device_timeout))
+        if result.ok:
+            # The machine is whole again at the snapshot's PC; a previous
+            # off-the-rails exit no longer describes it.
+            self._exited = False
+            self._last_run = _RunResult(
+                pc=self.backend.read_register("pc"), state="restored")
+        return {"ok": result.ok, "layer": result.layer,
+                "message": result.message,
+                "pc": self.backend.read_register("pc")}
+
+    def list_snapshots(self) -> List[Dict[str, Any]]:
+        """In-memory snapshot ids held by this session (files are yours to
+        track)."""
+        self.assert_active()
+        return [{"snapshot_id": sid, "devices": len(s.devices)}
+                for sid, s in sorted(self._snapshots.items())]
+
+    def delete_snapshot(self, snapshot_id: str) -> bool:
+        """Free an in-memory snapshot."""
+        self.assert_active()
+        snap = self._snapshots.pop(snapshot_id, None)
+        if snap is None:
+            raise SessionError(f"no such snapshot: {snapshot_id!r}")
+        snap.release()
         return True
 
     # ------------------------------------------------------------------

--- a/src/halucinator/peripheral_models/gpio.py
+++ b/src/halucinator/peripheral_models/gpio.py
@@ -18,6 +18,23 @@ class GPIO(object):
     # TODO: Should maybe be DefaultDict[int, bool] too
     gpio_state: DefaultDict[str, int] = defaultdict(int)
 
+    # ------------------------------------------------------------------
+    # Snapshot (Layer 2): the pin-level state map.
+    # ------------------------------------------------------------------
+    @classmethod
+    def save_state(cls) -> Dict[str, Any]:
+        import copy
+        return {"gpio_state": copy.deepcopy(cls.gpio_state)}
+
+    @classmethod
+    def restore_state(cls, state: Dict[str, Any]) -> bool:
+        """Restore pin state IN PLACE so any held alias stays valid."""
+        import copy
+        saved = copy.deepcopy(state.get("gpio_state", {}))
+        cls.gpio_state.clear()
+        cls.gpio_state.update(saved)
+        return True
+
     @classmethod
     @peripheral_server.tx_msg
     def write_pin(cls, gpio_id: str, value: int) -> Dict[str, Any]:

--- a/src/halucinator/peripheral_models/interrupts.py
+++ b/src/halucinator/peripheral_models/interrupts.py
@@ -30,6 +30,29 @@ class Interrupts:
     Active_Interrupts: Dict[Any, bool] = active  # alias used by tests
     enabled: Dict[int, bool] = defaultdict(bool)
 
+    # ------------------------------------------------------------------
+    # Snapshot (Layer 2): the active + enabled interrupt maps. Restore keeps
+    # ``Active_Interrupts`` pointing at the very same live ``active`` dict —
+    # code that captured that alias before the snapshot must keep working.
+    # ------------------------------------------------------------------
+    @classmethod
+    def save_state(cls) -> Dict[str, Any]:
+        import copy
+        return {"active": copy.deepcopy(cls.active),
+                "enabled": copy.deepcopy(cls.enabled)}
+
+    @classmethod
+    def restore_state(cls, state: Dict[str, Any]) -> bool:
+        import copy
+        cls.active.clear()
+        cls.active.update(copy.deepcopy(state.get("active", {})))
+        cls.enabled.clear()
+        cls.enabled.update(copy.deepcopy(state.get("enabled", {})))
+        # Re-point the alias at the same live dict (it never rebinds, but be
+        # explicit so the invariant is obvious).
+        cls.Active_Interrupts = cls.active
+        return True
+
     @classmethod
     @peripheral_server.reg_rx_handler
     def interrupt_request(cls, msg: Dict[str, Any]) -> None:

--- a/src/halucinator/peripheral_models/peripheral_server.py
+++ b/src/halucinator/peripheral_models/peripheral_server.py
@@ -21,6 +21,10 @@ log = logging.getLogger(__name__)
 # pylint: disable=global-statement
 
 __RX_HANDLERS__ = {}
+# Every class decorated with @peripheral_model, in registration order. The
+# snapshot layer (halucinator.snapshot.peripheral_registry) enumerates these
+# to capture/restore each model's host-side mutable state alongside the guest.
+__PERIPHERAL_MODELS__ = []
 __RX_CONTEXT__ = zmq.Context()
 __TX_CONTEXT__ = zmq.Context()
 __STOP_SERVER = False
@@ -54,6 +58,8 @@ def peripheral_model(cls: Type[Publisher]) -> Type[Publisher]:
     """
     Decorator which registers classes as peripheral models
     """
+    if cls not in __PERIPHERAL_MODELS__:
+        __PERIPHERAL_MODELS__.append(cls)
     methods = [
         getattr(cls, x) for x in dir(cls) if hasattr(getattr(cls, x), "is_rx_handler")
     ]
@@ -61,9 +67,15 @@ def peripheral_model(cls: Type[Publisher]) -> Type[Publisher]:
         key = f"Peripheral.{cls.__name__}.{method.__name__}"
         log.info("Adding method: %s", key)
         __RX_HANDLERS__[key] = (cls, method)
-        if __RX_SOCKET__ is not None:
-            log.info("Subscribing to: %s", key)
-            __RX_SOCKET__.setsockopt_string(zmq.SUBSCRIBE, key)
+        # Deliberately do NOT touch __RX_SOCKET__ here. This decorator can run
+        # on a different thread than run_server, which owns and is concurrently
+        # polling/recv'ing that SUB socket — zmq sockets are not thread-safe,
+        # so a cross-thread setsockopt races the poll. It is also unnecessary:
+        # run_server subscribes to b"" (ALL topics), so a model registered
+        # after start() is already covered. What matters here is the
+        # __RX_HANDLERS__ entry, which run_server consults to dispatch. (Topics
+        # registered before start() are subscribed by start() itself, on the
+        # caller thread, before run_server begins.)
 
     return cls
 

--- a/src/halucinator/peripheral_models/timer_model.py
+++ b/src/halucinator/peripheral_models/timer_model.py
@@ -33,6 +33,12 @@ class TimerModel(object):
         if name in cls.active_timers:
             (stop_event, t) = cls.active_timers[name]
             stop_event.set()
+            # Drop the entry so a later start_timer(name) can spawn a FRESH
+            # thread. Without this the stopped (dead) entry lingers and the
+            # `if name not in active_timers` guard in start_timer turns every
+            # re-arm into a no-op — e.g. GRBL's step timer never restarts for
+            # a second move. The signalled thread exits on its own stop_event.
+            del cls.active_timers[name]
 
     @classmethod
     def clear_timer(cls, irq_name: str) -> None:
@@ -43,6 +49,49 @@ class TimerModel(object):
     def shutdown(cls) -> None:
         for key, (stop_event, t) in list(cls.active_timers.items()):
             stop_event.set()
+
+    # -- snapshot (see doc/snapshot_restore.md) ------------------------
+    # active_timers holds live Event/Thread pairs — process-local plumbing
+    # the generic deep-copy can't (and shouldn't) capture. The machine
+    # state of a timer is its parameters; the thread is reconstructable.
+
+    @classmethod
+    def save_state(cls) -> Dict[str, dict]:
+        timers = {}
+        for name, (stop_event, t) in cls.active_timers.items():
+            timers[name] = {
+                "irq_num": t.irq_num,
+                "rate": t.rate,
+                "delay": t.delay,
+                "stopped": stop_event.is_set() or not t.is_alive(),
+            }
+        return {"timers": timers}
+
+    @classmethod
+    def restore_state(cls, state: Dict[str, dict]) -> bool:
+        """Stop every live timer, then relaunch the saved set. Tick phase is
+        not preserved — a restored periodic timer starts a fresh period,
+        which is indistinguishable to the guest.
+
+        Old timer threads are JOINED (not just signalled) before relaunching,
+        so a stale tick from a pre-restore timer can't fire an IRQ after
+        restore has reported success and the guest resumes."""
+        old = list(cls.active_timers.values())
+        for stop_event, _t in old:
+            stop_event.set()
+        # Event.set() wakes a thread parked in stopped.wait(rate) immediately;
+        # join with a bounded timeout so a wedged tick callback can't hang
+        # restore forever (the thread is a daemon and will not outlive us).
+        for _stop_event, t in old:
+            if t.is_alive():
+                t.join(timeout=2.0)
+        cls.active_timers.clear()
+        for name, cfg in state.get("timers", {}).items():
+            if cfg.get("stopped"):
+                continue
+            cls.start_timer(name, cfg["irq_num"], cfg["rate"],
+                            cfg.get("delay", 0))
+        return True
 
 
 class TimerIRQ(Thread):

--- a/src/halucinator/peripheral_models/uart.py
+++ b/src/halucinator/peripheral_models/uart.py
@@ -27,6 +27,26 @@ class UARTPublisher(object):
     # next run. Left clear during normal operation (reads block as before).
     abort_blocking: threading.Event = threading.Event()
 
+    # ------------------------------------------------------------------
+    # Snapshot (Layer 2): the per-uart rx buffers ARE machine state — a read
+    # blocked on pending input must resume identically after restore. The
+    # abort_blocking Event is control-plane, not state, so it is excluded.
+    # ------------------------------------------------------------------
+    @classmethod
+    def save_state(cls) -> Dict[str, Any]:
+        import copy
+        return {"rx_buffers": copy.deepcopy(cls.rx_buffers)}
+
+    @classmethod
+    def restore_state(cls, state: Dict[str, Any]) -> bool:
+        """Restore rx buffers IN PLACE (clear+refill) so a caller holding a
+        reference to ``rx_buffers`` still sees the restored contents."""
+        import copy
+        saved = copy.deepcopy(state.get("rx_buffers", {}))
+        cls.rx_buffers.clear()
+        cls.rx_buffers.update(saved)
+        return True
+
     @classmethod
     @peripheral_server.tx_msg
     def write(cls, uart_id: int, chars: bytes) -> Dict[str, Any]:

--- a/src/halucinator/qemu_targets/arm_qemu.py
+++ b/src/halucinator/qemu_targets/arm_qemu.py
@@ -18,6 +18,7 @@ from avatar2 import QemuTarget, TargetStates
 
 from halucinator import hal_log
 from halucinator.bp_handlers import intercepts
+from halucinator.qemu_targets.qemu_connect import RobustQemuConnectMixin
 
 log = logging.getLogger(__name__)
 hal_log = hal_log.getHalLogger()
@@ -66,7 +67,7 @@ class AllocedMemory:
         )
 
 
-class ARMQemuTarget(QemuTarget):
+class ARMQemuTarget(RobustQemuConnectMixin, QemuTarget):
     """
     Implements a QEMU target that has function args for use with
     halucinator.  Enables read/writing and returning from

--- a/src/halucinator/qemu_targets/hal_qemu.py
+++ b/src/halucinator/qemu_targets/hal_qemu.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from avatar2 import QemuTarget
 
+from halucinator.qemu_targets.qemu_connect import RobustQemuConnectMixin
+
 log = logging.getLogger(__name__)
 
 
@@ -47,7 +49,7 @@ class AllocedMemory:
         )
 
 
-class HALQemuTarget(QemuTarget):
+class HALQemuTarget(RobustQemuConnectMixin, QemuTarget):
     """
         Implements a QEMU target that has function args for use with
         halucinator.  Enables read/writing and returning from

--- a/src/halucinator/qemu_targets/powerpc_qemu.py
+++ b/src/halucinator/qemu_targets/powerpc_qemu.py
@@ -13,6 +13,7 @@ from collections import deque
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from avatar2 import Avatar, QemuTarget
+from halucinator.qemu_targets.qemu_connect import RobustQemuConnectMixin
 from capstone import *
 from keystone.keystone_const import *
 from unicorn import *
@@ -57,7 +58,7 @@ class AllocedMemory():
         self.size += block.size
         self.base_addr = self.base_addr if self.base_addr <= block.base_addr else block.base_addr
 
-class PowerPCQemuTarget(QemuTarget):
+class PowerPCQemuTarget(RobustQemuConnectMixin, QemuTarget):
     '''
         Implements a QEMU target that has function args for use with
         halucinator.  Enables read/writing and returning from

--- a/src/halucinator/qemu_targets/qemu_connect.py
+++ b/src/halucinator/qemu_targets/qemu_connect.py
@@ -1,0 +1,90 @@
+# Copyright 2020 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+# Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains
+# certain rights in this software.
+"""Robust QEMU GDB-socket connection for avatar2-backed targets.
+
+avatar2's ``QemuTarget.init()`` spawns QEMU with
+``-gdb unix:<path>,server,nowait`` and then *immediately* opens the GDB
+connection, with no wait for QEMU to come up. On a loaded machine (seen
+intermittently on the ubuntu-24.04 CI runner) QEMU has not yet created and
+listened on the unix socket by the time avatar2 connects, so the connect
+raises ``GDBProtocol was unable to connect`` and the whole emulation run dies
+before the guest ever executes.
+
+QEMU creates the socket during start-up init, *before* running the guest, so
+the socket file appearing is a sound readiness signal. This mixin waits
+(bounded) for that file to exist and retries the connect a few times, turning
+a fatal start-up race into a short, silent wait.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# Max seconds to wait for QEMU to create its GDB unix socket. Override via
+# HALUCINATOR_QEMU_CONNECT_TIMEOUT for unusually slow/loaded environments.
+_CONNECT_TIMEOUT = float(os.environ.get("HALUCINATOR_QEMU_CONNECT_TIMEOUT", "30"))
+# Attempts at the avatar2 GDB/QMP handshake once the socket exists. The wait
+# above closes the common race; the retries cover the nanosecond window
+# between QEMU's bind() (socket file appears) and listen().
+_CONNECT_RETRIES = 3
+
+
+class RobustQemuConnectMixin:
+    """Harden avatar2 ``QemuTarget._connect_protocols`` against the QEMU
+    start-up socket race.
+
+    Insert as the *first* base of a ``QemuTarget`` subclass so this override
+    wins in the MRO and ``super()`` still reaches avatar2's implementation::
+
+        class ARMQemuTarget(RobustQemuConnectMixin, QemuTarget):
+            ...
+
+    Only the avatar2 path (which calls ``init()`` -> ``_connect_protocols()``)
+    is affected; the direct ``QEMUBackend`` never invokes ``_connect_protocols``
+    and so is untouched.
+    """
+
+    def _connect_protocols(self):  # type: ignore[override]
+        sock = getattr(self, "gdb_unix_socket_path", None)
+        if sock:
+            self._wait_for_gdb_socket(sock)
+
+        last_exc: Optional[BaseException] = None
+        for attempt in range(1, _CONNECT_RETRIES + 1):
+            try:
+                return super()._connect_protocols()  # type: ignore[misc]
+            except Exception as exc:  # avatar2 raises a bare Exception on failure
+                last_exc = exc
+                proc = getattr(self, "_process", None)
+                if proc is not None and proc.poll() is not None:
+                    # QEMU has exited — retrying can't help.
+                    break
+                if attempt < _CONNECT_RETRIES:
+                    log.warning(
+                        "GDB connect attempt %d/%d failed (%s); retrying",
+                        attempt, _CONNECT_RETRIES, exc,
+                    )
+                    time.sleep(0.5)
+        assert last_exc is not None
+        raise last_exc
+
+    def _wait_for_gdb_socket(self, sock_path: str) -> None:
+        deadline = time.monotonic() + _CONNECT_TIMEOUT
+        while not os.path.exists(sock_path):
+            proc = getattr(self, "_process", None)
+            if proc is not None and proc.poll() is not None:
+                # QEMU died during start-up; let the connect surface the real
+                # error rather than blocking for the full timeout.
+                return
+            if time.monotonic() >= deadline:
+                log.warning(
+                    "QEMU GDB socket %s did not appear within %.0fs; "
+                    "attempting connect anyway", sock_path, _CONNECT_TIMEOUT,
+                )
+                return
+            time.sleep(0.02)

--- a/src/halucinator/snapshot/__init__.py
+++ b/src/halucinator/snapshot/__init__.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Christopher Wright
+
+"""Snapshot / restore for HALucinator — the foundation for fast state resume.
+
+Three layers, each with ``save_state``/``restore_state``, composed by a
+coordinator:
+
+  * Layer 1 — backend guest CPU + RAM (+ native device state): implemented on
+    ``HalBackend`` (generic fallback) and specialized per backend
+    (``UnicornBackend`` native, fast).
+  * Layer 2 — Python peripheral-model host state: :mod:`.peripheral_registry`.
+  * Layer 3 — external device processes: Phase 2 (not yet here).
+
+The coordinator (:mod:`.system_snapshot`) bundles the layers into a
+``SystemSnapshot`` and restores them together, reporting per-layer failures via
+``RestoreResult``.
+"""
+from __future__ import annotations
+
+from .peripheral_registry import (
+    PeripheralRegistry,
+    SnapshotableModel,
+    default_restore,
+    default_save,
+)
+from .device_layer import DeviceLayer
+from .persist import load_snapshot_file, save_snapshot_file
+from .system_snapshot import (
+    RestoreResult,
+    SystemSnapshot,
+    system_restore,
+    system_snapshot,
+)
+
+__all__ = [
+    "PeripheralRegistry",
+    "SnapshotableModel",
+    "default_save",
+    "default_restore",
+    "RestoreResult",
+    "SystemSnapshot",
+    "system_snapshot",
+    "system_restore",
+    "save_snapshot_file",
+    "load_snapshot_file",
+    "DeviceLayer",
+]

--- a/src/halucinator/snapshot/device_layer.py
+++ b/src/halucinator/snapshot/device_layer.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Christopher Wright
+
+"""Layer-3 snapshot: external zmq device-process state.
+
+External devices (``external_devices/*``, connected over the peripheral
+server's PUB/SUB ipc pipes) may hold state that is part of the machine — a
+protocol bridge's session counters, a panel's latched outputs. PUB/SUB has
+**no membership**: HALucinator cannot enumerate who is connected, so this
+layer is a *cooperative, opt-in* protocol with a collection window:
+
+  save:    HAL publishes  ``Peripheral.SnapshotDevices.save    {snapshot_id}``
+           devices reply  ``Peripheral.SnapshotDevices.state   {snapshot_id,
+                                                                device_id,
+                                                                state}``
+           HAL collects replies for ``timeout`` seconds; whoever answered is
+           in the snapshot.
+  restore: HAL publishes  ``Peripheral.SnapshotDevices.restore {snapshot_id,
+                                                                states}``
+           devices reply  ``Peripheral.SnapshotDevices.restored {snapshot_id,
+                                                                 device_id,
+                                                                 ok}``
+           every device captured in the snapshot must ack ok within
+           ``timeout`` or the restore reports failure (all-or-nothing, per
+           the snapshot contract — a missing device means the machine cannot
+           be brought back whole).
+
+Stateless devices (a uart terminal that only displays, bridges whose sockets
+cannot be checkpointed anyway) simply don't participate; they are absent from
+the snapshot and the contract ignores them. Device authors opt in with
+:class:`halucinator.external_devices.snapshotable.SnapshotableDevice`.
+
+This layer is opt-in on the HAL side too: pass a :class:`DeviceLayer` to
+``system_snapshot``/``system_restore`` to include it. The fast in-memory
+checkpoint path should NOT enable it — the collection window (a full
+``timeout`` every save, because membership is unknowable) is disk-checkpoint
+money, not per-input money.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from typing import Any, Dict
+
+from ..peripheral_models import peripheral_server
+from ..peripheral_models.peripheral_server import (
+    encode_zmq_msg,
+    peripheral_model,
+    reg_rx_handler,
+)
+
+log = logging.getLogger(__name__)
+
+
+@peripheral_model
+class SnapshotDevices:
+    """Rx-side collector for device replies, dispatched by the peripheral
+    server's existing topic router (``Peripheral.SnapshotDevices.*``).
+
+    Class-level dicts are transient plumbing, NOT machine state — the
+    explicit no-op save/restore below keeps the Layer-2 registry from
+    capturing them (a snapshot of the snapshot machinery would be turtles
+    all the way down).
+    """
+
+    _lock = threading.Lock()
+    # snapshot_id -> {device_id: state}
+    collected: Dict[str, Dict[str, Any]] = {}
+    # snapshot_id -> {device_id: ok(bool)}
+    acked: Dict[str, Dict[str, bool]] = {}
+
+    @classmethod
+    @reg_rx_handler
+    def state(cls, msg: Dict[str, Any]) -> None:
+        snap_id = msg.get("snapshot_id")
+        device_id = msg.get("device_id")
+        if snap_id is None or device_id is None:
+            log.error("SnapshotDevices.state: malformed reply %r", msg)
+            return
+        with cls._lock:
+            if snap_id not in cls.collected:
+                log.warning("SnapshotDevices.state: reply for unknown/expired "
+                            "snapshot %s from %s; dropped", snap_id, device_id)
+                return
+            cls.collected[snap_id][device_id] = msg.get("state")
+
+    @classmethod
+    @reg_rx_handler
+    def restored(cls, msg: Dict[str, Any]) -> None:
+        snap_id = msg.get("snapshot_id")
+        device_id = msg.get("device_id")
+        if snap_id is None or device_id is None:
+            log.error("SnapshotDevices.restored: malformed ack %r", msg)
+            return
+        with cls._lock:
+            if snap_id not in cls.acked:
+                log.warning("SnapshotDevices.restored: ack for unknown/expired "
+                            "restore %s from %s; dropped", snap_id, device_id)
+                return
+            cls.acked[snap_id][device_id] = bool(msg.get("ok"))
+
+    # -- Layer-2 registry: nothing here is machine state ------------------
+    @classmethod
+    def save_state(cls) -> Dict[str, Any]:
+        return {}
+
+    @classmethod
+    def restore_state(cls, _state: Dict[str, Any]) -> bool:
+        return True
+
+
+def _publish(topic: str, data: Dict[str, Any]) -> bool:
+    """Publish on the peripheral server's TX socket. False if the server
+    isn't running (no socket)."""
+    sock = peripheral_server.__TX_SOCKET__
+    if sock is None:
+        return False
+    sock.send_string(encode_zmq_msg(topic, data))
+    return True
+
+
+class DeviceLayer:
+    """Save/restore external device state over the peripheral server.
+
+    ``timeout`` is the collection window (seconds). It is paid in full on
+    every ``snapshot()`` — PUB/SUB anonymity means there is no "everyone has
+    answered" signal, only "the window closed".
+    """
+
+    SAVE_TOPIC = "Peripheral.SnapshotDevices.save"
+    RESTORE_TOPIC = "Peripheral.SnapshotDevices.restore"
+
+    def __init__(self, timeout: float = 1.0, poll_interval: float = 0.02):
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+
+    def available(self) -> bool:
+        """True when the peripheral server is up (there is a TX socket)."""
+        return peripheral_server.__TX_SOCKET__ is not None
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Collect state from every participating device. Returns
+        ``{device_id: state}`` — empty when no server is running or nothing
+        answered (both legitimate: a fleet of stateless devices)."""
+        snap_id = uuid.uuid4().hex
+        with SnapshotDevices._lock:
+            SnapshotDevices.collected[snap_id] = {}
+        try:
+            if not _publish(self.SAVE_TOPIC, {"snapshot_id": snap_id}):
+                log.debug("DeviceLayer.snapshot: peripheral server not "
+                          "running; empty device layer")
+                return {}
+            deadline = time.time() + self.timeout
+            while time.time() < deadline:
+                time.sleep(self.poll_interval)
+            with SnapshotDevices._lock:
+                states = dict(SnapshotDevices.collected[snap_id])
+        finally:
+            with SnapshotDevices._lock:
+                SnapshotDevices.collected.pop(snap_id, None)
+        log.info("DeviceLayer.snapshot: captured %d device(s)%s",
+                 len(states),
+                 (": " + ", ".join(sorted(states))) if states else "")
+        return states
+
+    def restore(self, states: Dict[str, Any]) -> bool:
+        """Push captured state back to the devices. All-or-nothing: every
+        device in *states* must ack ok within the window, else False. An
+        empty *states* is trivially True (nothing was captured)."""
+        if not states:
+            return True
+        snap_id = uuid.uuid4().hex
+        with SnapshotDevices._lock:
+            SnapshotDevices.acked[snap_id] = {}
+        try:
+            if not _publish(self.RESTORE_TOPIC,
+                            {"snapshot_id": snap_id, "states": states}):
+                log.error("DeviceLayer.restore: %d captured device(s) but "
+                          "the peripheral server is not running",
+                          len(states))
+                return False
+            deadline = time.time() + self.timeout
+            while time.time() < deadline:
+                with SnapshotDevices._lock:
+                    acks = dict(SnapshotDevices.acked[snap_id])
+                if (set(acks) >= set(states)
+                        and all(acks[d] for d in states)):
+                    return True  # everyone in, early exit — acks have membership
+                if any(d in acks and not acks[d] for d in states):
+                    break  # an explicit NACK can't improve; fail now
+                time.sleep(self.poll_interval)
+            with SnapshotDevices._lock:
+                acks = dict(SnapshotDevices.acked[snap_id])
+        finally:
+            with SnapshotDevices._lock:
+                SnapshotDevices.acked.pop(snap_id, None)
+        missing = sorted(set(states) - set(acks))
+        nacked = sorted(d for d in states if d in acks and not acks[d])
+        log.error("DeviceLayer.restore failed: missing ack from %s; "
+                  "nack from %s", missing or "-", nacked or "-")
+        return False

--- a/src/halucinator/snapshot/peripheral_registry.py
+++ b/src/halucinator/snapshot/peripheral_registry.py
@@ -1,0 +1,192 @@
+# Copyright 2026 Christopher Wright
+
+"""Layer-2 snapshot: Python host-side peripheral-model state.
+
+Every backend forwards MMIO to Python peripheral models, so their *class-level*
+mutable state (rx buffers, gpio pins, interrupt maps, handler instance dicts,
+run stats) is part of the machine state and must be captured/restored alongside
+the guest CPU+RAM. This module enumerates those state holders and snapshots them.
+
+Two capture strategies, in priority order:
+
+1. **Explicit** — a model that defines ``save_state()``/``restore_state()``
+   (uart, gpio, interrupts) knows exactly which fields are state and restores
+   them IN PLACE (so external aliases stay valid). Preferred: nothing is missed.
+2. **Generic deep-copy** — for everything else (bp-handler instances, models
+   without an explicit impl), :func:`default_save` deep-copies every mutable
+   container attribute and :func:`default_restore` writes it back in place.
+
+The ``SnapshotableModel`` mixin exposes strategy 2 as the default so a model can
+opt in just by inheriting it.
+"""
+from __future__ import annotations
+
+import copy
+import logging
+from collections import deque
+from typing import Any, Dict
+
+log = logging.getLogger(__name__)
+
+# Container types we know how to deep-copy AND restore in place (clear+refill),
+# which is what preserves aliases like Interrupts.Active_Interrupts is active.
+_MUTABLE = (dict, list, set, deque, bytearray)
+
+
+def _snapshotable_attrs(obj: Any) -> Dict[str, Any]:
+    """Return {name: value} for each mutable-container attribute of *obj*
+    (a class or instance) — dunder and callable attributes excluded."""
+    out: Dict[str, Any] = {}
+    for name in dir(obj):
+        if name.startswith("__"):
+            continue
+        try:
+            value = getattr(obj, name)
+        except Exception:  # noqa: BLE001 -- descriptor may raise; skip it
+            continue
+        if callable(value):
+            continue
+        if isinstance(value, _MUTABLE):
+            out[name] = value
+    return out
+
+
+def default_save(obj: Any) -> Dict[str, Any]:
+    """Deep-copy every mutable container attribute of *obj*. Generic strategy
+    for objects without an explicit ``save_state``."""
+    return {name: copy.deepcopy(value)
+            for name, value in _snapshotable_attrs(obj).items()}
+
+
+def _restore_in_place(current: Any, saved: Any) -> bool:
+    """Overwrite *current* container's contents with *saved* (a deep copy),
+    mutating in place so aliases survive. Returns False if the shapes don't
+    match a known container pair (caller falls back to setattr).
+
+    The deep copy happens INSIDE the matching branch, so the type-mismatch
+    fallback doesn't copy here and then copy again in the caller's setattr."""
+    if isinstance(current, dict) and isinstance(saved, dict):
+        current.clear()
+        current.update(copy.deepcopy(saved))
+    elif isinstance(current, (list, deque)) and isinstance(saved, (list, deque)):
+        current.clear()
+        current.extend(copy.deepcopy(saved))
+    elif isinstance(current, set) and isinstance(saved, set):
+        current.clear()
+        current.update(copy.deepcopy(saved))
+    elif isinstance(current, bytearray) and isinstance(saved, (bytes, bytearray)):
+        current[:] = saved  # slice-assign copies; bytes/bytearray are flat
+    else:
+        return False
+    return True
+
+
+def default_restore(obj: Any, state: Dict[str, Any]) -> bool:
+    """Inverse of :func:`default_save`. Restores each attribute IN PLACE when
+    it is still a matching live container (preserving aliases), else rebinds."""
+    for name, saved in state.items():
+        current = getattr(obj, name, None)
+        if not _restore_in_place(current, saved):
+            setattr(obj, name, copy.deepcopy(saved))
+    return True
+
+
+class SnapshotableModel:
+    """Mixin giving a peripheral model the generic deep-copy snapshot behavior
+    as classmethods. Models that need to exclude fields or restore differently
+    override ``save_state``/``restore_state`` directly (uart/gpio/interrupts do)."""
+
+    @classmethod
+    def save_state(cls) -> Dict[str, Any]:
+        return default_save(cls)
+
+    @classmethod
+    def restore_state(cls, state: Dict[str, Any]) -> bool:
+        return default_restore(cls, state)
+
+
+def _save_one(obj: Any) -> Dict[str, Any]:
+    """Capture one target using its explicit save_state if present, else generic."""
+    save = getattr(obj, "save_state", None)
+    if callable(save):
+        return save()
+    return default_save(obj)
+
+
+def _restore_one(obj: Any, state: Dict[str, Any]) -> bool:
+    """Restore one target using its explicit restore_state if present, else generic."""
+    restore = getattr(obj, "restore_state", None)
+    if callable(restore):
+        return bool(restore(state))
+    return default_restore(obj, state)
+
+
+class PeripheralRegistry:
+    """Enumerates the Layer-2 state holders and save/restores them as a unit.
+
+    Sources (all discovered live at snapshot time so nothing is hard-coded):
+      * every ``@peripheral_model`` class (``peripheral_server.__PERIPHERAL_MODELS__``)
+      * every cached bp-handler instance (``intercepts.initalized_classes``)
+      * the global ``hal_stats.stats`` dict
+
+    Targets are keyed by a stable string so restore re-resolves the same live
+    object. ``restore`` returns False (without half-applying) if a snapshot
+    entry has no matching live target — an inconsistency the caller must handle.
+    """
+
+    STATS_KEY = "hal_stats.stats"
+
+    def _models(self) -> Dict[str, Any]:
+        from ..peripheral_models import peripheral_server
+        out: Dict[str, Any] = {}
+        for cls in peripheral_server.__PERIPHERAL_MODELS__:
+            out[f"model:{cls.__module__}.{cls.__qualname__}"] = cls
+        return out
+
+    def _handlers(self) -> Dict[str, Any]:
+        from ..bp_handlers import intercepts
+        out: Dict[str, Any] = {}
+        for key, inst in intercepts.initalized_classes.items():
+            out[f"handler:{key}"] = inst
+        return out
+
+    def _targets(self) -> Dict[str, Any]:
+        """All live save/restore targets except hal_stats (handled specially)."""
+        targets = self._models()
+        targets.update(self._handlers())
+        return targets
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Capture every Layer-2 target. Raises on any failure (never partial):
+        a peripheral snapshot is whole or it does not exist."""
+        from .. import hal_stats
+        try:
+            captured = {key: _save_one(obj)
+                        for key, obj in self._targets().items()}
+            captured[self.STATS_KEY] = copy.deepcopy(hal_stats.stats)
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                f"PeripheralRegistry.snapshot failed: {exc!r}") from exc
+        return captured
+
+    def restore(self, state: Dict[str, Any]) -> bool:
+        """Restore every captured target. Returns False (before mutating) if a
+        captured target is no longer live, so restore is all-or-nothing."""
+        from .. import hal_stats
+        targets = self._targets()
+        for key in state:
+            if key == self.STATS_KEY:
+                continue
+            if key not in targets:
+                log.error("PeripheralRegistry.restore: target %s no longer "
+                          "present; refusing partial restore", key)
+                return False
+        for key, saved in state.items():
+            if key == self.STATS_KEY:
+                hal_stats.stats.clear()
+                hal_stats.stats.update(copy.deepcopy(saved))
+                continue
+            if not _restore_one(targets[key], saved):
+                log.error("PeripheralRegistry.restore: target %s failed", key)
+                return False
+        return True

--- a/src/halucinator/snapshot/persist.py
+++ b/src/halucinator/snapshot/persist.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Christopher Wright
+
+"""Disk persistence for snapshots: survive process death.
+
+The in-memory ``Snapshot`` / ``SystemSnapshot`` objects are checkpoint-fast but
+die with the process. This module serializes them to a single compressed file
+so a snapshot taken in one run can be restored in a *fresh* process (same
+config, freshly-init'd backend) — the boot-once / iterate-forever workflow.
+
+Only PORTABLE snapshots may be persisted: a raw unicorn context blob pickles
+happily but embeds process-local pointers, and restoring one in another
+process SIGBUSes (verified empirically — same unicorn build, same CPU model).
+``save_snapshot_file`` therefore rejects a snapshot holding a native context
+and tells the caller to capture with ``save_state(portable=True)`` /
+``system_snapshot(..., portable=True)``.
+
+Format: one gzip stream (level 1 -- guest RAM is mostly zeros, so the cheap
+level already compresses well) containing a pickled ``(header, payload)`` tuple.
+The header is validated BEFORE the payload is handed to the caller, per the
+snapshot contract (reject cleanly, never mutate on mismatch): ``magic`` /
+``format_version`` gate files we don't understand; ``unicorn_version`` is
+recorded for provenance and logged (warning) on mismatch — harmless for
+portable payloads, but worth seeing in a debug log.
+
+Writes are atomic: serialize to a temp file in the destination directory, then
+``os.replace`` — a failed save never leaves a partial file behind.
+
+The backend-compat check (``backend_type`` + ``SNAPSHOT_VERSION``) stays where
+it already lives: ``HalBackend.restore_state`` validates before mutating.
+"""
+from __future__ import annotations
+
+import gzip
+import logging
+import os
+import pickle
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Optional, Tuple, Union
+
+from ..backends.hal_backend import Snapshot, SnapshotError
+from .system_snapshot import SystemSnapshot
+
+log = logging.getLogger(__name__)
+
+MAGIC = "HALSNAP"
+FORMAT_VERSION = 1
+
+# gzip level 1: guest RAM is overwhelmingly zeros, so even the fastest level
+# crushes it; higher levels just burn wall-clock on multi-MB images.
+_GZIP_LEVEL = 1
+
+
+def _unicorn_version() -> Optional[str]:
+    try:
+        import unicorn
+        return str(unicorn.__version__)
+    except ImportError:
+        return None
+
+
+def _backend_snap(payload: Union[Snapshot, SystemSnapshot]) -> Snapshot:
+    return payload.backend if isinstance(payload, SystemSnapshot) else payload
+
+
+def _reject_nonportable(payload: Union[Snapshot, SystemSnapshot]) -> None:
+    """A native uc context blob is process-local (it pickles, but restoring
+    it in another process crashes) — refuse it up front with the fix."""
+    data = _backend_snap(payload).data
+    if isinstance(data, dict) and "context" in data:
+        raise SnapshotError(
+            "save_snapshot_file: this snapshot holds a process-local native "
+            "CPU context and cannot be persisted. Capture it with "
+            "save_state(portable=True) / system_snapshot(..., portable=True) "
+            "instead.")
+
+
+def save_snapshot_file(payload: Union[Snapshot, SystemSnapshot],
+                       path: Union[str, Path]) -> Path:
+    """Serialize *payload* (a backend ``Snapshot`` or a whole
+    ``SystemSnapshot``) to *path*. Atomic: on any failure the destination is
+    untouched. Raises ``SnapshotError`` on unpicklable state.
+    """
+    path = Path(path)
+    _reject_nonportable(payload)
+    backend_snap = _backend_snap(payload)
+    header = {
+        "magic": MAGIC,
+        "format_version": FORMAT_VERSION,
+        "kind": "system" if isinstance(payload, SystemSnapshot) else "backend",
+        "backend_type": backend_snap.backend_type,
+        "snapshot_version": backend_snap.version,
+        "unicorn_version": (_unicorn_version()
+                            if backend_snap.backend_type == "UnicornBackend"
+                            else None),
+        "created": time.time(),
+    }
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent,
+                                    prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as raw, \
+                gzip.GzipFile(fileobj=raw, mode="wb",
+                              compresslevel=_GZIP_LEVEL) as gz:
+            pickle.dump((header, payload), gz, protocol=pickle.HIGHEST_PROTOCOL)
+        os.replace(tmp_name, path)
+    except Exception as exc:  # noqa: BLE001
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise SnapshotError(
+            f"save_snapshot_file({path}): serialization failed: {exc!r}"
+        ) from exc
+    log.info("snapshot saved: %s (%d bytes, kind=%s, backend=%s)",
+             path, path.stat().st_size, header["kind"], header["backend_type"])
+    return path
+
+
+def load_snapshot_file(path: Union[str, Path],
+                       ) -> Tuple[Union[Snapshot, SystemSnapshot], dict]:
+    """Load a snapshot file. Returns ``(payload, header)`` where payload is the
+    ``Snapshot`` / ``SystemSnapshot`` ready for ``restore_state`` /
+    ``system_restore``.
+
+    Raises ``SnapshotError`` if the file is not a HALucinator snapshot or is a
+    format we don't understand. The header is validated before the payload is
+    returned so a bad file can never reach a restore path.
+    """
+    path = Path(path)
+    try:
+        with gzip.open(path, "rb") as gz:
+            header, payload = pickle.load(gz)
+    except SnapshotError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise SnapshotError(
+            f"load_snapshot_file({path}): not a readable snapshot file: {exc!r}"
+        ) from exc
+
+    if not isinstance(header, dict) or header.get("magic") != MAGIC:
+        raise SnapshotError(f"load_snapshot_file({path}): bad magic — "
+                            "not a HALucinator snapshot file")
+    if header.get("format_version") != FORMAT_VERSION:
+        raise SnapshotError(
+            f"load_snapshot_file({path}): format_version="
+            f"{header.get('format_version')} not supported "
+            f"(this build reads {FORMAT_VERSION})")
+
+    saved_uc = header.get("unicorn_version")
+    if saved_uc is not None:
+        current_uc = _unicorn_version()
+        if current_uc != saved_uc:
+            log.warning("load_snapshot_file(%s): produced under unicorn %s, "
+                        "loading under %s (portable payload — expected to be "
+                        "fine, noted for provenance)",
+                        path, saved_uc, current_uc or "none")
+
+    expected = SystemSnapshot if header.get("kind") == "system" else Snapshot
+    if not isinstance(payload, expected):
+        raise SnapshotError(
+            f"load_snapshot_file({path}): header kind={header.get('kind')!r} "
+            f"but payload is {type(payload).__name__}")
+    return payload, header

--- a/src/halucinator/snapshot/system_snapshot.py
+++ b/src/halucinator/snapshot/system_snapshot.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Christopher Wright
+
+"""Composite system snapshot: bundles Layer-1 (backend guest CPU+RAM, +native
+device state where the emulator has it), Layer-2 (Python peripheral-model
+state), and optionally Layer-3 (external zmq device processes) into a single
+checkpoint, and restores them together.
+
+Layer 3 is opt-in per call (pass a ``DeviceLayer``): its collection window
+costs a full timeout on every save, which is disk-checkpoint money, not
+per-restore money — see snapshot/device_layer.py.
+
+Failure contract (per the design):
+  * ``system_snapshot`` raises (via the layers' own ``SnapshotError`` /
+    RuntimeError) rather than returning a half-captured bundle.
+  * ``system_restore`` restores backend, THEN peripherals, THEN devices; on
+    the first layer that returns False it stops and reports which layer
+    failed, so the caller never resumes a half-restored machine.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from ..backends.hal_backend import HalBackend, Snapshot
+from .peripheral_registry import PeripheralRegistry
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class RestoreResult:
+    """Outcome of :func:`system_restore`. ``ok`` is the headline; on failure
+    ``layer`` names the layer that refused ("backend"/"peripherals") and
+    ``message`` explains. The machine is inconsistent when ``ok`` is False —
+    the caller must re-init rather than resume."""
+
+    ok: bool
+    layer: Optional[str] = None
+    message: str = ""
+
+
+@dataclass
+class SystemSnapshot:
+    """A whole-system checkpoint. Only constructed once every layer captured
+    successfully, so possessing one means it is complete. ``devices`` is
+    empty unless a DeviceLayer participated (and may legitimately be empty
+    with one — a fleet of stateless devices)."""
+
+    backend: Snapshot
+    peripherals: Any  # opaque dict from PeripheralRegistry.snapshot()
+    devices: Dict[str, Any] = field(default_factory=dict)
+    _released: bool = False
+
+    def release(self) -> None:
+        """Free resources held by every layer. Idempotent."""
+        if self._released:
+            return
+        try:
+            self.backend.release()
+        finally:
+            self._released = True
+
+    def __enter__(self) -> "SystemSnapshot":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.release()
+
+
+def system_snapshot(backend: HalBackend,
+                    registry: Optional[PeripheralRegistry] = None,
+                    portable: bool = False,
+                    device_layer: Optional[Any] = None) -> SystemSnapshot:
+    """Capture backend + peripheral (+ optionally device) state as one bundle.
+
+    ``portable=True`` requests a picklable, cross-process-safe backend
+    capture — required when the bundle is destined for disk
+    (:mod:`.persist`). The peripheral layer is plain python either way.
+
+    ``device_layer`` (a :class:`.device_layer.DeviceLayer`) opts Layer 3 in:
+    external zmq devices are polled for their state inside the capture.
+
+    Raises ``SnapshotError`` (backend) or ``RuntimeError`` (peripherals) on any
+    failure — a partial capture is discarded, never returned. Take this with the
+    guest stopped so the layers are consistent.
+    """
+    if registry is None:
+        registry = PeripheralRegistry()
+    backend_snap = backend.save_state(portable=portable)  # raises SnapshotError on failure
+    try:
+        periph_snap = registry.snapshot()        # raises on failure
+        devices = device_layer.snapshot() if device_layer is not None else {}
+    except Exception:
+        backend_snap.release()                   # don't leak the half-bundle
+        raise
+    return SystemSnapshot(backend=backend_snap, peripherals=periph_snap,
+                          devices=devices)
+
+
+def system_restore(backend: HalBackend, snap: SystemSnapshot,
+                   registry: Optional[PeripheralRegistry] = None,
+                   device_layer: Optional[Any] = None) -> RestoreResult:
+    """Restore a :class:`SystemSnapshot`: backend, then peripherals, then
+    (when captured) external devices.
+
+    Stops at the first layer that returns False and reports it. No layer is
+    restored past a failure, so the caller gets a clear "inconsistent, re-init"
+    signal instead of a silently half-restored machine.
+    """
+    if registry is None:
+        registry = PeripheralRegistry()
+
+    if not backend.restore_state(snap.backend):
+        return RestoreResult(
+            ok=False, layer="backend",
+            message="backend.restore_state returned False "
+                    "(incompatible snapshot or restore error)")
+
+    if not registry.restore(snap.peripherals):
+        return RestoreResult(
+            ok=False, layer="peripherals",
+            message="peripheral registry restore returned False "
+                    "(a captured target is missing or failed)")
+
+    # `devices` is absent on snapshots pickled before Layer 3 existed —
+    # treat those as empty (nothing was captured, nothing to push back).
+    devices = getattr(snap, "devices", {}) or {}
+    if devices:
+        if device_layer is None:
+            return RestoreResult(
+                ok=False, layer="devices",
+                message=f"snapshot captured {len(devices)} external "
+                        "device(s) but no DeviceLayer was passed to "
+                        "system_restore")
+        if not device_layer.restore(devices):
+            return RestoreResult(
+                ok=False, layer="devices",
+                message="device layer restore failed (a captured device "
+                        "is missing, silent, or nacked)")
+
+    return RestoreResult(ok=True,
+                         message="restored backend + peripherals"
+                                 + (" + devices" if devices else ""))

--- a/test/firmware-rehosting/bpv5/run_tests.bash
+++ b/test/firmware-rehosting/bpv5/run_tests.bash
@@ -20,8 +20,8 @@
 # Expected pass time: ~60s on unicorn, ~120s on avatar2+qemu.
 # Hard timeout: 300s.
 
-set -e
 set +m  # disable job-control notifications ("Terminated: 15" on cleanup)
+# NB: no `set -e` — the retry loop below handles failures explicitly.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -38,61 +38,90 @@ else
 fi
 TIMEOUT="${BPV5_SMOKE_TIMEOUT:-${BPV5_TIMEOUT:-300}}"
 EXIT_MARKER="${BPV5_SMOKE_EXIT_MARKER:-work with pins}"
-
-# --- cleanup -------------------------------------------------------------
-pkill -9 -f qemu-system-arm   2>/dev/null || true
-pkill -9 -f halucinator       2>/dev/null || true
-pkill -9 -f bpv5_terminal     2>/dev/null || true
-pkill -9 -f gdb-multiarch     2>/dev/null || true
-sleep 1
-rm -f bpv5_hal.log bpv5_dev.log
-
-# --- launch the device FIRST --------------------------------------------
-# Ordering matters on the in-process unicorn backend: it boots to the
-# banner in well under a second, so if halucinator publishes the banner
-# before the device's ZMQ SUB socket is connected, those bytes are lost
-# to the PUB/SUB slow-joiner window and the device never sees a first
-# tx_buf (so it never sends its --prelude). Starting the device first and
-# giving its SUB a moment to bind closes that race. (qemu/avatar2 boot
-# slowly enough that the original order also worked.)
-echo "=== Launching bpv5_terminal in scripted mode ==="
+# Retry the whole run a few times: on avatar2/qemu the emulator can
+# transiently fail to spin up (e.g. "GDBProtocol was unable to connect" when
+# QEMU's gdbstub isn't listening yet). Those are startup races, not firmware
+# failures — a fresh spawn succeeds. Genuine breakage still fails all attempts.
+ATTEMPTS="${BPV5_SMOKE_ATTEMPTS:-3}"
 export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}src:."
-python3 -m halucinator.external_devices.bpv5_terminal \
-        --script 'h\r\n' \
-        --script-delay 3 \
-        --exit-on "${EXIT_MARKER}" \
-        --max-runtime "${TIMEOUT}" \
-        >bpv5_dev.log 2>&1 &
-DEV_PID=$!
 
-# Let the device's SUB socket connect before halucinator publishes.
-sleep 3
+_cleanup() {
+    pkill -9 -f qemu-system-arm   2>/dev/null || true
+    pkill -9 -f halucinator       2>/dev/null || true
+    pkill -9 -f bpv5_terminal     2>/dev/null || true
+    pkill -9 -f gdb-multiarch     2>/dev/null || true
+}
 
-# --- launch halucinator --------------------------------------------------
-echo "=== Launching halucinator (--emulator $EMULATOR) ==="
-HAL_EMULATOR="$EMULATOR" "$SCRIPT_DIR/run.sh" >bpv5_hal.log 2>&1 &
-HAL_PID=$!
+# One attempt. Returns 0 = pass, 2 = halucinator died at startup (transient,
+# worth retrying), 1 = device ran but the exit marker was not seen.
+run_attempt() {
+    _cleanup
+    sleep 1
+    rm -f bpv5_hal.log bpv5_dev.log
 
-# --- wait for the device to finish (marker seen or --max-runtime) --------
-if wait "$DEV_PID"; then
-    DEV_RC=0
-else
-    DEV_RC=$?
-fi
+    # --- launch the device FIRST ----------------------------------------
+    # Ordering matters on the in-process unicorn backend: it boots to the
+    # banner in well under a second, so if halucinator publishes the banner
+    # before the device's ZMQ SUB socket is connected, those bytes are lost
+    # to the PUB/SUB slow-joiner window and the device never sees a first
+    # tx_buf (so it never sends its --prelude). Starting the device first and
+    # giving its SUB a moment to bind closes that race. (qemu/avatar2 boot
+    # slowly enough that the original order also worked.)
+    echo "=== Launching bpv5_terminal in scripted mode ==="
+    python3 -m halucinator.external_devices.bpv5_terminal \
+            --script 'h\r\n' \
+            --script-delay 3 \
+            --exit-on "${EXIT_MARKER}" \
+            --max-runtime "${TIMEOUT}" \
+            >bpv5_dev.log 2>&1 &
+    DEV_PID=$!
 
-# --- evaluate ------------------------------------------------------------
-if [[ "$DEV_RC" -eq 0 ]] && grep -q "exit marker .* seen" bpv5_dev.log; then
-    echo "=== bpv5 smoke test PASSED (--emulator $EMULATOR) ==="
+    # Let the device's SUB socket connect before halucinator publishes.
+    sleep 3
+
+    # --- launch halucinator ---------------------------------------------
+    echo "=== Launching halucinator (--emulator $EMULATOR) ==="
+    HAL_EMULATOR="$EMULATOR" "$SCRIPT_DIR/run.sh" >bpv5_hal.log 2>&1 &
+    HAL_PID=$!
+
+    # Wait for the device to finish, but bail out FAST if halucinator dies
+    # first (a startup crash) instead of blocking on the device's full
+    # --max-runtime. On unicorn/qemu halucinator runs until we kill it, so
+    # the loop simply waits for the device.
+    local DEV_RC
+    while kill -0 "$DEV_PID" 2>/dev/null; do
+        if ! kill -0 "$HAL_PID" 2>/dev/null; then
+            echo "=== halucinator exited before the device finished (startup failure) ==="
+            kill "$DEV_PID" 2>/dev/null || true
+            wait "$DEV_PID" 2>/dev/null || true
+            return 2
+        fi
+        sleep 1
+    done
+    wait "$DEV_PID"; DEV_RC=$?
     { kill "$HAL_PID"; wait "$HAL_PID"; } 2>/dev/null || true
     pkill -9 -f qemu-system-arm 2>/dev/null || true
-    exit 0
-fi
 
-echo "=== bpv5 smoke test FAILED (--emulator $EMULATOR, device exit=$DEV_RC) ==="
-echo "--- last 30 lines of bpv5_dev.log ---"
-tail -30 bpv5_dev.log || true
-echo "--- last 50 lines of bpv5_hal.log ---"
-tail -50 bpv5_hal.log || true
-{ kill "$HAL_PID"; wait "$HAL_PID"; } 2>/dev/null || true
-pkill -9 -f qemu-system-arm 2>/dev/null || true
+    if [[ "$DEV_RC" -eq 0 ]] && grep -q "exit marker .* seen" bpv5_dev.log; then
+        return 0
+    fi
+    return 1
+}
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+    echo "########## bpv5 smoke attempt $attempt/$ATTEMPTS (--emulator $EMULATOR) ##########"
+    if run_attempt; then
+        echo "=== bpv5 smoke test PASSED (--emulator $EMULATOR, attempt $attempt) ==="
+        exit 0
+    fi
+    rc=$?
+    echo "=== bpv5 smoke attempt $attempt failed (rc=$rc) ==="
+    echo "--- last 30 lines of bpv5_dev.log ---"
+    tail -30 bpv5_dev.log 2>/dev/null || true
+    echo "--- last 50 lines of bpv5_hal.log ---"
+    tail -50 bpv5_hal.log 2>/dev/null || true
+done
+
+echo "=== bpv5 smoke test FAILED after $ATTEMPTS attempts (--emulator $EMULATOR) ==="
+_cleanup
 exit 1

--- a/test/pytest/backends/test_ghidra_backend.py
+++ b/test/pytest/backends/test_ghidra_backend.py
@@ -163,3 +163,40 @@ def test_live_thumb_step(tmp_path):
         assert b.read_register("pc") == 0x08000004
     finally:
         b.shutdown()
+
+
+@pytest.mark.skipif(not _HAVE_PYGHIDRA, reason="pyghidra not installed")
+@pytest.mark.skipif(
+    not __import__("os").environ.get("GHIDRA_INSTALL_DIR"),
+    reason="GHIDRA_INSTALL_DIR not set",
+)
+def test_live_snapshot_restore(tmp_path):
+    """The Ghidra p-code backend uses the generic reg+RAM snapshot fallback;
+    verify a full save -> clobber -> restore round-trip on the real emulator."""
+    from halucinator.backends.ghidra_backend import GhidraBackend
+    from halucinator.backends.hal_backend import MemoryRegion
+
+    code = bytes([0x42, 0x20, 0x10, 0x21, 0xfe, 0xe7])  # movs r0,#0x42; ...
+    fw = tmp_path / "fw.bin"
+    fw.write_bytes(code + b"\x00" * 1024)
+    b = GhidraBackend(arch="cortex-m3")
+    b.add_memory_region(MemoryRegion(
+        name="flash", base_addr=0x08000000, size=0x1000, file=str(fw)))
+    b.add_memory_region(MemoryRegion(
+        name="ram", base_addr=0x20000000, size=0x1000, permissions="rw"))
+    b.init()
+    try:
+        b.write_memory(0x20000040, 1, b"snap-me!", 8, raw=True)
+        b.write_register("r0", 0x1234)
+        snap = b.save_state()
+        assert snap.data["mem"]
+        assert snap.data["regs"].get("r0") == 0x1234
+
+        b.write_memory(0x20000040, 1, b"CLOBBER!", 8, raw=True)
+        b.write_register("r0", 0)
+
+        assert b.restore_state(snap) is True
+        assert bytes(b.read_memory(0x20000040, 1, 8, raw=True)) == b"snap-me!"
+        assert b.read_register("r0") == 0x1234
+    finally:
+        b.shutdown()

--- a/test/pytest/backends/test_live_avatar2_backend.py
+++ b/test/pytest/backends/test_live_avatar2_backend.py
@@ -124,6 +124,14 @@ class TestAvatar2BackendLive:
         backend.write_register("r5", 0xDEADBEEF)
         assert backend.read_register("r5") == 0xDEADBEEF
 
+    def test_snapshot_restore_round_trip(self, backend):
+        from backend_snapshot_helpers import (
+            assert_backend_snapshot_round_trip,
+            assert_restore_rejects_wrong_backend_type,
+        )
+        assert_backend_snapshot_round_trip(backend, _RAM_BASE)
+        assert_restore_rejects_wrong_backend_type(backend)
+
     def test_set_remove_breakpoint_does_not_crash(self, backend):
         # cont/step on a vectorless raw-bin Cortex-M3 is unreliable
         # under avatar-qemu's `configurable` machine (the CPU resets

--- a/test/pytest/backends/test_live_libafl_qemu_backend.py
+++ b/test/pytest/backends/test_live_libafl_qemu_backend.py
@@ -167,6 +167,14 @@ class TestLibAflQemuBackendLive:
         backend.write_register("r5", 0xDEADBEEF)
         assert backend.read_register("r5") == 0xDEADBEEF
 
+    def test_snapshot_restore_round_trip(self, backend):
+        from backend_snapshot_helpers import (
+            assert_backend_snapshot_round_trip,
+            assert_restore_rejects_wrong_backend_type,
+        )
+        assert_backend_snapshot_round_trip(backend, _RAM_BASE)
+        assert_restore_rejects_wrong_backend_type(backend)
+
     def test_set_remove_breakpoint_does_not_crash(self, backend):
         bp = backend.set_breakpoint(_BP_ADDR)
         assert isinstance(bp, int)

--- a/test/pytest/backends/test_live_qemu_backend.py
+++ b/test/pytest/backends/test_live_qemu_backend.py
@@ -162,6 +162,14 @@ class TestQEMUBackendLive:
         backend.write_register("r5", 0xDEADBEEF)
         assert backend.read_register("r5") == 0xDEADBEEF
 
+    def test_snapshot_restore_round_trip(self, backend):
+        from backend_snapshot_helpers import (
+            assert_backend_snapshot_round_trip,
+            assert_restore_rejects_wrong_backend_type,
+        )
+        assert_backend_snapshot_round_trip(backend, _RAM_BASE)
+        assert_restore_rejects_wrong_backend_type(backend)
+
     def test_set_remove_breakpoint_does_not_crash(self, backend):
         # cont/step on a vectorless raw-bin Cortex-M3 is unreliable
         # under avatar-qemu's `configurable` machine. Limit the live

--- a/test/pytest/backends/test_live_renode_backend.py
+++ b/test/pytest/backends/test_live_renode_backend.py
@@ -104,6 +104,19 @@ class TestRenodeBackendLive:
         v = backend.read_register("r5")
         assert isinstance(v, int)
 
+    def test_snapshot_restore_round_trip(self, backend):
+        # Renode drops register writes while paused at reset (see
+        # test_register_rw), so assert the RAM round-trip only. The register
+        # capture path is still exercised (save reads them) — restore's
+        # dropped writes are tolerated by the generic path.
+        from backend_snapshot_helpers import (
+            assert_backend_snapshot_round_trip,
+            assert_restore_rejects_wrong_backend_type,
+        )
+        assert_backend_snapshot_round_trip(backend, _RAM_BASE,
+                                           check_registers=False)
+        assert_restore_rejects_wrong_backend_type(backend)
+
     def test_set_remove_breakpoint_does_not_crash(self, backend):
         # Renode boots a real Cortex-M3 model; without a proper
         # vector table at flash[0..7] the CPU faults on first

--- a/test/pytest/helpers/backend_snapshot_helpers.py
+++ b/test/pytest/helpers/backend_snapshot_helpers.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Christopher Wright
+
+"""Shared snapshot/restore round-trip assertion for the live backend tests
+(qemu, libafl-qemu, renode, avatar2, ghidra). Each of those backends uses the
+generic HalBackend.save_state/restore_state fallback (reg + writable-RAM
+capture); this exercises it end-to-end against the real running backend."""
+from __future__ import annotations
+
+from typing import Any
+
+from halucinator.backends.hal_backend import MemoryRegion
+
+
+def _ensure_ram_region(backend: Any, ram_base: int, ram_size: int) -> None:
+    """Make sure a writable, non-emulated RAM region is registered so the
+    generic snapshot has something to capture (some live fixtures configure
+    memory via the emulator's own config rather than add_memory_region)."""
+    regions = getattr(backend, "_regions", None)
+    if regions is None:
+        backend._regions = regions = []
+    covered = any(r.base_addr == ram_base and "w" in r.permissions
+                  and not getattr(r, "emulate", None) for r in regions)
+    if not covered:
+        regions.append(MemoryRegion("snap_ram", ram_base, ram_size, "rw"))
+
+
+def assert_backend_snapshot_round_trip(backend: Any, ram_base: int,
+                                       ram_size: int = 0x1000,
+                                       check_registers: bool = True) -> None:
+    """Write known RAM (+ optionally a register), snapshot, clobber, restore,
+    and assert the machine is back to the snapshot. Works against any
+    HalBackend whose save_state/restore_state is the generic reg+RAM fallback.
+
+    ``check_registers=False`` for backends that drop register writes in the
+    state the fixture leaves them in (e.g. Renode's GDB stub while paused at
+    reset) — the memory round-trip is still fully asserted."""
+    _ensure_ram_region(backend, ram_base, ram_size)
+
+    assert backend.can_snapshot() is True
+
+    marker = b"snap-me!"
+    backend.write_memory(ram_base + 0x40, 1, marker, len(marker), raw=True)
+    if check_registers:
+        backend.write_register("r0", 0x1234)
+
+    snap = backend.save_state()
+    assert snap.data["mem"], "generic snapshot captured no memory"
+    if check_registers:
+        assert snap.data["regs"].get("r0") == 0x1234
+
+    backend.write_memory(ram_base + 0x40, 1, b"CLOBBER!", 8, raw=True)
+    if check_registers:
+        backend.write_register("r0", 0)
+
+    assert backend.restore_state(snap) is True
+    assert bytes(backend.read_memory(ram_base + 0x40, 1, len(marker),
+                                     raw=True)) == marker
+    if check_registers:
+        assert backend.read_register("r0") == 0x1234
+
+
+def assert_restore_rejects_wrong_backend_type(backend: Any) -> None:
+    """A snapshot from a different backend type must be refused without
+    mutating state."""
+    from halucinator.backends.hal_backend import Snapshot
+    alien = Snapshot(backend_type="SomeOtherBackend", version=1,
+                     data={"regs": {}, "mem": []})
+    assert backend.restore_state(alien) is False

--- a/test/pytest/peripheral_models/test_IEEE802_15_4.py
+++ b/test/pytest/peripheral_models/test_IEEE802_15_4.py
@@ -212,11 +212,20 @@ def test_tx_frame_passes_frame_to_ioserver():
         "Peripheral.IEEE802_15_4.tx_frame", rx_frame_handler
     )
     frame = "frame".encode()
-    model_IEEE802_15_4.tx_frame("an_interface_id", frame)
-    wait_assert(
-        lambda: rx_frame_handler.assert_called_once_with(
-            ioserver, {"frame": frame}
-        )
-    )
+
+    # Re-send on each retry rather than sending once up front. A single
+    # zmq PUB/SUB send can be silently dropped if the SUB subscription has
+    # not propagated yet (the "slow joiner" problem) — and register_topic
+    # subscribes from this thread while IOServer.run() polls the socket on
+    # another, so the first send frequently loses the race. Sending inside
+    # wait_assert keeps trying until one message is delivered; we assert on
+    # the delivered content (assert_called_with checks the latest call, and
+    # every send carries identical args), so a redundant extra delivery is
+    # harmless.
+    def _send_and_check():
+        model_IEEE802_15_4.tx_frame("an_interface_id", frame)
+        rx_frame_handler.assert_called_with(ioserver, {"frame": frame})
+
+    wait_assert(_send_and_check)
     ioserver.shutdown()
     fix_server_shutdown(ioserver.rx_socket, ioserver.tx_socket, 1000)

--- a/test/pytest/snapshot/test_backend_snapshot.py
+++ b/test/pytest/snapshot/test_backend_snapshot.py
@@ -1,0 +1,335 @@
+"""Layer-1 backend snapshot tests: the generic fallback (HalBackend) and the
+native Unicorn override.
+
+The load-bearing assertion is BYTE-IDENTICAL resume: snapshot, mutate everything
+reachable (all RAM + every register), restore, and assert the full memory image
+and register file are bit-for-bit what they were at snapshot time.
+"""
+import struct
+
+import pytest
+
+from halucinator.backends.hal_backend import (
+    HalBackend,
+    MemoryRegion,
+    Snapshot,
+    SnapshotError,
+)
+
+try:
+    import unicorn  # noqa: F401
+    _HAVE_UNICORN = True
+except ImportError:
+    _HAVE_UNICORN = False
+
+FLASH_BASE = 0x08000000
+RAM_BASE = 0x20000000
+FLASH_SIZE = 0x10000
+RAM_SIZE = 0x8000
+
+
+# ---------------------------------------------------------------------------
+# A minimal in-memory backend to exercise the GENERIC fallback save/restore.
+# ---------------------------------------------------------------------------
+
+class DictBackend(HalBackend):
+    """Backend backed by a python dict of byte arrays — no real CPU. Enough to
+    drive HalBackend.save_state/restore_state (the generic path)."""
+
+    def __init__(self):
+        self._regions = [MemoryRegion("ram", RAM_BASE, RAM_SIZE, "rw")]
+        self._mem = bytearray(RAM_SIZE)
+        self._regs = {name: 0 for name in self.list_registers()}
+
+    # -- memory --
+    def read_memory(self, addr, size, num_words=1, raw=False):
+        off = addr - RAM_BASE
+        n = size * num_words
+        data = bytes(self._mem[off:off + n])
+        if raw:
+            return data
+        return int.from_bytes(data, "little")
+
+    def write_memory(self, addr, size, value, num_words=1, raw=False):
+        off = addr - RAM_BASE
+        if raw:
+            data = bytes(value)
+        else:
+            data = int(value).to_bytes(size * num_words, "little")
+        self._mem[off:off + len(data)] = data
+        return True
+
+    def read_register(self, register):
+        return self._regs[register]
+
+    def write_register(self, register, value):
+        self._regs[register] = value
+
+    # -- unused abstract-ish control methods for this test --
+    def set_breakpoint(self, addr, **kw):  # pragma: no cover - unused
+        return 0
+
+    def remove_breakpoint(self, bp_id):  # pragma: no cover - unused
+        return True
+
+    def cont(self, *a, **k):  # pragma: no cover - unused
+        pass
+
+    def step(self, *a, **k):  # pragma: no cover - unused
+        pass
+
+    def init(self):  # pragma: no cover - unused
+        pass
+
+    def add_memory_region(self, region):  # pragma: no cover - unused
+        self._regions.append(region)
+
+    def stop(self, *a, **k):  # pragma: no cover - unused
+        pass
+
+
+class TestGenericFallback:
+    def test_round_trip_reverts_memory_and_regs(self):
+        b = DictBackend()
+        b.write_memory(RAM_BASE, 1, b"snapshot-me", 11, raw=True)
+        b.write_register("r0", 0x11111111)
+
+        snap = b.save_state()
+        assert isinstance(snap, Snapshot)
+        assert snap.backend_type == "DictBackend"
+        assert snap.version == HalBackend.SNAPSHOT_VERSION
+
+        # Scribble over both memory and registers.
+        b.write_memory(RAM_BASE, 1, b"CLOBBEREDXX", 11, raw=True)
+        b.write_register("r0", 0xDEADBEEF)
+
+        assert b.restore_state(snap) is True
+        assert b.read_memory(RAM_BASE, 1, 11, raw=True) == b"snapshot-me"
+        assert b.read_register("r0") == 0x11111111
+
+    def test_restore_rejects_wrong_backend_type(self):
+        b = DictBackend()
+        b.write_register("r0", 7)
+        alien = Snapshot(backend_type="SomeOtherBackend", version=1,
+                         data={"regs": {"r0": 999}, "mem": []})
+        assert b.restore_state(alien) is False
+        assert b.read_register("r0") == 7  # unchanged — no mutation on mismatch
+
+    def test_restore_rejects_wrong_version(self):
+        b = DictBackend()
+        b.write_register("r0", 7)
+        snap = b.save_state()
+        snap.version = 999
+        assert b.restore_state(snap) is False
+        assert b.read_register("r0") == 7
+
+    def test_save_raises_when_no_regions(self):
+        b = DictBackend()
+        b._regions = []
+        with pytest.raises(SnapshotError):
+            b.save_state()
+
+    def test_restore_returns_false_when_memory_write_fails(self):
+        """A rejected memory write must make restore_state return False
+        (whole-or-nothing) instead of silently reporting success."""
+        b = DictBackend()
+        b.write_register("r0", 0x1234)
+        snap = b.save_state()
+
+        # Make the next write_memory fail.
+        b.write_memory = lambda *a, **k: False
+        assert b.restore_state(snap) is False
+
+
+# ---------------------------------------------------------------------------
+# Unicorn native path.
+# ---------------------------------------------------------------------------
+
+pytestmark_uc = pytest.mark.skipif(
+    not _HAVE_UNICORN, reason="unicorn-engine not installed")
+
+
+def _make_unicorn():
+    from halucinator.backends.unicorn_backend import UnicornBackend
+    b = UnicornBackend(arch="cortex-m3")
+    b.add_memory_region(MemoryRegion("flash", FLASH_BASE, FLASH_SIZE, "rwx"))
+    b.add_memory_region(MemoryRegion("ram", RAM_BASE, RAM_SIZE, "rw"))
+    b.init()
+    return b
+
+
+def _full_dump(b):
+    """Byte-exact machine image: every mapped region's bytes + every register."""
+    mem = {base: bytes(b._uc.mem_read(base, end - base + 1))
+           for (base, end, _p) in b._uc.mem_regions()}
+    regs = {name: b.read_register(name) for name in b.list_registers()}
+    return mem, regs
+
+
+@pytestmark_uc
+class TestUnicornNative:
+    def test_capability_probes(self):
+        b = _make_unicorn()
+        assert b.can_snapshot() is True
+        assert b.snapshot_is_fast() is True
+
+    def test_round_trip_byte_identical(self):
+        b = _make_unicorn()
+        # Seed distinct patterns into flash + ram and set registers.
+        b.write_memory(RAM_BASE, 1, bytes(range(256)) * 4, 1024, raw=True)
+        b.write_memory(FLASH_BASE, 1, b"\xAB" * 512, 512, raw=True)
+        b.write_register("r0", 0xCAFEBABE)
+        b.write_register("r5", 0x00C0FFEE)
+        b.write_register("sp", RAM_BASE + 0x2000)
+        b.write_register("pc", FLASH_BASE + 0x100)
+
+        snap = b.save_state()
+        before_mem, before_regs = _full_dump(b)
+
+        # Corrupt everything we can reach.
+        b.write_memory(RAM_BASE, 1, b"\x00" * 1024, 1024, raw=True)
+        b.write_memory(FLASH_BASE, 1, b"\xFF" * 512, 512, raw=True)
+        b.write_register("r0", 0)
+        b.write_register("r5", 0)
+        b.write_register("sp", RAM_BASE + 0x10)
+        b.write_register("pc", FLASH_BASE)
+
+        assert b.restore_state(snap) is True
+        after_mem, after_regs = _full_dump(b)
+
+        assert after_mem == before_mem, "RAM/flash not byte-identical after restore"
+        assert after_regs == before_regs, "registers not identical after restore"
+
+    def test_deterministic_resume_executes_identically(self):
+        """Snapshot at a PC, run a fixed Thumb sequence, capture state; restore
+        and run the SAME sequence again — the resulting machine image must be
+        byte-identical, proving the snapshot is a faithful resume point."""
+        b = _make_unicorn()
+        # MOV r0,#1; MOV r1,#2; MOV r2,#3; BX LR
+        insns = struct.pack("<HHHH", 0x2001, 0x2102, 0x2203, 0x4770)
+        b.write_memory(FLASH_BASE, 1, insns, len(insns), raw=True)
+        b.write_register("pc", FLASH_BASE)
+        b.write_register("lr", FLASH_BASE + len(insns))
+        b.write_register("sp", RAM_BASE + 0x2000)
+
+        snap = b.save_state()
+
+        b.set_breakpoint(FLASH_BASE + 6)  # stop at BX LR
+        b.cont()
+        run1 = _full_dump(b)
+
+        assert b.restore_state(snap) is True
+        b.cont()
+        run2 = _full_dump(b)
+
+        assert run1[0] == run2[0]
+        assert run1[1] == run2[1]
+
+    def test_restore_rejects_wrong_backend_type(self):
+        b = _make_unicorn()
+        b.write_register("r0", 0x1234)
+        alien = Snapshot(backend_type="NotUnicorn", version=1, data=None)
+        assert b.restore_state(alien) is False
+        assert b.read_register("r0") == 0x1234
+
+    def test_save_raises_before_init(self):
+        from halucinator.backends.unicorn_backend import UnicornBackend
+        b = UnicornBackend(arch="cortex-m3")
+        with pytest.raises(SnapshotError):
+            b.save_state()
+
+    def test_portable_restore_rejects_mismatched_memory_map(self):
+        """A portable snapshot carries a machine fingerprint; restoring it
+        onto a backend with a different memory map must be refused BEFORE any
+        write, not half-applied."""
+        from halucinator.backends.hal_backend import MemoryRegion
+        from halucinator.backends.unicorn_backend import UnicornBackend
+
+        b = _make_unicorn()
+        b.write_memory(RAM_BASE, 1, b"original-ram", 12, raw=True)
+        snap = b.save_state(portable=True)
+
+        # A second backend with an EXTRA region -> different fingerprint.
+        b2 = UnicornBackend(arch="cortex-m3")
+        b2.add_memory_region(MemoryRegion("flash", FLASH_BASE, FLASH_SIZE, "rwx"))
+        b2.add_memory_region(MemoryRegion("ram", RAM_BASE, RAM_SIZE, "rw"))
+        b2.add_memory_region(MemoryRegion("extra", 0x40000000, 0x1000, "rw"))
+        b2.init()
+        b2.write_memory(RAM_BASE, 1, b"UNTOUCHED-XX", 12, raw=True)
+
+        assert b2.restore_state(snap) is False
+        # Rejected before mutating: RAM is unchanged.
+        assert b2.read_memory(RAM_BASE, 1, 12, raw=True) == b"UNTOUCHED-XX"
+
+    def test_portable_restore_accepts_matching_fingerprint(self):
+        from halucinator.backends.hal_backend import MemoryRegion
+        from halucinator.backends.unicorn_backend import UnicornBackend
+
+        b = _make_unicorn()
+        b.write_memory(RAM_BASE, 1, b"fingerprint-ok", 14, raw=True)
+        snap = b.save_state(portable=True)
+
+        b2 = _make_unicorn()  # same config -> same fingerprint
+        assert b2.restore_state(snap) is True
+        assert b2.read_memory(RAM_BASE, 1, 14, raw=True) == b"fingerprint-ok"
+
+
+# ---------------------------------------------------------------------------
+# A-profile VFP: FPEXC must survive a portable snapshot round-trip.
+# ---------------------------------------------------------------------------
+
+def _make_arm_a9_vfp():
+    """An A-profile (Cortex-A9) unicorn backend with the VFP unit enabled — the
+    configuration that exposes FPEXC. The caller must have set
+    HAL_ARM_CPU_MODEL=UC_CPU_ARM_CORTEX_A9 (a VFP-capable model) first."""
+    from unicorn import arm_const as A
+
+    from halucinator.backends.unicorn_backend import UnicornBackend
+    b = UnicornBackend(arch="arm")
+    b.add_memory_region(MemoryRegion("ram", RAM_BASE, RAM_SIZE, "rwx"))
+    b.init()
+    uc = b._uc
+    # Grant cp10/cp11 (VFP) full access via CPACR and enable the unit (FPEXC.EN).
+    uc.reg_write(A.UC_ARM_REG_CP_REG, (15, 0, 0, 1, 0, 0, 2, (0xF << 20)))
+    uc.reg_write(A.UC_ARM_REG_FPEXC, 0x40000000)  # EN = bit 30
+    return b, uc, A
+
+
+@pytestmark_uc
+class TestUnicornArmVfpFpexc:
+    """Regression for the FPEXC snapshot gap. On A-profile cores unicorn's
+    context_save() does NOT preserve FPEXC (the VFP enable/exception register),
+    so a portable snapshot must capture/restore it explicitly. Without it a
+    restored machine comes back with VFP DISABLED and the first VFP instruction
+    traps UC_ERR_INSN_INVALID — observed restoring a real Cortex-A9 VxWorks
+    image, where `vpush {d8,d9}` in the post-keygen app-init faulted."""
+
+    def test_fpexc_and_dregs_round_trip(self, monkeypatch):
+        monkeypatch.setenv("HAL_ARM_CPU_MODEL", "UC_CPU_ARM_CORTEX_A9")
+        b, uc, A = _make_arm_a9_vfp()
+        uc.reg_write(A.UC_ARM_REG_D8, 0xDEADBEEFCAFEF00D)
+        assert uc.reg_read(A.UC_ARM_REG_FPEXC) & 0x40000000  # EN set at snapshot
+        snap = b.save_state(portable=True)
+        # Simulate unicorn dropping FPEXC on a context restore + clobber d8.
+        uc.reg_write(A.UC_ARM_REG_FPEXC, 0x0)  # VFP now disabled
+        uc.reg_write(A.UC_ARM_REG_D8, 0x0)
+        assert b.restore_state(snap) is True
+        assert uc.reg_read(A.UC_ARM_REG_FPEXC) & 0x40000000, "FPEXC.EN not restored"
+        assert uc.reg_read(A.UC_ARM_REG_D8) == 0xDEADBEEFCAFEF00D
+
+    def test_vfp_instruction_executes_after_restore(self, monkeypatch):
+        """The exact production failure mode: a VFP instruction must decode and
+        execute after restore. `vpush {d8}` (0xed2d8b02) traps
+        UC_ERR_INSN_INVALID with VFP disabled; with FPEXC restored it runs."""
+        monkeypatch.setenv("HAL_ARM_CPU_MODEL", "UC_CPU_ARM_CORTEX_A9")
+        b, uc, A = _make_arm_a9_vfp()
+        code = RAM_BASE
+        uc.mem_write(code, struct.pack("<I", 0xED2D8B02))  # vpush {d8}
+        uc.reg_write(A.UC_ARM_REG_SP, RAM_BASE + 0x4000)   # writable stack
+        snap = b.save_state(portable=True)
+        uc.reg_write(A.UC_ARM_REG_FPEXC, 0x0)  # disable VFP (as a bare restore would)
+        assert b.restore_state(snap) is True
+        # Single-step the vpush; must NOT raise UcError(UC_ERR_INSN_INVALID).
+        uc.emu_start(code, code + 4, count=1)
+        # sp decremented by 8 (one 64-bit d-reg pushed) proves it ran as VFP.
+        assert uc.reg_read(A.UC_ARM_REG_SP) == RAM_BASE + 0x4000 - 8

--- a/test/pytest/snapshot/test_cli_e2e.py
+++ b/test/pytest/snapshot/test_cli_e2e.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Christopher Wright
+
+"""End-to-end CLI snapshot/restore: real firmware, real `halucinator.main`
+processes, real process boundary.
+
+  1. ground truth: run the arm32 UART firmware start-to-TX, record what it
+     transmits.
+  2. run A: --snapshot-at main --snapshot-out boot.halsnap
+     (boots from the reset path, snapshots at main, exits).
+  3. run B (FRESH process): --restore boot.halsnap
+     (resumes at main — skipping the boot path entirely — and must transmit
+     exactly what the ground-truth run did).
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ARM32_DIR = REPO_ROOT / "test" / "multi_arch" / "arm32"
+MAIN_ADDR = "0x08000051"  # `main` in test_uart_addrs.yaml
+
+pytestmark = pytest.mark.skipif(
+    not (ARM32_DIR / "firmware" / "test_uart.bin").exists(),
+    reason="arm32 test firmware not built",
+)
+
+_TX_RE = re.compile(rb"UART TX:(b['\"].*?['\"])")
+
+
+def _cmd(*extra: str, ports: int) -> list:
+    return [
+        sys.executable, "-m", "halucinator.main",
+        "-c", "test_uart_config.yaml",
+        "-c", "test_uart_addrs.yaml",
+        "-c", "test_uart_memory.yaml",
+        "--emulator", "unicorn",
+        "-r", str(ports), "-t", str(ports + 1),
+        *extra,
+    ]
+
+
+def _env() -> dict:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "src")
+    return env
+
+
+def _run_until_tx_or_exit(cmd, timeout=90.0) -> bytes:
+    """Run the CLI, return combined output once a UART TX line appears (the
+    firmware then blocks in uart_read forever — kill it) or the process
+    exits on its own. select()-driven so a silent child can't wedge the
+    test past its deadline."""
+    import select
+    proc = subprocess.Popen(cmd, cwd=ARM32_DIR, env=_env(),
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT)
+    out = b""
+    deadline = time.time() + timeout
+    try:
+        while time.time() < deadline:
+            ready, _, _ = select.select([proc.stdout], [], [], 0.5)
+            if ready:
+                chunk = os.read(proc.stdout.fileno(), 65536)
+                out += chunk
+                if _TX_RE.search(out):
+                    return out
+                if not chunk and proc.poll() is not None:
+                    return out
+            elif proc.poll() is not None:
+                out += proc.stdout.read() or b""
+                return out
+        raise AssertionError(
+            f"no UART TX and no exit within {timeout}s:\n"
+            f"{out.decode(errors='replace')}")
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+@pytest.mark.slow_zmq
+class TestCliSnapshotRestore:
+    def test_snapshot_then_restore_transmits_identically(self, tmp_path):
+        snap = tmp_path / "boot.halsnap"
+
+        # 1. Ground truth: what does an uninterrupted boot transmit?
+        truth_out = _run_until_tx_or_exit(_cmd(ports=6710))
+        truth_tx = _TX_RE.search(truth_out)
+        assert truth_tx, truth_out.decode(errors="replace")
+
+        # 2. Boot again, snapshot at main, exit. Must exit on its own,
+        #    BEFORE any UART traffic (main hasn't run yet).
+        snap_run = subprocess.run(
+            _cmd("--snapshot-at", MAIN_ADDR, "--snapshot-out", str(snap),
+                 ports=6720),
+            cwd=ARM32_DIR, env=_env(), capture_output=True, timeout=90)
+        combined = snap_run.stdout + snap_run.stderr
+        assert snap_run.returncode == 0, combined.decode(errors="replace")
+        assert b"Snapshot written" in combined
+        assert not _TX_RE.search(combined), "snapshot ran past main"
+        assert snap.exists() and snap.stat().st_size > 0
+
+        # 3. Fresh process, restore, resume at main: identical TX.
+        restore_out = _run_until_tx_or_exit(
+            _cmd("--restore", str(snap), ports=6730))
+        assert b"Restored snapshot" in restore_out, \
+            restore_out.decode(errors="replace")
+        restored_tx = _TX_RE.search(restore_out)
+        assert restored_tx, restore_out.decode(errors="replace")
+        assert restored_tx.group(1) == truth_tx.group(1), (
+            "restored run transmitted differently:\n"
+            f"  truth:    {truth_tx.group(1)!r}\n"
+            f"  restored: {restored_tx.group(1)!r}")
+
+    def test_restore_missing_file_fails_cleanly(self, tmp_path):
+        r = subprocess.run(
+            _cmd("--restore", str(tmp_path / "nope.halsnap"), ports=6740),
+            cwd=ARM32_DIR, env=_env(), capture_output=True, timeout=90)
+        assert r.returncode != 0

--- a/test/pytest/snapshot/test_device_layer.py
+++ b/test/pytest/snapshot/test_device_layer.py
@@ -1,0 +1,350 @@
+"""Layer-3 (external zmq device) snapshot tests.
+
+Driven through fakes — a stand-in TX socket on the HAL side and a recording
+IOServer on the device side — so the protocol logic is tested deterministically
+without real zmq plumbing or its timing flakes.
+"""
+import pytest
+
+from halucinator.peripheral_models import peripheral_server
+from halucinator.peripheral_models.peripheral_server import decode_zmq_msg
+from halucinator.snapshot import DeviceLayer, SystemSnapshot, system_restore
+from halucinator.snapshot.device_layer import SnapshotDevices
+from halucinator.external_devices.snapshotable import SnapshotableDevice
+
+from .test_backend_snapshot import DictBackend
+
+
+class FakeTxSocket:
+    """Captures publishes; optionally reacts like a connected device."""
+
+    def __init__(self):
+        self.sent = []          # decoded (topic, msg) tuples
+        self.on_send = None     # optional callback(topic, msg)
+
+    def send_string(self, s):
+        topic, msg = decode_zmq_msg(s)
+        self.sent.append((topic, msg))
+        if self.on_send is not None:
+            self.on_send(topic, msg)
+
+
+@pytest.fixture
+def fake_server(monkeypatch):
+    sock = FakeTxSocket()
+    monkeypatch.setattr(peripheral_server, "__TX_SOCKET__", sock)
+    return sock
+
+
+@pytest.fixture
+def no_server(monkeypatch):
+    monkeypatch.setattr(peripheral_server, "__TX_SOCKET__", None)
+
+
+def fast_layer():
+    return DeviceLayer(timeout=0.15, poll_interval=0.01)
+
+
+class TestDeviceLayerSnapshot:
+    def test_no_server_yields_empty_layer(self, no_server):
+        layer = fast_layer()
+        assert layer.available() is False
+        assert layer.snapshot() == {}
+
+    def test_collects_replies_within_window(self, fake_server):
+        def reply(topic, msg):
+            if topic == DeviceLayer.SAVE_TOPIC:
+                SnapshotDevices.state({"snapshot_id": msg["snapshot_id"],
+                                       "device_id": "bridge-1",
+                                       "state": {"count": 7}})
+                SnapshotDevices.state({"snapshot_id": msg["snapshot_id"],
+                                       "device_id": "panel-2",
+                                       "state": {"leds": [1, 0]}})
+        fake_server.on_send = reply
+
+        states = fast_layer().snapshot()
+        assert states == {"bridge-1": {"count": 7}, "panel-2": {"leds": [1, 0]}}
+        # collection slot is cleaned up afterwards
+        assert SnapshotDevices.collected == {}
+
+    def test_silent_fleet_yields_empty(self, fake_server):
+        assert fast_layer().snapshot() == {}
+        assert fake_server.sent[0][0] == DeviceLayer.SAVE_TOPIC
+
+    def test_stale_reply_is_dropped(self, fake_server):
+        # A reply for a snapshot that is no longer collecting must not crash
+        # or resurrect the slot.
+        SnapshotDevices.state({"snapshot_id": "expired", "device_id": "d",
+                               "state": {}})
+        assert "expired" not in SnapshotDevices.collected
+
+    def test_malformed_reply_is_ignored(self, fake_server):
+        SnapshotDevices.state({"device_id": "no-snapshot-id"})
+        SnapshotDevices.state({"snapshot_id": "no-device-id"})
+        assert SnapshotDevices.collected == {}
+
+
+class TestDeviceLayerRestore:
+    def test_empty_states_trivially_true_without_publishing(self, fake_server):
+        assert fast_layer().restore({}) is True
+        assert fake_server.sent == []
+
+    def test_no_server_with_captured_devices_fails(self, no_server):
+        assert fast_layer().restore({"bridge-1": {}}) is False
+
+    def test_all_acked_early_exit(self, fake_server):
+        def ack(topic, msg):
+            if topic == DeviceLayer.RESTORE_TOPIC:
+                for dev in msg["states"]:
+                    SnapshotDevices.restored({"snapshot_id": msg["snapshot_id"],
+                                              "device_id": dev, "ok": True})
+        fake_server.on_send = ack
+        # A 30 s window that must return promptly: pass ⇒ the early exit
+        # (full-membership ack check) worked, not the timeout.
+        layer = DeviceLayer(timeout=30.0, poll_interval=0.01)
+        assert layer.restore({"bridge-1": {"count": 7}}) is True
+        assert SnapshotDevices.acked == {}
+
+    def test_missing_ack_fails_after_window(self, fake_server):
+        def ack_one(topic, msg):
+            if topic == DeviceLayer.RESTORE_TOPIC:
+                SnapshotDevices.restored({"snapshot_id": msg["snapshot_id"],
+                                          "device_id": "bridge-1", "ok": True})
+        fake_server.on_send = ack_one
+        assert fast_layer().restore({"bridge-1": {}, "gone-2": {}}) is False
+
+    def test_explicit_nack_fails(self, fake_server):
+        def nack(topic, msg):
+            if topic == DeviceLayer.RESTORE_TOPIC:
+                SnapshotDevices.restored({"snapshot_id": msg["snapshot_id"],
+                                          "device_id": "bridge-1", "ok": False})
+        fake_server.on_send = nack
+        assert fast_layer().restore({"bridge-1": {}}) is False
+
+    def test_malformed_ack_is_ignored(self, fake_server):
+        # Missing snapshot_id or device_id: dropped, no crash, no state.
+        SnapshotDevices.restored({"device_id": "d", "ok": True})
+        SnapshotDevices.restored({"snapshot_id": "s", "ok": True})
+        assert SnapshotDevices.acked == {}
+
+    def test_stale_ack_is_dropped(self, fake_server):
+        # An ack for a restore that is no longer awaiting must not resurrect
+        # the slot.
+        SnapshotDevices.restored({"snapshot_id": "expired", "device_id": "d",
+                                  "ok": True})
+        assert "expired" not in SnapshotDevices.acked
+
+
+class TestCoordinatorIntegration:
+    def test_captured_devices_but_no_layer_fails_restore(self):
+        b = DictBackend()
+        snap = SystemSnapshot(backend=b.save_state(), peripherals={},
+                              devices={"bridge-1": {"count": 7}})
+        # No peripherals were captured, so an empty-registry restore is fine;
+        # the device layer is what must refuse.
+        res = system_restore(b, snap)
+        assert res.ok is False
+        assert res.layer == "devices"
+
+    def test_devices_restored_through_coordinator(self, fake_server):
+        def ack(topic, msg):
+            if topic == DeviceLayer.RESTORE_TOPIC:
+                for dev in msg["states"]:
+                    SnapshotDevices.restored({"snapshot_id": msg["snapshot_id"],
+                                              "device_id": dev, "ok": True})
+        fake_server.on_send = ack
+        b = DictBackend()
+        snap = SystemSnapshot(backend=b.save_state(), peripherals={},
+                              devices={"bridge-1": {"count": 7}})
+        res = system_restore(b, snap, device_layer=fast_layer())
+        assert res.ok is True
+        assert "devices" in res.message
+
+    def test_pre_layer3_snapshot_restores_fine(self):
+        """A SystemSnapshot pickled before `devices` existed has no such
+        attribute — it must restore as an empty device layer, not crash."""
+        b = DictBackend()
+        snap = SystemSnapshot(backend=b.save_state(), peripherals={})
+        del snap.devices  # simulate the old pickle layout
+        res = system_restore(b, snap)
+        assert res.ok is True
+
+
+class FakeIOServer:
+    def __init__(self):
+        self.topics = {}
+        self.sent = []
+
+    def register_topic(self, topic, method):
+        self.topics[topic] = method
+
+    def send_msg(self, topic, data):
+        self.sent.append((topic, data))
+
+
+class TestIOServerResilience:
+    """IOServer.run() must not let one bad message/handler kill the rx loop
+    (the second containment layer behind finding 1). Driven with fakes — no
+    real zmq — so it's deterministic."""
+
+    def _drive(self, messages, handlers):
+        """Run IOServer.run()'s loop over a fixed message list via fakes."""
+        import threading
+        from halucinator.external_devices.ioserver import IOServer
+        from halucinator.peripheral_models.peripheral_server import (
+            encode_zmq_msg,
+        )
+
+        io = IOServer.__new__(IOServer)  # skip __init__ (no real sockets)
+        io._IOServer__stop = threading.Event()
+        io.handlers = handlers
+        io.packet_log = None
+        encoded = iter([encode_zmq_msg(t, d) for t, d in messages])
+
+        class FakeRx:
+            def recv_string(self_inner):
+                return next(encoded)
+        io.rx_socket = FakeRx()
+
+        def poll(_timeout):
+            # Yield POLLIN until messages run out, then signal stop.
+            try:
+                io.rx_socket._next = encoded.__length_hint__()
+            except Exception:
+                pass
+            if encoded.__length_hint__() == 0:
+                io._IOServer__stop.set()
+                return {}
+            return {io.rx_socket: 1}  # zmq.POLLIN == 1
+        io.poller = type("P", (), {"poll": staticmethod(poll)})()
+        io.run()
+        return io
+
+    def test_run_survives_handler_exception(self):
+        calls = []
+
+        def boom(_io, _data):
+            calls.append("boom")
+            raise RuntimeError("handler blew up")
+
+        def ok(_io, _data):
+            calls.append("ok")
+
+        self._drive(
+            [("T.boom", {"k": 1}), ("T.ok", {"k": 2})],
+            {"T.boom": boom, "T.ok": ok},
+        )
+        # The exception in `boom` did not abort the loop: `ok` still ran.
+        assert calls == ["boom", "ok"]
+
+    def test_run_survives_unknown_topic(self):
+        calls = []
+        self._drive(
+            [("T.unknown", {"k": 1}), ("T.ok", {"k": 2})],
+            {"T.ok": lambda _i, _d: calls.append("ok")},
+        )
+        assert calls == ["ok"]  # unknown topic skipped, loop continued
+
+
+class TestSnapshotableDevice:
+    def _make(self, get_state=None, set_state=None):
+        io = FakeIOServer()
+        holder = {"state": {"count": 1}}
+        dev = SnapshotableDevice(
+            io, "dev-1",
+            get_state or (lambda: dict(holder["state"])),
+            set_state or holder["state"].update)
+        return io, dev, holder
+
+    def test_registers_both_topics(self):
+        io, dev, _ = self._make()
+        assert set(io.topics) == {SnapshotableDevice.SAVE_TOPIC,
+                                  SnapshotableDevice.RESTORE_TOPIC}
+
+    def test_save_replies_with_state(self):
+        io, dev, _ = self._make()
+        io.topics[SnapshotableDevice.SAVE_TOPIC](io, {"snapshot_id": "s1"})
+        assert io.sent == [(SnapshotableDevice.STATE_TOPIC,
+                            {"snapshot_id": "s1", "device_id": "dev-1",
+                             "state": {"count": 1}})]
+
+    def test_get_state_failure_stays_silent(self):
+        def boom():
+            raise RuntimeError("no state for you")
+        io, dev, _ = self._make(get_state=boom)
+        io.topics[SnapshotableDevice.SAVE_TOPIC](io, {"snapshot_id": "s1"})
+        assert io.sent == []  # absent from the snapshot, not lying in it
+
+    def test_restore_applies_state_and_acks(self):
+        io, dev, holder = self._make()
+        io.topics[SnapshotableDevice.RESTORE_TOPIC](
+            io, {"snapshot_id": "s2",
+                 "states": {"dev-1": {"count": 42}}})
+        assert holder["state"] == {"count": 42}
+        assert io.sent == [(SnapshotableDevice.RESTORED_TOPIC,
+                            {"snapshot_id": "s2", "device_id": "dev-1",
+                             "ok": True})]
+
+    def test_restore_not_involving_us_is_ignored(self):
+        io, dev, holder = self._make()
+        io.topics[SnapshotableDevice.RESTORE_TOPIC](
+            io, {"snapshot_id": "s3", "states": {"other-dev": {}}})
+        assert io.sent == []
+        assert holder["state"] == {"count": 1}
+
+    def test_set_state_failure_nacks(self):
+        def boom(_state):
+            raise RuntimeError("cannot apply")
+        io, dev, _ = self._make(set_state=boom)
+        io.topics[SnapshotableDevice.RESTORE_TOPIC](
+            io, {"snapshot_id": "s4", "states": {"dev-1": {"count": 9}}})
+        assert io.sent == [(SnapshotableDevice.RESTORED_TOPIC,
+                            {"snapshot_id": "s4", "device_id": "dev-1",
+                             "ok": False})]
+
+    def test_malformed_save_is_ignored(self):
+        # No snapshot_id: nothing captured, get_state not even called.
+        called = []
+        io, dev, _ = self._make(get_state=lambda: called.append(1) or {})
+        io.topics[SnapshotableDevice.SAVE_TOPIC](io, {"no": "snapshot_id"})
+        assert io.sent == []
+        assert called == []
+
+    def test_malformed_restore_is_ignored(self):
+        # No snapshot_id: set_state not called, nothing acked.
+        io, dev, holder = self._make()
+        io.topics[SnapshotableDevice.RESTORE_TOPIC](
+            io, {"states": {"dev-1": {"count": 5}}})
+        assert io.sent == []
+        assert holder["state"] == {"count": 1}
+
+    def test_two_devices_on_one_ioserver_both_answer(self):
+        """Two devices sharing an IOServer must BOTH answer save (the
+        dispatcher fans out) — not silently clobber via register_topic."""
+        io = FakeIOServer()
+        SnapshotableDevice(io, "dev-a", lambda: {"a": 1}, lambda s: None)
+        SnapshotableDevice(io, "dev-b", lambda: {"b": 2}, lambda s: None)
+        io.topics[SnapshotableDevice.SAVE_TOPIC](io, {"snapshot_id": "s"})
+        replied = {d["device_id"]: d["state"] for _t, d in io.sent}
+        assert replied == {"dev-a": {"a": 1}, "dev-b": {"b": 2}}
+
+    def test_duplicate_device_id_raises(self):
+        io = FakeIOServer()
+        SnapshotableDevice(io, "dup", lambda: {}, lambda s: None)
+        with pytest.raises(ValueError, match="duplicate snapshot device_id"):
+            SnapshotableDevice(io, "dup", lambda: {}, lambda s: None)
+
+    def test_send_failure_does_not_escape(self):
+        """A non-serializable state (send raises) must be contained so the
+        IOServer rx thread survives — the device just stays absent."""
+        class BoomOnSend(FakeIOServer):
+            def send_msg(self, topic, data):
+                raise TypeError("cannot represent this state in yaml")
+
+        io = BoomOnSend()
+        dev = SnapshotableDevice(io, "dev-1", lambda: {"x": object()},
+                                 lambda s: None)
+        # Must NOT raise out of the handler (which would kill the rx thread).
+        io.topics[SnapshotableDevice.SAVE_TOPIC](io, {"snapshot_id": "s1"})
+        io.topics[SnapshotableDevice.RESTORE_TOPIC](
+            io, {"snapshot_id": "s2", "states": {"dev-1": {}}})

--- a/test/pytest/snapshot/test_peripheral_registry.py
+++ b/test/pytest/snapshot/test_peripheral_registry.py
@@ -1,0 +1,282 @@
+"""Layer-2 peripheral-model snapshot tests.
+
+Covers the explicit per-model save/restore (uart/gpio/interrupts), the generic
+deep-copy fallback + SnapshotableModel mixin, and the whole PeripheralRegistry
+round-trip. The alias-preservation case (Interrupts.Active_Interrupts is active)
+is the subtle correctness requirement.
+"""
+from collections import defaultdict, deque
+
+import pytest
+
+from halucinator.peripheral_models.gpio import GPIO
+from halucinator.peripheral_models.interrupts import Interrupts
+from halucinator.peripheral_models.uart import UARTPublisher
+from halucinator.snapshot import (
+    PeripheralRegistry,
+    SnapshotableModel,
+    default_restore,
+    default_save,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    """Reset the class-level peripheral state around every test so nothing
+    leaks between tests (these are module-global dicts/deques)."""
+    UARTPublisher.rx_buffers = defaultdict(deque)
+    GPIO.gpio_state = defaultdict(int)
+    Interrupts.active = defaultdict(bool)
+    Interrupts.Active_Interrupts = Interrupts.active
+    Interrupts.enabled = defaultdict(bool)
+    yield
+
+
+class TestExplicitModelSaveRestore:
+    def test_uart_round_trip(self):
+        UARTPublisher.rx_buffers[0].extend("hello")
+        UARTPublisher.rx_buffers[1].extend("world")
+        state = UARTPublisher.save_state()
+
+        UARTPublisher.rx_buffers[0].clear()
+        UARTPublisher.rx_buffers[2].extend("junk")
+
+        assert UARTPublisher.restore_state(state) is True
+        assert list(UARTPublisher.rx_buffers[0]) == list("hello")
+        assert list(UARTPublisher.rx_buffers[1]) == list("world")
+        assert 2 not in UARTPublisher.rx_buffers
+
+    def test_uart_restore_preserves_buffer_alias(self):
+        """A caller holding a reference to rx_buffers before restore should see
+        the restored contents through that same reference (in-place restore)."""
+        alias = UARTPublisher.rx_buffers
+        UARTPublisher.rx_buffers[0].extend("abc")
+        state = UARTPublisher.save_state()
+        UARTPublisher.rx_buffers[0].clear()
+        UARTPublisher.restore_state(state)
+        assert alias is UARTPublisher.rx_buffers
+        assert list(alias[0]) == list("abc")
+
+    def test_gpio_round_trip(self):
+        GPIO.gpio_state["PA0"] = 1
+        GPIO.gpio_state["PB3"] = 1
+        state = GPIO.save_state()
+
+        GPIO.gpio_state["PA0"] = 0
+        GPIO.gpio_state["PC7"] = 1
+
+        assert GPIO.restore_state(state) is True
+        assert GPIO.gpio_state["PA0"] == 1
+        assert GPIO.gpio_state["PB3"] == 1
+        assert "PC7" not in GPIO.gpio_state
+
+    def test_interrupts_round_trip_and_alias(self):
+        Interrupts.active[3] = True
+        Interrupts.enabled[3] = True
+        state = Interrupts.save_state()
+
+        # Mutate, and confirm the alias tracks the mutation (they are one dict).
+        Interrupts.active[3] = False
+        Interrupts.active[9] = True
+        assert Interrupts.Active_Interrupts[9] is True
+
+        assert Interrupts.restore_state(state) is True
+        assert Interrupts.active[3] is True
+        assert 9 not in Interrupts.active
+        # The alias MUST still be the very same object after restore.
+        assert Interrupts.Active_Interrupts is Interrupts.active
+        assert Interrupts.Active_Interrupts[3] is True
+
+
+class TestGenericDefault:
+    def test_default_save_restore_mutable_attrs(self):
+        class Model:
+            d = {}
+            lst = []
+
+        Model.d["k"] = 1
+        Model.lst.append("x")
+        state = default_save(Model)
+
+        Model.d["k"] = 999
+        Model.lst.append("y")
+
+        assert default_restore(Model, state) is True
+        assert Model.d == {"k": 1}
+        assert Model.lst == ["x"]
+
+    def test_default_restore_is_in_place(self):
+        class Model:
+            d = {"a": 1}
+
+        alias = Model.d
+        state = default_save(Model)
+        Model.d["a"] = 2
+        default_restore(Model, state)
+        assert alias is Model.d  # not rebound
+        assert alias["a"] == 1
+
+    def test_snapshotable_mixin(self):
+        class Model(SnapshotableModel):
+            counters = {}
+
+        Model.counters["hits"] = 5
+        state = Model.save_state()
+        Model.counters["hits"] = 0
+        assert Model.restore_state(state) is True
+        assert Model.counters["hits"] == 5
+
+    def test_set_and_bytearray_restore_in_place(self):
+        """A model whose state is a set / bytearray must restore through the
+        set/bytearray in-place branches (not the setattr rebind), preserving
+        aliases just like dict/list do."""
+        class Model:
+            flags = {1, 2, 3}
+            buf = bytearray(b"orig")
+
+        flags_alias, buf_alias = Model.flags, Model.buf
+        state = default_save(Model)
+        Model.flags.add(99)
+        Model.flags.discard(1)
+        Model.buf[:] = b"XXXX"
+
+        assert default_restore(Model, state) is True
+        assert Model.flags == {1, 2, 3}
+        assert bytes(Model.buf) == b"orig"
+        # in place: the same live objects, not rebound copies
+        assert Model.flags is flags_alias
+        assert Model.buf is buf_alias
+
+    def test_restore_rebinds_when_container_type_changed(self):
+        """If the live attribute is no longer a matching container (shape
+        changed since capture), _restore_in_place returns False and
+        default_restore falls back to setattr — the value is still restored,
+        just rebound rather than mutated in place."""
+        class Model:
+            val = {"was": "dict"}
+
+        state = default_save(Model)
+        Model.val = ["now", "a", "list"]  # type changed -> rebind path
+        assert default_restore(Model, state) is True
+        assert Model.val == {"was": "dict"}
+
+    def test_snapshotable_attrs_skips_raising_descriptor(self):
+        """A property that raises on access must be skipped by the attribute
+        walk, not abort the whole capture (the descriptor-guard branch)."""
+        class Model:
+            good = {"k": 1}
+
+            @property
+            def boom(self):  # noqa: D401 - test fixture
+                raise RuntimeError("do not touch me")
+
+        # default_save walks dir(instance); the raising property is skipped.
+        state = default_save(Model())
+        assert state == {"good": {"k": 1}}
+
+
+class TestPeripheralRegistry:
+    def test_round_trip_across_models(self):
+        UARTPublisher.rx_buffers[0].extend("uart")
+        GPIO.gpio_state["PA1"] = 1
+        Interrupts.active[2] = True
+        Interrupts.enabled[2] = True
+
+        reg = PeripheralRegistry()
+        snap = reg.snapshot()
+
+        # Mutate every model.
+        UARTPublisher.rx_buffers[0].clear()
+        GPIO.gpio_state["PA1"] = 0
+        Interrupts.active[2] = False
+
+        assert reg.restore(snap) is True
+        assert list(UARTPublisher.rx_buffers[0]) == list("uart")
+        assert GPIO.gpio_state["PA1"] == 1
+        assert Interrupts.active[2] is True
+        assert Interrupts.Active_Interrupts is Interrupts.active
+
+    def test_registry_captures_hal_stats(self):
+        from halucinator import hal_stats
+        hal_stats.stats.clear()
+        hal_stats.stats["boots"] = 1
+
+        reg = PeripheralRegistry()
+        snap = reg.snapshot()
+
+        hal_stats.stats["boots"] = 42
+        hal_stats.stats["extra"] = "x"
+
+        assert reg.restore(snap) is True
+        assert hal_stats.stats == {"boots": 1}
+
+    def test_restore_false_when_target_missing(self):
+        reg = PeripheralRegistry()
+        snap = reg.snapshot()
+        # A captured target that no longer resolves to a live object.
+        snap["model:nonexistent.Model"] = {"x": 1}
+        assert reg.restore(snap) is False
+
+    def test_snapshot_raises_when_a_target_save_fails(self):
+        """A registered handler whose save_state raises must make the whole
+        snapshot raise (never a partial capture)."""
+        from halucinator.bp_handlers import intercepts
+
+        class BadSave:
+            def save_state(self):
+                raise ValueError("cannot capture me")
+
+        intercepts.initalized_classes["bad_save"] = BadSave()
+        try:
+            with pytest.raises(RuntimeError, match="snapshot failed"):
+                PeripheralRegistry().snapshot()
+        finally:
+            intercepts.initalized_classes.pop("bad_save", None)
+
+    def test_restore_false_when_a_target_restore_fails(self):
+        """A live target whose restore_state returns False makes the registry
+        restore return False (all-or-nothing)."""
+        from halucinator.bp_handlers import intercepts
+
+        class BadRestore:
+            def save_state(self):
+                return {"v": 1}
+
+            def restore_state(self, _state):
+                return False
+
+        intercepts.initalized_classes["bad_restore"] = BadRestore()
+        try:
+            reg = PeripheralRegistry()
+            snap = reg.snapshot()
+            assert reg.restore(snap) is False
+        finally:
+            intercepts.initalized_classes.pop("bad_restore", None)
+
+    def test_timer_model_snapshots_parameters_not_threads(self):
+        """TimerModel.active_timers holds live Event/Thread pairs — the
+        generic deep-copy chokes on those (the full-suite order-dependency
+        bug this guards against). Its explicit save/restore captures timer
+        PARAMETERS and relaunches threads on restore."""
+        from halucinator.peripheral_models.timer_model import TimerModel
+        try:
+            # Rate is huge so no tick ever fires during the test.
+            TimerModel.start_timer("snap_test_timer", 42, 3600.0)
+
+            reg = PeripheralRegistry()
+            snap = reg.snapshot()  # must not raise on the live thread
+            key = ("model:halucinator.peripheral_models.timer_model."
+                   "TimerModel")
+            assert snap[key]["timers"]["snap_test_timer"] == {
+                "irq_num": 42, "rate": 3600.0, "delay": 0, "stopped": False}
+
+            TimerModel.stop_timer("snap_test_timer")
+            TimerModel.active_timers.clear()
+
+            assert reg.restore(snap) is True
+            assert "snap_test_timer" in TimerModel.active_timers
+            _ev, thread = TimerModel.active_timers["snap_test_timer"]
+            assert thread.irq_num == 42 and thread.rate == 3600.0
+        finally:
+            TimerModel.shutdown()
+            TimerModel.active_timers.clear()

--- a/test/pytest/snapshot/test_persist.py
+++ b/test/pytest/snapshot/test_persist.py
@@ -1,0 +1,378 @@
+"""Disk-persistence tests: a snapshot written by one process must restore in a
+fresh one. The load-bearing assertion is the CROSS-PROCESS round-trip: save a
+unicorn snapshot to a file, restore it in a brand-new python process into a
+freshly-init'd backend, and get a byte-identical machine image back.
+"""
+import hashlib
+import pickle
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from halucinator.backends.hal_backend import Snapshot, SnapshotError
+from halucinator.snapshot import (
+    SystemSnapshot,
+    load_snapshot_file,
+    save_snapshot_file,
+)
+from halucinator.snapshot.persist import FORMAT_VERSION
+
+from .test_backend_snapshot import (
+    FLASH_BASE,
+    FLASH_SIZE,
+    RAM_BASE,
+    RAM_SIZE,
+    DictBackend,
+)
+
+try:
+    import unicorn  # noqa: F401
+    _HAVE_UNICORN = True
+except ImportError:
+    _HAVE_UNICORN = False
+
+
+class TestFileRoundTrip:
+    def test_generic_snapshot_survives_the_file(self, tmp_path):
+        b = DictBackend()
+        b.write_memory(RAM_BASE, 1, b"persist-me!", 11, raw=True)
+        b.write_register("r3", 0x33333333)
+        snap = b.save_state()
+
+        p = save_snapshot_file(snap, tmp_path / "s.halsnap")
+        loaded, header = load_snapshot_file(p)
+
+        assert header["kind"] == "backend"
+        assert header["backend_type"] == "DictBackend"
+        assert header["format_version"] == FORMAT_VERSION
+
+        # Clobber, then restore from the LOADED (deserialized) snapshot.
+        b.write_memory(RAM_BASE, 1, b"XXXXXXXXXXX", 11, raw=True)
+        b.write_register("r3", 0)
+        assert b.restore_state(loaded) is True
+        assert b.read_memory(RAM_BASE, 1, 11, raw=True) == b"persist-me!"
+        assert b.read_register("r3") == 0x33333333
+
+    def test_system_snapshot_kind_round_trips(self, tmp_path):
+        b = DictBackend()
+        snap = SystemSnapshot(backend=b.save_state(),
+                              peripherals={"model:fake": {"rx": [1, 2, 3]}})
+        p = save_snapshot_file(snap, tmp_path / "sys.halsnap")
+        loaded, header = load_snapshot_file(p)
+        assert header["kind"] == "system"
+        assert isinstance(loaded, SystemSnapshot)
+        assert loaded.peripherals == {"model:fake": {"rx": [1, 2, 3]}}
+        assert b.restore_state(loaded.backend) is True
+
+
+class TestUnicornVersionProbe:
+    def test_returns_none_when_unicorn_absent(self, monkeypatch):
+        """unicorn is an optional dependency; _unicorn_version must return
+        None (not raise) when it isn't importable."""
+        import sys
+        from halucinator.snapshot import persist
+        # sys.modules[name] = None makes `import name` raise ImportError.
+        monkeypatch.setitem(sys.modules, "unicorn", None)
+        assert persist._unicorn_version() is None
+
+
+class TestHeaderValidation:
+    def test_rejects_non_snapshot_file(self, tmp_path):
+        p = tmp_path / "junk.halsnap"
+        p.write_bytes(b"this is not a snapshot")
+        with pytest.raises(SnapshotError):
+            load_snapshot_file(p)
+
+    def test_rejects_wrong_magic(self, tmp_path):
+        import gzip
+        p = tmp_path / "alien.halsnap"
+        with gzip.open(p, "wb") as gz:
+            pickle.dump(({"magic": "NOTHAL"}, None), gz)
+        with pytest.raises(SnapshotError, match="bad magic"):
+            load_snapshot_file(p)
+
+    def test_rejects_future_format_version(self, tmp_path):
+        import gzip
+        p = tmp_path / "future.halsnap"
+        with gzip.open(p, "wb") as gz:
+            pickle.dump(({"magic": "HALSNAP", "format_version": 999}, None), gz)
+        with pytest.raises(SnapshotError, match="format_version"):
+            load_snapshot_file(p)
+
+    def test_rejects_kind_payload_mismatch(self, tmp_path):
+        import gzip
+        p = tmp_path / "lie.halsnap"
+        header = {"magic": "HALSNAP", "format_version": FORMAT_VERSION,
+                  "kind": "system", "unicorn_version": None}
+        with gzip.open(p, "wb") as gz:
+            pickle.dump((header, Snapshot("X", 1, None)), gz)
+        with pytest.raises(SnapshotError, match="kind"):
+            load_snapshot_file(p)
+
+    @pytest.mark.skipif(not _HAVE_UNICORN, reason="unicorn not installed")
+    def test_rejects_nonportable_unicorn_snapshot(self, tmp_path):
+        """A native context blob pickles fine but is process-local — the save
+        must refuse it (with the portable=True fix in the message) rather
+        than write a file that crashes some future process."""
+        from halucinator.backends.hal_backend import MemoryRegion
+        from halucinator.backends.unicorn_backend import UnicornBackend
+        b = UnicornBackend(arch="cortex-m3")
+        b.add_memory_region(MemoryRegion("ram", RAM_BASE, RAM_SIZE, "rw"))
+        b.init()
+        with pytest.raises(SnapshotError, match="portable=True"):
+            save_snapshot_file(b.save_state(), tmp_path / "uc.halsnap")
+        assert not (tmp_path / "uc.halsnap").exists()
+
+    @pytest.mark.skipif(not _HAVE_UNICORN, reason="unicorn not installed")
+    def test_unicorn_version_mismatch_warns_but_loads(self, tmp_path,
+                                                      monkeypatch, caplog):
+        from halucinator.backends.hal_backend import MemoryRegion
+        from halucinator.backends.unicorn_backend import UnicornBackend
+        b = UnicornBackend(arch="cortex-m3")
+        b.add_memory_region(MemoryRegion("ram", RAM_BASE, RAM_SIZE, "rw"))
+        b.init()
+        p = save_snapshot_file(b.save_state(portable=True),
+                               tmp_path / "uc.halsnap")
+
+        monkeypatch.setattr("halucinator.snapshot.persist._unicorn_version",
+                            lambda: "0.0.0-other-build")
+        with caplog.at_level("WARNING"):
+            loaded, header = load_snapshot_file(p)
+        assert loaded.backend_type == "UnicornBackend"
+        assert any("unicorn" in r.message for r in caplog.records)
+
+
+class TestAtomicity:
+    def test_failed_save_leaves_no_file(self, tmp_path):
+        import threading
+        bad = Snapshot(backend_type="X", version=1,
+                       data={"lock": threading.Lock()})  # unpicklable
+        dest = tmp_path / "never.halsnap"
+        with pytest.raises(SnapshotError):
+            save_snapshot_file(bad, dest)
+        assert not dest.exists()
+        assert list(tmp_path.iterdir()) == []  # no temp litter either
+
+
+# ---------------------------------------------------------------------------
+# Portable-capture fidelity: the enumerated form must carry the system state
+# a context blob would have (banked modes + CP15 on A-profile, MSP/PSP &
+# friends on M-profile) — this is what the M340/ARM926 rehost depends on.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _HAVE_UNICORN, reason="unicorn not installed")
+class TestPortableFidelity:
+    def _fresh(self, arch, cpu_model=None):
+        import os
+        from halucinator.backends.hal_backend import MemoryRegion
+        from halucinator.backends.unicorn_backend import UnicornBackend
+        old = os.environ.get("HAL_ARM_CPU_MODEL")
+        if cpu_model:
+            os.environ["HAL_ARM_CPU_MODEL"] = cpu_model
+        try:
+            b = UnicornBackend(arch=arch)
+            b.add_memory_region(MemoryRegion("ram", RAM_BASE, RAM_SIZE, "rwx"))
+            b.init()
+        finally:
+            if cpu_model:
+                if old is None:
+                    os.environ.pop("HAL_ARM_CPU_MODEL", None)
+                else:
+                    os.environ["HAL_ARM_CPU_MODEL"] = old
+        return b
+
+    def test_vfp_and_v7_cp15_round_trip_on_cortex_a15(self, tmp_path):
+        """A VFP-capable A-profile core (cortex-a15) must round-trip the
+        VFP register file and the v7 CP15 regs (VBAR/TTBR1/TPIDR*) through a
+        portable disk snapshot — the fidelity gap findings 2 & 3 flagged."""
+        import unicorn.arm_const as a
+        b = self._fresh("arm", cpu_model="UC_CPU_ARM_CORTEX_A15")
+        uc = b._uc
+        # Plant FP state and a relocated vector base + a thread-id reg.
+        uc.reg_write(a.UC_ARM_REG_D8, 0x1122334455667788)
+        uc.reg_write(a.UC_ARM_REG_D0, 0xCAFEF00DDEADBEEF)
+        uc.reg_write(a.UC_ARM_REG_CP_REG, (15, 0, 0, 12, 0, 0, 0, 0x70000000))  # VBAR
+        uc.reg_write(a.UC_ARM_REG_CP_REG, (15, 0, 0, 13, 0, 0, 2, 0xABCD0000))  # TPIDRURW
+
+        snap = b.save_state(portable=True)
+        assert snap.data["vfp"]["d8"] == 0x1122334455667788
+        assert snap.data["cp15"]["vbar"] == 0x70000000
+        assert snap.data["cp15"]["tpidrurw"] == 0xABCD0000
+
+        p = save_snapshot_file(snap, tmp_path / "a15.halsnap")
+        loaded, _ = load_snapshot_file(p)
+        b2 = self._fresh("arm", cpu_model="UC_CPU_ARM_CORTEX_A15")
+        assert b2.restore_state(loaded) is True
+        uc2 = b2._uc
+        assert uc2.reg_read(a.UC_ARM_REG_D8) == 0x1122334455667788
+        assert uc2.reg_read(a.UC_ARM_REG_D0) == 0xCAFEF00DDEADBEEF
+        assert uc2.reg_read(a.UC_ARM_REG_CP_REG, (15, 0, 0, 12, 0, 0, 0)) == 0x70000000
+        assert uc2.reg_read(a.UC_ARM_REG_CP_REG, (15, 0, 0, 13, 0, 0, 2)) == 0xABCD0000
+
+    def test_a_profile_banked_and_cp15_round_trip(self, tmp_path):
+        import unicorn.arm_const as a
+        b = self._fresh("arm")
+        uc = b._uc
+        cpsr_id = a.UC_ARM_REG_CPSR
+        orig_cpsr = uc.reg_read(cpsr_id)
+
+        # Plant distinct values in three banked modes + one CP15 reg.
+        planted = {0x12: ("irq", 0x20001111), 0x13: ("svc", 0x20002222),
+                   0x11: ("fiq", 0x20003333)}
+        for mode, (_tag, sp) in planted.items():
+            uc.reg_write(cpsr_id, (orig_cpsr & ~0x1F) | mode)
+            uc.reg_write(a.UC_ARM_REG_SP, sp)
+        uc.reg_write(cpsr_id, orig_cpsr)
+        dacr_spec = (15, 0, 0, 3, 0, 0, 0)
+        uc.reg_write(a.UC_ARM_REG_CP_REG, dacr_spec + (0x55555555,))
+
+        snap = b.save_state(portable=True)
+        assert snap.data.get("portable") is True
+        # It must actually have captured the planted banked values.
+        assert snap.data["banked"]["irq"]["sp"] == 0x20001111
+        assert snap.data["banked"]["svc"]["sp"] == 0x20002222
+        assert snap.data["banked"]["fiq"]["sp"] == 0x20003333
+        assert snap.data["cp15"]["dacr"] == 0x55555555
+
+        # Round-trip through DISK into a FRESH backend (same process — the
+        # cross-process case is covered below; this isolates fidelity).
+        p = save_snapshot_file(snap, tmp_path / "aprof.halsnap")
+        loaded, _ = load_snapshot_file(p)
+        b2 = self._fresh("arm")
+        assert b2.restore_state(loaded) is True
+        uc2 = b2._uc
+        for mode, (_tag, sp) in planted.items():
+            uc2.reg_write(cpsr_id, (uc2.reg_read(cpsr_id) & ~0x1F) | mode)
+            assert uc2.reg_read(a.UC_ARM_REG_SP) == sp, hex(mode)
+        uc2.reg_write(cpsr_id, orig_cpsr)
+        assert uc2.reg_read(a.UC_ARM_REG_CP_REG, dacr_spec) == 0x55555555
+        assert uc2.reg_read(cpsr_id) == orig_cpsr
+
+    def test_m_profile_sysregs_round_trip(self, tmp_path):
+        import unicorn.arm_const as a
+        b = self._fresh("cortex-m3")
+        b._uc.reg_write(a.UC_ARM_REG_MSP, RAM_BASE + 0x4000)
+        b._uc.reg_write(a.UC_ARM_REG_PSP, RAM_BASE + 0x2000)
+        b._uc.reg_write(a.UC_ARM_REG_PRIMASK, 1)
+
+        snap = b.save_state(portable=True)
+        assert snap.data["m_sysregs"]["msp"] == RAM_BASE + 0x4000
+        assert snap.data["m_sysregs"]["psp"] == RAM_BASE + 0x2000
+        assert snap.data["m_sysregs"]["primask"] == 1
+
+        p = save_snapshot_file(snap, tmp_path / "mprof.halsnap")
+        loaded, _ = load_snapshot_file(p)
+        b2 = self._fresh("cortex-m3")
+        assert b2.restore_state(loaded) is True
+        assert b2._uc.reg_read(a.UC_ARM_REG_MSP) == RAM_BASE + 0x4000
+        assert b2._uc.reg_read(a.UC_ARM_REG_PSP) == RAM_BASE + 0x2000
+        assert b2._uc.reg_read(a.UC_ARM_REG_PRIMASK) == 1
+
+    def test_portable_resume_executes_identically(self):
+        """The portable form must be as faithful a resume point as the native
+        context blob: run the same code from both and compare images."""
+        import struct
+        b = self._fresh("cortex-m3")
+        insns = struct.pack("<HHHH", 0x2001, 0x2102, 0x2203, 0x4770)
+        b.write_memory(RAM_BASE, 1, insns, len(insns), raw=True)
+        b.write_register("pc", RAM_BASE)
+        b.write_register("lr", RAM_BASE + len(insns))
+        b.write_register("sp", RAM_BASE + 0x2000)
+
+        native = b.save_state()
+        portable = b.save_state(portable=True)
+
+        b.set_breakpoint(RAM_BASE + 6)
+        b.cont()
+        run_native_regs = {n: b.read_register(n) for n in b.list_registers()}
+
+        assert b.restore_state(portable) is True
+        b.cont()
+        run_portable_regs = {n: b.read_register(n) for n in b.list_registers()}
+        assert run_portable_regs == run_native_regs
+
+        assert b.restore_state(native) is True  # leave nothing weird behind
+
+
+# ---------------------------------------------------------------------------
+# The point of the module: restore in a FRESH PROCESS.
+# ---------------------------------------------------------------------------
+
+_CHILD = textwrap.dedent("""
+    import hashlib, struct, sys
+    from halucinator.backends.hal_backend import MemoryRegion
+    from halucinator.backends.unicorn_backend import UnicornBackend
+    from halucinator.snapshot import load_snapshot_file
+
+    FLASH_BASE, FLASH_SIZE = {flash_base}, {flash_size}
+    RAM_BASE, RAM_SIZE = {ram_base}, {ram_size}
+
+    # Fresh backend, same config as the producer — the documented restore flow.
+    b = UnicornBackend(arch="cortex-m3")
+    b.add_memory_region(MemoryRegion("flash", FLASH_BASE, FLASH_SIZE, "rwx"))
+    b.add_memory_region(MemoryRegion("ram", RAM_BASE, RAM_SIZE, "rw"))
+    b.init()
+
+    snap, header = load_snapshot_file(sys.argv[1])
+    assert b.restore_state(snap) is True, "restore_state refused the snapshot"
+
+    # Resume: run the same 3-instruction sequence to its breakpoint.
+    b.set_breakpoint(FLASH_BASE + 6)
+    b.cont()
+
+    h = hashlib.sha256()
+    for base, end, _p in sorted(b._uc.mem_regions()):
+        h.update(bytes(b._uc.mem_read(base, end - base + 1)))
+    for name in b.list_registers():
+        h.update(struct.pack("<Q", b.read_register(name) & (2**64 - 1)))
+    print(h.hexdigest())
+""")
+
+
+@pytest.mark.skipif(not _HAVE_UNICORN, reason="unicorn not installed")
+class TestCrossProcess:
+    def test_restore_in_fresh_process_resumes_identically(self, tmp_path):
+        """Producer boots + snapshots + runs to completion; a child process
+        restores the file and runs the same stretch. Both final machine
+        images must hash identically."""
+        import struct
+        from halucinator.backends.hal_backend import MemoryRegion
+        from halucinator.backends.unicorn_backend import UnicornBackend
+
+        b = UnicornBackend(arch="cortex-m3")
+        b.add_memory_region(MemoryRegion("flash", FLASH_BASE, FLASH_SIZE, "rwx"))
+        b.add_memory_region(MemoryRegion("ram", RAM_BASE, RAM_SIZE, "rw"))
+        b.init()
+
+        # MOV r0,#1; MOV r1,#2; MOV r2,#3; BX LR  (Thumb)
+        insns = struct.pack("<HHHH", 0x2001, 0x2102, 0x2203, 0x4770)
+        b.write_memory(FLASH_BASE, 1, insns, len(insns), raw=True)
+        b.write_memory(RAM_BASE, 1, b"boot-state-marker", 17, raw=True)
+        b.write_register("pc", FLASH_BASE)
+        b.write_register("lr", FLASH_BASE + len(insns))
+        b.write_register("sp", RAM_BASE + 0x2000)
+
+        snap_file = save_snapshot_file(b.save_state(portable=True),
+                                       tmp_path / "boot.halsnap")
+
+        # Producer's ground-truth run.
+        b.set_breakpoint(FLASH_BASE + 6)
+        b.cont()
+        h = hashlib.sha256()
+        for base, end, _p in sorted(b._uc.mem_regions()):
+            h.update(bytes(b._uc.mem_read(base, end - base + 1)))
+        for name in b.list_registers():
+            h.update(struct.pack("<Q", b.read_register(name) & (2**64 - 1)))
+        expected = h.hexdigest()
+
+        child_src = _CHILD.format(flash_base=FLASH_BASE, flash_size=FLASH_SIZE,
+                                  ram_base=RAM_BASE, ram_size=RAM_SIZE)
+        result = subprocess.run(
+            [sys.executable, "-c", child_src, str(snap_file)],
+            capture_output=True, text=True, timeout=120)
+        assert result.returncode == 0, (
+            f"child failed:\nstdout={result.stdout}\nstderr={result.stderr}")
+        assert result.stdout.strip() == expected, (
+            "fresh-process resume diverged from the producer's run")

--- a/test/pytest/snapshot/test_session_snapshot.py
+++ b/test/pytest/snapshot/test_session_snapshot.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Christopher Wright
+
+"""MCP-session snapshot tools against the real arm32 test firmware:
+in-memory checkpoint/rewind within a session, and .halsnap files that
+restore into a completely new session."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from halucinator.mcp import HalucinatorSession, SessionError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ARM32_DIR = REPO_ROOT / "test" / "multi_arch" / "arm32"
+
+
+def _arm32_configs():
+    return [
+        str(ARM32_DIR / "test_uart_config.yaml"),
+        str(ARM32_DIR / "test_uart_addrs.yaml"),
+        str(ARM32_DIR / "test_uart_memory.yaml"),
+    ]
+
+
+pytestmark = pytest.mark.skipif(
+    not (ARM32_DIR / "firmware" / "test_uart.bin").exists(),
+    reason="arm32 test firmware not built",
+)
+
+
+@pytest.fixture
+def session(monkeypatch):
+    monkeypatch.chdir(ARM32_DIR)
+    sess = HalucinatorSession()
+    sess.start(_arm32_configs(), emulator="unicorn",
+               target_name="snap_test", start_periph_server=False)
+    yield sess
+    sess.shutdown()
+
+
+class TestInMemorySnapshots:
+    def test_save_step_restore_rewinds(self, session):
+        saved = session.save_snapshot()
+        assert saved["kind"] == "memory"
+        start_pc = saved["pc"]
+
+        for _ in range(4):
+            session.step()
+        assert session.read_register("pc") != start_pc
+
+        out = session.restore_snapshot(snapshot_id=saved["snapshot_id"])
+        assert out["ok"] is True, out
+        assert session.read_register("pc") == start_pc
+        # ... and the machine is runnable again from there.
+        session.step()
+
+    def test_list_and_delete(self, session):
+        a = session.save_snapshot()["snapshot_id"]
+        b = session.save_snapshot()["snapshot_id"]
+        ids = [s["snapshot_id"] for s in session.list_snapshots()]
+        assert sorted(ids) == sorted([a, b])
+        assert session.delete_snapshot(a) is True
+        ids = [s["snapshot_id"] for s in session.list_snapshots()]
+        assert ids == [b]
+        with pytest.raises(SessionError, match="no such snapshot"):
+            session.delete_snapshot(a)
+
+    def test_restore_unknown_id_raises(self, session):
+        with pytest.raises(SessionError, match="no such snapshot"):
+            session.restore_snapshot(snapshot_id="snap-nope")
+
+    def test_restore_needs_exactly_one_source(self, session):
+        with pytest.raises(SessionError, match="exactly one"):
+            session.restore_snapshot()
+        with pytest.raises(SessionError, match="exactly one"):
+            session.restore_snapshot(snapshot_id="x", path="y")
+
+
+class TestFileSnapshots:
+    def test_file_snapshot_restores_in_new_session(self, tmp_path,
+                                                   monkeypatch):
+        monkeypatch.chdir(ARM32_DIR)
+        snap_file = str(tmp_path / "session.halsnap")
+
+        s1 = HalucinatorSession()
+        s1.start(_arm32_configs(), emulator="unicorn",
+                 target_name="snap_a", start_periph_server=False)
+        for _ in range(3):
+            s1.step()
+        mark_pc = s1.read_register("pc")
+        s1.write_memory(0x20000100, b"snapshot-marker")
+        saved = s1.save_snapshot(path=snap_file)
+        assert saved["kind"] == "file"
+        assert saved["pc"] == mark_pc
+        s1.shutdown()
+
+        # A brand-new session from the same configs — the documented
+        # fresh-process restore flow, minus the process boundary (that
+        # boundary is covered by test_persist.TestCrossProcess and the CLI
+        # e2e; this exercises the session/tool layer).
+        s2 = HalucinatorSession()
+        s2.start(_arm32_configs(), emulator="unicorn",
+                 target_name="snap_b", start_periph_server=False)
+        assert s2.read_register("pc") != mark_pc or True  # fresh at entry
+        out = s2.restore_snapshot(path=snap_file)
+        assert out["ok"] is True, out
+        assert s2.read_register("pc") == mark_pc
+        assert s2.read_memory(0x20000100, 15) == b"snapshot-marker"
+        s2.step()  # runnable
+        s2.shutdown()
+
+    def test_restore_missing_file_raises(self, session, tmp_path):
+        with pytest.raises(SessionError, match="not a readable snapshot"):
+            session.restore_snapshot(path=str(tmp_path / "missing.halsnap"))

--- a/test/pytest/snapshot/test_system_snapshot.py
+++ b/test/pytest/snapshot/test_system_snapshot.py
@@ -1,0 +1,178 @@
+"""Coordinator tests: the composite SystemSnapshot bundling Layer-1 (backend)
+and Layer-2 (peripherals), plus the RestoreResult failure contract.
+
+The headline test boots a tiny Unicorn machine, fills peripheral state, takes a
+system snapshot, corrupts BOTH layers, restores, and asserts the whole system —
+guest memory + registers AND python peripheral state — is byte-identical.
+"""
+from collections import defaultdict, deque
+
+import pytest
+
+from halucinator.backends.hal_backend import MemoryRegion, Snapshot
+from halucinator.peripheral_models.gpio import GPIO
+from halucinator.peripheral_models.interrupts import Interrupts
+from halucinator.peripheral_models.uart import UARTPublisher
+from halucinator.snapshot import (
+    PeripheralRegistry,
+    RestoreResult,
+    SystemSnapshot,
+    system_restore,
+    system_snapshot,
+)
+
+try:
+    import unicorn  # noqa: F401
+    _HAVE_UNICORN = True
+except ImportError:
+    _HAVE_UNICORN = False
+
+FLASH_BASE = 0x08000000
+RAM_BASE = 0x20000000
+
+
+@pytest.fixture(autouse=True)
+def clean_periph_state():
+    UARTPublisher.rx_buffers = defaultdict(deque)
+    GPIO.gpio_state = defaultdict(int)
+    Interrupts.active = defaultdict(bool)
+    Interrupts.Active_Interrupts = Interrupts.active
+    Interrupts.enabled = defaultdict(bool)
+    yield
+
+
+def _make_unicorn():
+    from halucinator.backends.unicorn_backend import UnicornBackend
+    b = UnicornBackend(arch="cortex-m3")
+    b.add_memory_region(MemoryRegion("flash", FLASH_BASE, 0x10000, "rwx"))
+    b.add_memory_region(MemoryRegion("ram", RAM_BASE, 0x8000, "rw"))
+    b.init()
+    return b
+
+
+def _full_backend_dump(b):
+    mem = {base: bytes(b._uc.mem_read(base, end - base + 1))
+           for (base, end, _p) in b._uc.mem_regions()}
+    regs = {name: b.read_register(name) for name in b.list_registers()}
+    return mem, regs
+
+
+@pytest.mark.skipif(not _HAVE_UNICORN, reason="unicorn-engine not installed")
+class TestSystemRoundTrip:
+    def test_byte_identical_backend_and_peripherals(self):
+        b = _make_unicorn()
+        b.write_memory(RAM_BASE, 1, bytes(range(256)) * 2, 512, raw=True)
+        b.write_register("r0", 0xABCDEF01)
+        b.write_register("sp", RAM_BASE + 0x2000)
+
+        UARTPublisher.rx_buffers[0].extend("greetings")
+        GPIO.gpio_state["LED"] = 1
+        Interrupts.active[7] = True
+        Interrupts.enabled[7] = True
+
+        reg = PeripheralRegistry()
+        snap = system_snapshot(b, reg)
+        assert isinstance(snap, SystemSnapshot)
+
+        before_mem, before_regs = _full_backend_dump(b)
+
+        # Corrupt BOTH layers.
+        b.write_memory(RAM_BASE, 1, b"\x00" * 512, 512, raw=True)
+        b.write_register("r0", 0)
+        UARTPublisher.rx_buffers[0].clear()
+        GPIO.gpio_state["LED"] = 0
+        Interrupts.active[7] = False
+
+        result = system_restore(b, snap, reg)
+        assert result.ok is True
+        assert result.layer is None
+
+        after_mem, after_regs = _full_backend_dump(b)
+        assert after_mem == before_mem
+        assert after_regs == before_regs
+        assert list(UARTPublisher.rx_buffers[0]) == list("greetings")
+        assert GPIO.gpio_state["LED"] == 1
+        assert Interrupts.active[7] is True
+
+    def test_context_manager_releases(self):
+        b = _make_unicorn()
+        with system_snapshot(b) as snap:
+            assert snap._released is False
+        assert snap._released is True
+
+    def test_release_is_idempotent(self):
+        b = _make_unicorn()
+        snap = system_snapshot(b)
+        snap.release()
+        assert snap._released is True
+        snap.release()  # second call hits the early-return, must not raise
+        assert snap._released is True
+
+    def test_system_snapshot_raises_leaves_no_bundle(self):
+        """If the peripheral layer fails to capture, the backend snapshot is
+        released and the exception propagates — no half-bundle is returned."""
+        b = _make_unicorn()
+
+        class BoomRegistry:
+            def snapshot(self):
+                raise RuntimeError("peripheral capture boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            system_snapshot(b, BoomRegistry())
+
+
+class TestRestoreResultFailureContract:
+    def test_backend_failure_reported(self):
+        """When the backend refuses (incompatible snapshot), system_restore
+        reports layer='backend' and never touches peripherals."""
+        class FakeBackend:
+            def restore_state(self, snap):
+                return False
+
+        snap = SystemSnapshot(
+            backend=Snapshot(backend_type="X", version=1, data=None),
+            peripherals={})
+        result = system_restore(FakeBackend(), snap, PeripheralRegistry())
+        assert isinstance(result, RestoreResult)
+        assert result.ok is False
+        assert result.layer == "backend"
+        assert "backend" in result.message
+
+    def test_peripheral_failure_reported(self):
+        """Backend restores OK but a peripheral target is missing → the result
+        names the peripherals layer."""
+        class OkBackend:
+            def restore_state(self, snap):
+                return True
+
+        reg = PeripheralRegistry()
+        periph = reg.snapshot()
+        periph["model:ghost.Model"] = {"x": 1}  # unresolvable on restore
+
+        snap = SystemSnapshot(
+            backend=Snapshot(backend_type="X", version=1, data=None),
+            peripherals=periph)
+        result = system_restore(OkBackend(), snap, reg)
+        assert result.ok is False
+        assert result.layer == "peripherals"
+
+    def test_device_layer_failure_reported(self):
+        """Backend + peripherals restore OK, but the device layer refuses →
+        the result names the devices layer."""
+        class OkBackend:
+            def restore_state(self, snap):
+                return True
+
+        class FailingDeviceLayer:
+            def restore(self, _states):
+                return False
+
+        snap = SystemSnapshot(
+            backend=Snapshot(backend_type="X", version=1, data=None),
+            peripherals={},
+            devices={"bridge-1": {"count": 7}})
+        result = system_restore(OkBackend(), snap, PeripheralRegistry(),
+                                device_layer=FailingDeviceLayer())
+        assert result.ok is False
+        assert result.layer == "devices"
+        assert "device layer restore failed" in result.message


### PR DESCRIPTION
## What

Whole-machine **snapshot / restore** for HALucinator: save and restore the
complete state of an emulation and resume from it — in-memory (millisecond
experiment checkpoints) or on disk (surviving process death, even a
fresh process). The motivating workflow is deep-gate rehosting: boot a
firmware once to a marker, then restore-and-experiment in seconds instead of
re-booting for every model tweak.

## Architecture — three layers, one coordinator (`snapshot/`)

| Layer | State | Implementation |
|---|---|---|
| 1 | Guest CPU + RAM | `UnicornBackend` native (fast) + **portable** plain-python capture for disk; generic reg+RAM fallback on every other backend |
| 2 | Python peripheral-model state | `PeripheralRegistry` (auto-discovers `@peripheral_model` classes, bp-handler instances, `hal_stats`) |
| 3 | External zmq device processes | cooperative save/state/restore/ack protocol; device opt-in via `SnapshotableDevice` |

`system_snapshot` / `system_restore` compose the layers. Contract is
**whole-or-nothing**: save raises rather than return a partial; restore
validates before mutating; the coordinator stops at the first failing layer
and names it; disk writes are atomic (temp + `os.replace`).

### Portability discovery
A raw unicorn `UcContext` pickles happily but embeds process-local pointers and
**SIGBUSes when restored in another process**. The portable form therefore
enumerates architectural state into plain values: general + banked ARM
registers (via a CPSR mode-switch dance), a CP15 set spanning ARMv5 MMU through
v7 (`VBAR`/`TTBR1`/`MAIR`/`TPIDR*`/`CPACR`, `SCTLR` restored last), and
VFP/NEON — each guarded so ARM926 through cortex-a15 all work. A machine
fingerprint (arch / CPU model / memory map) is validated before any write.

## Surface
- **Disk**: `snapshot/persist.py` — gzip'd pickled `(header, payload)`; header
  validated before the payload can reach a restore path.
- **MCP tools**: `save_snapshot` / `restore_snapshot` / `list_snapshots` /
  `delete_snapshot`.
- **CLI** (unicorn): `--snapshot-at <addr|symbol> --snapshot-out <path>`,
  `--restore <path>`, `--snapshot-include-devices`.

## All backends

Snapshot/restore works on **every** HalBackend, not just Unicorn. Unicorn has
a native fast path plus the portable disk form; the other five use the generic
`HalBackend` register + writable-RAM fallback (guest CPU + RAM — peripheral
state lives in Layer 2, so that is the correct split for HALucinator's
forwarded-peripheral model).

| Backend | Snapshot path | What it captures | Verified |
|---|---|---|---|
| **Unicorn** | native (`context_save`) + portable enumerated | full CPU incl. banked regs, CP15 (ARMv5→v7), VFP/NEON + all RAM; fingerprint-checked | unit + fresh-process e2e (local) |
| **QEMU** | generic reg+RAM (over GDB-RSP) | guest registers + writable RAM regions | live round-trip, real `qemu-system-arm` (Docker) |
| **LibAFL-QEMU** | inherits `QEMUBackend` | same as QEMU | live round-trip, real libafl-qemu (Docker) |
| **Avatar2** | generic reg+RAM | guest registers + writable RAM regions | live round-trip, real qemu via avatar2 (Docker) |
| **Renode** | generic reg+RAM | writable RAM (register writes need `start`) | live round-trip (memory), real renode (Docker) |
| **Ghidra** | generic reg+RAM (in-process p-code) | guest registers + writable RAM regions | live round-trip, real Ghidra emulator (Docker) |

Fixes required to make the generic path work everywhere:
- **Avatar2** never recorded `self._regions` (`add_memory_region` only forwarded
  to avatar) — its fallback raised "no writable regions". Now mirrors regions.
- **QEMU `_GDBClient`** sent a whole transfer in one `m`/`M` packet; a
  full-region read exceeds the stub's packet size and returns `E22`. Both
  directions are now chunked (general robustness fix, not snapshot-specific).
- The generic path **skips `emulate=` MMIO** (that is Layer-2 peripheral state,
  not RAM) and **tolerates per-stub register-set quirks** (a register a given
  GDB stub can't read/write is skipped with a warning, not fatal — different
  stubs expose different register names), while staying strict on memory.

Every backend's live round-trip is exercised in the CI Docker image against
the real emulator (`test/pytest/backends/test_live_*`, `test_ghidra_backend`);
the full backend + snapshot suites are **380 passed** there.

## Testing
- Unit + e2e locally, incl. **fresh-process byte-identical resume**
  (`test_cli_e2e.py`); snapshot package ~99% line coverage.
- Every backend's live snapshot round-trip **passes inside the CI Docker image**
  with real `qemu-system-arm` / libafl-qemu / renode / ghidra / avatar2 (full
  backend + snapshot suites: 380 passed).
- Hardening included along the way: an unguarded device-reply send that could
  kill the IOServer rx thread, a two-device `register_topic` clobber, a
  cross-thread SUB-socket subscribe, and several contract-hardening fixes.

## Not in scope (future)
Native full-machine snapshot for QEMU (`savevm`/migration) and Renode
(`Save`/`Load`) to also capture emulator-internal core devices; portable
capture of non-ARM hidden system state (x86 segments/MSRs, MIPS cp0).

Design of record: `doc/snapshot_restore.md`.

