### PR TITLE
libafl-qemu backend: fast in-QEMU snapshot/restore + native execution coverage over QMP (stacks on #49)

### DIFF
--- a/doc/snapshot_restore.md
+++ b/doc/snapshot_restore.md
@@ -73,7 +73,7 @@ checkpoints, wrong for per-input restores.
 | Unicorn | native + portable | full (CPU incl. banked/CP15/VFP + RAM) | ✅ | unit + e2e (local) |
 | Ghidra | generic reg+RAM | CPU regs + RAM | — | live round-trip (Docker) |
 | QEMU | generic reg+RAM | CPU regs + RAM (guest); QEMU-internal core devices not captured | — | live round-trip (Docker) |
-| LibAFL-QEMU | generic reg+RAM (via QEMUBackend) | same as QEMU | — | live round-trip (Docker) |
+| LibAFL-QEMU | **native syx-snapshot** (in-QEMU RAM+device); generic reg+RAM for `portable=True` | full machine, in-process | ✅ | live round-trip (Docker) |
 | Renode | generic reg+RAM | CPU regs + RAM (register writes need `start`) | — | live round-trip, memory (Docker) |
 | Avatar2 | generic reg+RAM | CPU regs + RAM (guest) | — | live round-trip (Docker) |
 
@@ -87,6 +87,21 @@ peripheral state lives in Layer 2 (Python models). Emulator-*internal* core
 devices that aren't forwarded to Python (e.g. an in-QEMU interrupt controller)
 are not captured by the generic path — a native `savevm`/`Save` override is a
 possible future enhancement (see roadmap).
+
+### LibAFL-QEMU: native syx-snapshot (fast in-QEMU checkpoint)
+
+`LibAflQemuBackend` overrides `save_state`/`restore_state` (default,
+non-portable form) to drive libafl-qemu's `syx-snapshot` — a whole-machine
+RAM + device checkpoint kept **inside** QEMU — via two custom QMP commands
+(`libafl-syx-snapshot` / `libafl-syx-restore`, added in the libafl-qemu-bridge
+fork's `hw/avatar/hal_irq.c`). Save/restore happen in-process in QEMU rather
+than reading all of guest RAM back over the GDB stub, which is the fast path
+an iterative loop needs (`snapshot_is_fast() == True`). QEMU keeps exactly one
+syx snapshot, so a `Snapshot` handle carries a generation and restore refuses
+a superseded one. Restore reloads the **full** RAM baseline (not the dirty
+list, which under-approximates outside the LibAFL Rust harness), so it cannot
+under-restore between restores. `save_state(portable=True)` still returns a
+disk-able generic reg+RAM snapshot.
 
 ### Layer 2 — peripheral registry
 

--- a/src/halucinator/backends/libafl_qemu_backend.py
+++ b/src/halucinator/backends/libafl_qemu_backend.py
@@ -113,3 +113,124 @@ class LibAflQemuBackend(QEMUBackend):
                 )
         super().__init__(config=config, arch=arch, qemu_path=qemu_path,
                          **kwargs)
+        # Monotonic id of the current in-QEMU syx snapshot. QEMU keeps exactly
+        # one; taking a new snapshot supersedes the previous, so a Snapshot
+        # handle carries the generation it was minted at and restore refuses a
+        # superseded one.
+        self._syx_generation = 0
+
+    # ------------------------------------------------------------------
+    # Snapshot / restore — fast in-QEMU checkpoint via libafl syx-snapshot
+    #
+    # The generic QEMUBackend fallback reads all of guest RAM back over the
+    # GDB stub (slow). The libafl-qemu-bridge instead exposes syx-snapshot
+    # (a whole-machine RAM+device checkpoint) through the custom QMP commands
+    # `libafl-syx-snapshot` / `libafl-syx-restore`, so save/restore happen
+    # entirely inside QEMU — the fast path an iterative loop needs.
+    # ------------------------------------------------------------------
+
+    def can_snapshot(self) -> bool:
+        return True
+
+    def snapshot_is_fast(self) -> bool:
+        return True
+
+    def save_state(self, portable: bool = False) -> "Snapshot":
+        from .hal_backend import Snapshot, SnapshotError
+        if portable:
+            # A syx snapshot lives inside the QEMU process and cannot be
+            # serialized to disk. For the portable/persistent form, fall back
+            # to the generic reg+RAM capture (which IS picklable).
+            return super().save_state(portable=True)
+        resp = self._qmp.execute("libafl-syx-snapshot")
+        if resp.get("error"):
+            raise SnapshotError(
+                f"libafl-syx-snapshot QMP command failed: {resp['error']}")
+        self._syx_generation += 1
+        return Snapshot(backend_type=self.__class__.__name__,
+                        version=self.SNAPSHOT_VERSION,
+                        data={"syx": True, "generation": self._syx_generation})
+
+    def restore_state(self, snap: "Snapshot") -> bool:
+        from .hal_backend import log_snapshot_mismatch
+        data = snap.data if isinstance(snap.data, dict) else {}
+        if not data.get("syx"):
+            # A generic (portable) snapshot — restore via the base reg+RAM
+            # path, not the syx QMP command.
+            return super().restore_state(snap)
+        if snap.backend_type != self.__class__.__name__:
+            log_snapshot_mismatch(self, snap, "backend_type")
+            return False
+        if snap.version != self.SNAPSHOT_VERSION:
+            log_snapshot_mismatch(self, snap, "version")
+            return False
+        if data.get("generation") != self._syx_generation:
+            log.error("libafl-syx-restore: snapshot (generation %s) was "
+                      "superseded by a newer syx snapshot (%s); QEMU keeps "
+                      "only the latest", data.get("generation"),
+                      self._syx_generation)
+            return False
+        resp = self._qmp.execute("libafl-syx-restore")
+        if resp.get("error"):
+            log.error("libafl-syx-restore QMP command failed: %r",
+                      resp["error"])
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Edge coverage — native libafl-qemu AFL-style edge instrumentation
+    #
+    # libafl-qemu compiles the edge-coverage TCG hooks and a 64 KB AFL
+    # hitcount map into the binary, but nothing registers the hook unless
+    # the embedded Rust harness does. The bridge's `libafl-cov-open` /
+    # `libafl-cov-result` QMP commands register it from C and fold the map
+    # diff host-side, so a coverage-guided loop over GDB+QMP gets native
+    # instrumentation speed without shipping the 64 KB map each iteration.
+    #
+    # The coverage map is host-side (not guest RAM / vmstate), so a syx
+    # restore does not touch it — the caller resets it via coverage_open().
+    # ------------------------------------------------------------------
+
+    def coverage_available(self) -> bool:
+        return True
+
+    def coverage_open(self) -> bool:
+        """Register the edge-coverage hook and zero the coverage maps.
+
+        Idempotent enable (the hook is registered once, which tb_flushes so
+        already-translated blocks re-translate with instrumentation) plus a
+        reset of the current and cumulative maps. Call once up front. Returns False if the command errored.
+        """
+        resp = self._qmp.execute("libafl-cov-open")
+        if resp.get("error"):
+            log.error("libafl-cov-open QMP command failed: %r", resp["error"])
+            return False
+        return True
+
+    def coverage_result(self) -> Optional[Dict[str, int]]:
+        """Fold the last run's edges into the cumulative set and reset the
+        current map for the next run.
+
+        Returns ``{"new_edges": N, "total_edges": M}`` where *new_edges* is how
+        many edges the last run covered that no prior run had, and *total_edges*
+        is the cumulative distinct-edge count. Returns None on error.
+        """
+        resp = self._qmp.execute("libafl-cov-result")
+        if resp.get("error"):
+            log.error("libafl-cov-result QMP command failed: %r", resp["error"])
+            return None
+        ret = resp.get("return", {})
+        # Distinguish "the bridge reported no new edges" from "the bridge did
+        # not report edge counts at all". Defaulting a missing key to 0 makes a
+        # broken/absent coverage hook look identical to a run that genuinely
+        # covered nothing, which is unfalsifiable at the call site.
+        if "new-edges" not in ret or "total-edges" not in ret:
+            # Log the WHOLE response, not just its "return" member: an empty
+            # ret is ambiguous between "the command answered without counts"
+            # and "there was no answer at all" (a QMP timeout, which the
+            # slower CI runner does hit). Those have different causes.
+            log.error("libafl-cov-result returned an unexpected payload "
+                      "(no edge counts): ret=%r full_response=%r", ret, resp)
+            return None
+        return {"new_edges": int(ret["new-edges"]),
+                "total_edges": int(ret["total-edges"])}

--- a/src/halucinator/backends/qemu_backend.py
+++ b/src/halucinator/backends/qemu_backend.py
@@ -765,6 +765,8 @@ class _QMPClient:
         self._sock: Optional[socket.socket] = None
         self._buf: bytes = b""
         self._lock = threading.Lock()
+        # Monotonic request id so a reply can be matched to its command.
+        self._id: int = 0
 
     def connect(self) -> None:
         if self.unix_path:
@@ -812,11 +814,30 @@ class _QMPClient:
         return json.loads(line) if line else {}
 
     def execute(self, command: str, arguments: Optional[Dict] = None) -> Dict:
-        msg: Dict = {"execute": command}
+        # QMP interleaves ASYNCHRONOUS EVENTS with command replies on the same
+        # socket, so the next line after a request is not necessarily its
+        # answer: resuming the guest emits RESUME, stopping emits STOP, and so
+        # on. Returning that event as the reply silently yields a response with
+        # no "return" member -- e.g. libafl-cov-result appearing to report no
+        # edge counts when it was never actually read. Tag every request with
+        # an id and read until the reply carrying it arrives, discarding events
+        # (which never carry an id).
+        self._id += 1
+        req_id = self._id
+        msg: Dict = {"execute": command, "id": req_id}
         if arguments:
             msg["arguments"] = arguments
         self._send(msg)
-        return self._recv_line()
+        while True:
+            resp = self._recv_line()
+            if not isinstance(resp, dict) or not resp:
+                return resp
+            if "event" in resp:
+                continue          # asynchronous event, not our reply
+            if resp.get("id") == req_id:
+                return resp
+            # A reply for an earlier request (or an id-less message): skip it
+            # rather than mistake it for this command's answer.
 
 
 # ---------------------------------------------------------------------------

--- a/test/pytest/backends/test_live_libafl_qemu_backend.py
+++ b/test/pytest/backends/test_live_libafl_qemu_backend.py
@@ -42,6 +42,96 @@ _FLASH_BASE = 0x08000000
 _RAM_BASE = 0x20000000
 _BP_ADDR = _FLASH_BASE + 0x04
 
+# A classic-ARM (32-bit) program used for the coverage tests. The cortex-m3
+# fixture above cannot execute guest code: this configurable machine leaves
+# PC/SP unset (SP=0) after launch and the armv7m GDB stub silently drops xpsr
+# writes, so the Thumb bit can't be set -> any run locks up. Classic ARM runs
+# in the CPU's default (T=0) state, so it executes cleanly. Two basic blocks
+# with a real block->block edge, ending in an infinite loop (the bp target):
+#   0x00: mov r0,#0 ; 0x04: cmp r0,#0 ; 0x08: beq 0x10 (2-exit block)
+#   0x0c: nop       ; 0x10: mov r2,#3 ; 0x14: b .   (bp here)
+_ARM_PROGRAM = bytes.fromhex(
+    "0000a0e3" "000050e3" "0000000a" "0000a0e1" "0320a0e3" "feffffea"
+)
+_ARM_BP_ADDR = _FLASH_BASE + 0x14
+
+
+def _spawn_libafl_backend(tmp_path, program, cpu_model, arch):
+    """Spawn a libafl-qemu-bridge backend running *program* from flash, on the
+    ``configurable`` machine with the given CPU. Returns a launched
+    LibAflQemuBackend (its QEMU process is on ``._process``)."""
+    from halucinator.backends.libafl_qemu_backend import LibAflQemuBackend
+
+    fw = tmp_path / "tinyfw.bin"
+    fw.write_bytes(program + b"\x00" * (0x1000 - len(program)))
+
+    conf = {
+        "cpu_model": cpu_model,
+        "entry_address": _FLASH_BASE,
+        "init_pc": _FLASH_BASE | 1,
+        "init_sp": _RAM_BASE + 0x800,
+        "memory_mapping": [
+            {"name": "flash", "address": _FLASH_BASE, "size": 0x1000,
+             "permissions": "rwx", "is_special": False, "is_symbolic": False,
+             "file": str(fw)},
+            {"name": "ram", "address": _RAM_BASE, "size": 0x1000,
+             "permissions": "rw-", "is_special": False, "is_symbolic": False},
+        ],
+    }
+    conf_path = tmp_path / "machine.json"
+    conf_path.write_text(json.dumps(conf))
+
+    gdb_port = _free_port()
+    qmp_port = _free_port()
+    while qmp_port == gdb_port:
+        qmp_port = _free_port()
+
+    qemu_path = _libafl_qemu_arm_path()
+    cmd = [
+        qemu_path,
+        "-machine", f"configurable,config-filename={conf_path}",
+        "-S",
+        "-gdb", f"tcp::{gdb_port}",
+        "-qmp", f"tcp:127.0.0.1:{qmp_port},server,nowait",
+        "-nographic",
+    ]
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL,
+                            stderr=subprocess.PIPE)
+    time.sleep(0.5)
+
+    b = LibAflQemuBackend(arch=arch, qemu_path=qemu_path,
+                          gdb_port=gdb_port, qmp_port=qmp_port)
+    b._process = proc
+
+    last_err = None
+    for _ in range(10):
+        try:
+            b.launch()
+            last_err = None
+            break
+        except (ConnectionRefusedError, OSError) as e:  # noqa: BLE001
+            last_err = e
+            time.sleep(0.3)
+    if last_err is not None:
+        proc.kill()
+        raise last_err
+    return b
+
+
+def _teardown_backend(b):
+    proc = b._process
+    try:
+        b.shutdown()
+    except Exception:  # noqa: BLE001
+        pass
+    if proc is None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=2)
+    except Exception:  # noqa: BLE001
+        proc.kill()
+
 
 def _libafl_qemu_arm_path():
     """Resolve the libafl-qemu-bridge ARM binary the same way the
@@ -70,91 +160,21 @@ def _free_port():
 class TestLibAflQemuBackendLive:
     @pytest.fixture
     def backend(self, tmp_path):
-        from halucinator.backends.libafl_qemu_backend import LibAflQemuBackend
-
-        fw = tmp_path / "tinyfw.bin"
-        fw.write_bytes(_PROGRAM + b"\x00" * (0x1000 - len(_PROGRAM)))
-
-        conf = {
-            "cpu_model": "cortex-m3",
-            "entry_address": _FLASH_BASE,
-            "init_pc": _FLASH_BASE | 1,
-            "init_sp": _RAM_BASE + 0x800,
-            "memory_mapping": [
-                {
-                    "name": "flash",
-                    "address": _FLASH_BASE,
-                    "size": 0x1000,
-                    "permissions": "rwx",
-                    "is_special": False,
-                    "is_symbolic": False,
-                    "file": str(fw),
-                },
-                {
-                    "name": "ram",
-                    "address": _RAM_BASE,
-                    "size": 0x1000,
-                    "permissions": "rw-",
-                    "is_special": False,
-                    "is_symbolic": False,
-                },
-            ],
-        }
-        conf_path = tmp_path / "machine.json"
-        conf_path.write_text(json.dumps(conf))
-
-        gdb_port = _free_port()
-        qmp_port = _free_port()
-        while qmp_port == gdb_port:
-            qmp_port = _free_port()
-
-        qemu_path = _libafl_qemu_arm_path()
-        cmd = [
-            qemu_path,
-            "-machine", f"configurable,config-filename={conf_path}",
-            "-S",
-            "-gdb", f"tcp::{gdb_port}",
-            "-qmp", f"tcp:127.0.0.1:{qmp_port},server,nowait",
-            "-nographic",
-        ]
-        proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-        )
-        time.sleep(0.5)
-
-        b = LibAflQemuBackend(
-            arch="cortex-m3", qemu_path=qemu_path,
-            gdb_port=gdb_port, qmp_port=qmp_port,
-        )
-        b._process = proc
-
-        last_err = None
-        for _ in range(10):
-            try:
-                b.launch()
-                last_err = None
-                break
-            except (ConnectionRefusedError, OSError) as e:  # noqa: BLE001
-                last_err = e
-                time.sleep(0.3)
-        if last_err is not None:
-            proc.kill()
-            raise last_err
-
+        b = _spawn_libafl_backend(tmp_path, _PROGRAM, "cortex-m3", "cortex-m3")
         try:
             yield b
         finally:
-            try:
-                b.shutdown()
-            except Exception:  # noqa: BLE001
-                pass
-            try:
-                proc.terminate()
-                proc.wait(timeout=2)
-            except Exception:  # noqa: BLE001
-                proc.kill()
+            _teardown_backend(b)
+
+    @pytest.fixture
+    def arm_backend(self, tmp_path):
+        """A classic-ARM backend that can actually execute guest code (unlike
+        the cortex-m3 fixture) — used by the coverage tests."""
+        b = _spawn_libafl_backend(tmp_path, _ARM_PROGRAM, "arm926", "arm")
+        try:
+            yield b
+        finally:
+            _teardown_backend(b)
 
     def test_memory_read_flash(self, backend):
         assert backend.read_memory(_FLASH_BASE, 2, 1) == 0x2042
@@ -167,15 +187,96 @@ class TestLibAflQemuBackendLive:
         backend.write_register("r5", 0xDEADBEEF)
         assert backend.read_register("r5") == 0xDEADBEEF
 
-    def test_snapshot_restore_round_trip(self, backend):
-        from backend_snapshot_helpers import (
-            assert_backend_snapshot_round_trip,
-            assert_restore_rejects_wrong_backend_type,
-        )
-        assert_backend_snapshot_round_trip(backend, _RAM_BASE)
-        assert_restore_rejects_wrong_backend_type(backend)
+    def test_syx_snapshot_restore_round_trip(self, backend):
+        """save_state() with no args uses the fast in-QEMU syx snapshot
+        (libafl-syx-snapshot/restore QMP commands), not the slow generic
+        reg+RAM-over-GDB path."""
+        assert backend.snapshot_is_fast() is True
+        backend.write_memory(_RAM_BASE + 0x40, 1, b"syx-me!!", 8, raw=True)
+        backend.write_register("r0", 0x1234)
+
+        snap = backend.save_state()          # -> libafl-syx-snapshot
+        # Opaque handle: the state lives inside QEMU, not in the Python object.
+        assert snap.data.get("syx") is True
+
+        backend.write_memory(_RAM_BASE + 0x40, 1, b"CLOBBER!", 8, raw=True)
+        backend.write_register("r0", 0)
+
+        assert backend.restore_state(snap) is True   # -> libafl-syx-restore
+        assert bytes(backend.read_memory(_RAM_BASE + 0x40, 1, 8,
+                                         raw=True)) == b"syx-me!!"
+        assert backend.read_register("r0") == 0x1234
+
+    def test_syx_snapshot_superseded_is_refused(self, backend):
+        """QEMU keeps exactly one syx snapshot; a handle to a superseded one
+        must be refused rather than silently restoring the newer state."""
+        snap_a = backend.save_state()
+        backend.save_state()                 # supersedes A inside QEMU
+        assert backend.restore_state(snap_a) is False
+
+    def test_portable_snapshot_falls_back_to_generic(self, backend):
+        """portable=True can't use the in-QEMU syx snapshot (not
+        serializable); it falls back to the generic reg+RAM capture."""
+        from backend_snapshot_helpers import _ensure_ram_region
+        _ensure_ram_region(backend, _RAM_BASE, 0x1000)
+        backend.write_memory(_RAM_BASE + 0x40, 1, b"portable", 8, raw=True)
+        snap = backend.save_state(portable=True)
+        assert "mem" in snap.data            # generic, picklable structure
+        backend.write_memory(_RAM_BASE + 0x40, 1, b"XXXXXXXX", 8, raw=True)
+        assert backend.restore_state(snap) is True
+        assert bytes(backend.read_memory(_RAM_BASE + 0x40, 1, 8,
+                                         raw=True)) == b"portable"
 
     def test_set_remove_breakpoint_does_not_crash(self, backend):
         bp = backend.set_breakpoint(_BP_ADDR)
         assert isinstance(bp, int)
         backend.remove_breakpoint(bp)
+
+    def test_coverage_collects_native_edges(self, arm_backend):
+        """libafl-qemu native edge coverage over QMP: after executing guest
+        blocks, coverage_result() reports newly-covered edges; a second call
+        with no execution in between reports zero new edges (the current map
+        was folded into the cumulative set and reset) while the cumulative
+        total is unchanged."""
+        backend = arm_backend
+        assert backend.coverage_available() is True
+        assert backend.coverage_open() is True    # -> libafl-cov-open
+
+        # Run the ARM program from the start to the trailing infinite loop; the
+        # block hook records an edge for each executed basic block.
+        backend.write_register("sp", _RAM_BASE + 0x800)
+        backend.write_register("pc", _FLASH_BASE)
+        backend.set_breakpoint(_ARM_BP_ADDR)
+        backend.cont(blocking=True)
+
+        # Establish the guest actually ran before blaming the coverage hook:
+        # if execution never happened, zero edges is the correct answer and the
+        # bug is upstream of coverage. These two assertions fail differently so
+        # a CI log says which half broke.
+        pc = backend.read_register("pc")
+        assert pc == _ARM_BP_ADDR, (
+            f"guest did not reach the breakpoint: pc=0x{pc:x}, "
+            f"expected 0x{_ARM_BP_ADDR:x} — nothing executed, so the edge "
+            f"count below is meaningless")
+
+        r1 = backend.coverage_result()            # -> libafl-cov-result
+        assert r1 is not None, (
+            "coverage_result() returned None — libafl-cov-result failed or "
+            "reported no edge counts; see the backend log for the payload")
+        assert r1["new_edges"] > 0, (
+            f"guest reached the breakpoint but no edges were recorded: {r1} "
+            f"— the coverage hook is registered but not collecting")
+        assert r1["total_edges"] == r1["new_edges"]   # first fold: all are new
+
+        # Nothing executed since the fold+reset, so no NEW edges this time and
+        # the cumulative distinct-edge count is unchanged.
+        r2 = backend.coverage_result()
+        assert r2 is not None
+        assert r2["new_edges"] == 0
+        assert r2["total_edges"] == r1["total_edges"]
+
+    def test_coverage_open_is_idempotent(self, arm_backend):
+        """Enabling coverage twice re-registers nothing and just resets the
+        maps — it must not error."""
+        assert arm_backend.coverage_open() is True
+        assert arm_backend.coverage_open() is True

--- a/test/pytest/backends/test_qmp_unix_socket.py
+++ b/test/pytest/backends/test_qmp_unix_socket.py
@@ -3,6 +3,7 @@ round-trips than loopback TCP) and the buffered line reader.
 """
 from __future__ import annotations
 
+import json
 import socket
 from unittest import mock
 
@@ -42,6 +43,38 @@ class TestQMPClientTransport:
         c._sock.connect.assert_called_once_with(("localhost", 4444))
         c._sock.setsockopt.assert_any_call(
             socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+    def test_execute_skips_async_events_and_matches_id(self):
+        """QMP interleaves asynchronous events with command replies. A RESUME
+        event emitted by cont() must not be mistaken for the reply — that made
+        libafl-cov-result look like it returned no edge counts (halucinator#50).
+        """
+        c = _QMPClient(unix_path="/x")
+        c._sock = mock.MagicMock()
+        c._sock.recv.side_effect = [
+            b'{"timestamp":{"seconds":1},"event":"RESUME"}\n',
+            b'{"timestamp":{"seconds":2},"event":"STOP"}\n',
+            b'{"return":{"new-edges":7,"total-edges":9},"id":1}\n',
+        ]
+        resp = c.execute("libafl-cov-result")
+        assert resp["return"] == {"new-edges": 7, "total-edges": 9}
+
+        # The request carried an id so the reply could be matched to it.
+        sent = json.loads(c._sock.sendall.call_args[0][0].decode())
+        assert sent["execute"] == "libafl-cov-result"
+        assert sent["id"] == 1
+
+    def test_execute_skips_a_stale_reply_for_an_earlier_request(self):
+        """A late reply to a previous command must not be returned as this
+        command's answer."""
+        c = _QMPClient(unix_path="/x")
+        c._sock = mock.MagicMock()
+        c._id = 4                      # next request will be id 5
+        c._sock.recv.side_effect = [
+            b'{"return":{"stale":true},"id":4}\n',
+            b'{"return":{"fresh":true},"id":5}\n',
+        ]
+        assert c.execute("query-status")["return"] == {"fresh": True}
 
     def test_recv_line_buffers_chunks_and_splits(self):
         c = _QMPClient(unix_path="/x")


### PR DESCRIPTION
## What

Give `LibAflQemuBackend` two capabilities driven natively over QMP that make the
libafl-qemu-bridge QEMU a first-class **rehosting** backend:

1. **Fast in-QEMU snapshot/restore** — a whole-machine (RAM + device) checkpoint
   kept inside QEMU, taken/restored over QMP, instead of reading all of guest
   RAM back over the GDB stub. Checkpoint a booted rehosted state once and return
   to it instantly — for iterative analysis, re-running from a known point,
   debugging, and differential comparison. (`snapshot_is_fast() == True`.)
2. **Native execution coverage** — the bridge's edge-coverage instrumentation,
   exposed over QMP, to measure which code a rehosted firmware actually executes
   (execution paths, how much of an image a rehost reaches), with a 64 KB
   hitcount map kept host-side; only counts cross the wire.

Both compose with the whole-machine snapshot/restore in #49.

## How

- **libafl-qemu-bridge** (submodule bump): adds the QMP commands the backend
  drives — `libafl-syx-snapshot` / `libafl-syx-restore` (fast checkpoint) and
  `libafl-cov-open` / `libafl-cov-result` (execution coverage). The bridge QEMU
  has no QMP surface for these upstream; the commands let an external GDB+QMP
  driver use them. Restore reloads the full RAM baseline (robust across repeated
  restores). → companion PR: halucinator/libafl-qemu-bridge#3
- **HALucinator**:
  - `save_state` / `restore_state` (non-portable) drive the syx commands and
    return an opaque handle. QEMU keeps one checkpoint, so the handle carries a
    generation and a superseded handle is refused. `save_state(portable=True)`
    still returns a disk-able generic reg+RAM snapshot.
  - `coverage_open()` / `coverage_result()` drive the coverage commands and
    return `{new_edges, total_edges}`; the map lives host-side and a restore
    doesn't disturb it.
  - `_QMPClient.execute()` now skips asynchronous QMP events (RESUME/STOP from a
    preceding cont or breakpoint, IRQ-driven events) that can precede a command's
    reply — a general correctness fix for the QMP path (it also hardens IRQ
    injection while the guest is running).

## Testing

End-to-end against a real `qemu-system-arm` from the bridge (CI Docker image):
snapshot → clobber RAM + registers → restore reverts state byte-for-byte; a
superseded handle is refused; the portable fallback round-trips; execution
coverage is collected across executed blocks with correct fold/reset semantics.

## Stacking / dependencies

- **Stacks on #49** (whole-machine snapshot/restore across all backends).
- **Depends on** halucinator/libafl-qemu-bridge#3 — the submodule pointer here
  references the QEMU commit from that PR; merge order: bridge#3 → #49 → this.
