### PR TITLE
peripheral_models: AutoPeripheral/RecordingPeripheral MMIO catch-all

### DIFF
--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -181,9 +181,15 @@ def setup_memory(
             mod_path, _, cls_name = memory.emulate.rpartition(".")
             emulate = getattr(importlib.import_module(mod_path), cls_name)
         else:
-            # Bare name: resolve on the generic peripheral_models module
-            # (backward-compatible with existing configs).
-            emulate = getattr(peripheral_emulators, memory.emulate)
+            # Bare name: resolve on the generic peripheral_models module, then
+            # the auto_model module (so `emulate: AutoPeripheral` works without
+            # the fully-qualified path). Backward-compatible with existing configs.
+            from .peripheral_models import auto_model as _auto_model
+            emulate = (getattr(peripheral_emulators, memory.emulate, None)
+                       or getattr(_auto_model, memory.emulate, None))
+            if emulate is None:
+                raise AttributeError(
+                    "unknown emulate peripheral %r" % memory.emulate)
     else:
         emulate = None
     log.info(
@@ -923,9 +929,10 @@ def _instantiate_peripheral(name: str, memory: Any, db_path: str) -> Any:
     class path (``module.path.ClassName``) is imported directly — letting a
     device-specific model live in its own subpackage (e.g.
     ``peripheral_models.bpv5.*``) without polluting the generic module. A bare
-    name searches the at91 module (At91SysCtrl/At91Emac/At91Dbgu) then the
-    generic module (GenericPeripheral/HaltPeripheral). Returns None if unknown
-    (region falls back to plain RAM)."""
+    name searches the at91 module (At91SysCtrl/At91Emac/At91Dbgu), the auto_model
+    module (AutoPeripheral/RecordingPeripheral), then the generic module
+    (GenericPeripheral/HaltPeripheral). Returns None if unknown (region falls back
+    to plain RAM)."""
     if "." in name:
         import importlib
         mod_path, _, cls_name = name.rpartition(".")
@@ -934,8 +941,9 @@ def _instantiate_peripheral(name: str, memory: Any, db_path: str) -> Any:
         except ImportError:
             cls = None
     else:
-        from halucinator.peripheral_models import at91, generic
+        from halucinator.peripheral_models import at91, auto_model, generic
         cls = (getattr(at91, name, None)
+               or getattr(auto_model, name, None)
                or getattr(generic, name, None))
     if cls is None:
         log.warning("Unknown emulate peripheral %r; region %s left as RAM",

--- a/src/halucinator/peripheral_models/auto_model.py
+++ b/src/halucinator/peripheral_models/auto_model.py
@@ -1,0 +1,384 @@
+# Copyright 2026 Christopher Wright
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Recording and self-modelling catch-all peripherals.
+
+``RecordingPeripheral`` observes every MMIO access at a catch-all region and
+logs ``(seq, pc, addr, size, value, rw)`` — to memory always, and to a SQLite
+``mmio_trace`` table when a db path is configured. The trace is a general-purpose
+record of the firmware's MMIO behaviour, useful for analysis and for building a
+precise hand-written model later.
+
+``AutoPeripheral`` adds a runtime policy that lets unmodelled firmware boot
+without hand-written intercepts:
+
+  * Busy-wait breaker (uEmu-lite). Firmware routinely spins on a status bit —
+    ``while(!(REG & READY));`` or ``while(REG & BUSY);``. With a return-0
+    catch-all those loops never exit. We detect a stall (the same instruction
+    reading the same address many times in a row) and escalate the returned
+    value: first all-ones (breaks "wait for a bit to SET", the common case:
+    HSERDY/PLLRDY/TXE/RXNE), then zero (breaks "wait while BUSY"); whichever
+    ends the stall is cached for that ``(pc, addr)``.
+
+  * Free-running counters, 32- and 64-bit (opt-in; see the ``HAL_AUTO_COUNTER*``
+    knobs documented below).
+
+  * Output capture. A register that receives a stream of byte writes whose low
+    byte is printable ASCII is almost certainly a UART/data TX register; we
+    accumulate and log it, surfacing the firmware's console (e.g. a GRBL banner)
+    without knowing the driver function.
+
+This is intentionally heuristic: it gets firmware booting and records a trace of
+its MMIO behaviour for later analysis. It is a base class — concrete device
+peripheral models subclass ``AutoPeripheral`` to add specific register behaviour
+while keeping the recording and busy-wait-breaker machinery.
+
+Environment knobs (all opt-in, default off):
+
+  ``HAL_AUTO_COUNTER_ADDRS=0xA[,0xB...]``       each address becomes a free-running
+                                                up-counter (every read returns a
+                                                strictly larger value).
+  ``HAL_AUTO_COUNTER64_ADDRS=0xLO:0xHI[,...]``  a 64-bit up-counter split across
+                                                two 32-bit registers; a bare
+                                                ``0xLO`` implies ``HI = LO + 4``.
+  ``HAL_AUTO_COUNTER_STEP=0x1000``              increment applied per counter read.
+  ``HAL_MMIO_LOG=1``                            log the first read of every
+                                                ``(pc, addr)`` and the value
+                                                handed back (deduped).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import time
+from typing import (Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple)
+
+from halucinator import hal_log
+from halucinator.peripheral_models.generic import GenericPeripheral
+
+log = logging.getLogger(__name__)
+hlog = hal_log.getHalLogger()
+
+# --- environment knobs ------------------------------------------------------
+COUNTER_ADDRS_ENV = "HAL_AUTO_COUNTER_ADDRS"
+COUNTER64_ADDRS_ENV = "HAL_AUTO_COUNTER64_ADDRS"
+COUNTER_STEP_ENV = "HAL_AUTO_COUNTER_STEP"
+MMIO_LOG_ENV = "HAL_MMIO_LOG"
+NO_MMIO_TRACE_ENV = "HAL_NO_MMIO_TRACE"
+DEFAULT_COUNTER_STEP = 0x1000
+
+
+def _tokens(raw: str) -> Iterable[str]:
+    for tok in raw.split(","):
+        tok = tok.strip()
+        if tok:
+            yield tok
+
+
+def parse_counter_addrs(raw: Optional[str]) -> Tuple[Set[int], List[str]]:
+    """``"0x10,0x20"`` -> ``({0x10, 0x20}, [])``. Bad tokens are reported."""
+    addrs: Set[int] = set()
+    bad: List[str] = []
+    for tok in _tokens(raw or ""):
+        try:
+            addrs.add(int(tok, 0))
+        except ValueError:
+            bad.append(tok)
+    return addrs, bad
+
+
+def parse_counter64_addrs(raw: Optional[str]) -> Tuple[Dict[int, int], List[str]]:
+    """``"0x200:0x204,0x300"`` -> ``({0x204: 0x200, 0x304: 0x300}, [])``.
+
+    The mapping is ``hi_addr -> lo_addr``; the low address is the pair id.
+    """
+    pairs: Dict[int, int] = {}
+    bad: List[str] = []
+    for tok in _tokens(raw or ""):
+        try:
+            if ":" in tok:
+                lo_s, hi_s = tok.split(":", 1)
+                lo, hi = int(lo_s, 0), int(hi_s, 0)
+            else:
+                lo = int(tok, 0)
+                hi = lo + 4
+        except ValueError:
+            bad.append(tok)
+            continue
+        pairs[hi] = lo
+    return pairs, bad
+
+
+def parse_counter_step(raw: Optional[str]) -> int:
+    if not raw:
+        return DEFAULT_COUNTER_STEP
+    try:
+        return int(raw, 0)
+    except ValueError:
+        return DEFAULT_COUNTER_STEP
+
+
+def mmio_log_enabled(environ: Optional[Mapping[str, str]] = None) -> bool:
+    environ = os.environ if environ is None else environ
+    return environ.get(MMIO_LOG_ENV) == "1"
+
+
+def mmio_trace_disabled(environ: Optional[Mapping[str, str]] = None) -> bool:
+    """True when the host should pass ``db_path=None`` (throughput runs)."""
+    environ = os.environ if environ is None else environ
+    return environ.get(NO_MMIO_TRACE_ENV) == "1"
+
+
+def trace_db_path(db_path: Optional[str],
+                  environ: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    """The db_path a recording peripheral should actually be given: the
+    configured path unless ``HAL_NO_MMIO_TRACE=1``."""
+    return None if mmio_trace_disabled(environ) else db_path
+
+
+# --- the peripherals --------------------------------------------------------
+class RecordingPeripheral(GenericPeripheral):
+    """Catch-all that records every access. Reads still return 0."""
+
+    # Flush to SQLite every this many accesses so the trace survives even a
+    # hard kill (firmware that spins forever never lets a clean shutdown /
+    # flush run, because the unicorn emu_start C loop doesn't return).
+    FLUSH_EVERY = 4096      # accesses
+    FLUSH_SECONDS = 2.0     # ...or wall-clock, whichever comes first
+
+    # In-memory trace rows retained before the persisted prefix is dropped.
+    TRACE_HIGH_WATER = 200_000
+
+    def __init__(self, name: str, address: int, size: int,
+                 db_path: Optional[str] = None, **kwargs: Any) -> None:
+        super().__init__(name, address, size, **kwargs)
+        self.db_path = db_path
+        self._seq = 0
+        self._flushed = 0
+        self._conn: Optional[sqlite3.Connection] = None
+        self._last_flush = time.monotonic()
+        self.trace: List[Tuple[int, int, int, int, int, str]] = []
+
+    def _record(self, pc: int, addr: int, size: int, value: int, rw: str) -> None:
+        self.trace.append((self._seq, pc, addr, size, value, rw))
+        self._seq += 1
+        # Flush on either a count threshold (chatty firmware) or a wall-clock
+        # interval (low-MMIO firmware that loops forever in compute) — the
+        # emu_start C loop never returns so a clean-shutdown flush can't run.
+        if self.db_path and (self._seq - self._flushed) >= self.FLUSH_EVERY:
+            self.flush()
+        elif self.db_path and (time.monotonic() - self._last_flush) >= self.FLUSH_SECONDS:
+            self.flush()
+
+    def hw_read(self, offset: int, size: int, pc: int = 0xBAADBAAD, **kwargs: Any) -> int:
+        addr = self.address + offset
+        self._record(pc, addr, size, 0, "r")
+        return 0
+
+    def hw_write(self, offset: int, size: int, value: int,
+                 pc: int = 0xBAADBAAD, **kwargs: Any) -> bool:
+        addr = self.address + offset
+        self._record(pc, addr, size, value, "w")
+        return True
+
+    def flush(self) -> None:
+        """Persist new trace rows to SQLite (incremental). Safe to call
+        repeatedly; only rows since the last flush are written."""
+        if not self.db_path:
+            return
+        if self._conn is None:
+            self._conn = sqlite3.connect(self.db_path)
+            self._conn.execute(
+                "CREATE TABLE IF NOT EXISTS mmio_trace ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, region TEXT, seq INTEGER,"
+                " pc INTEGER, addr INTEGER, size INTEGER, value INTEGER, rw TEXT)")
+        new = self.trace[self._flushed:]
+        if new:
+            self._conn.executemany(
+                "INSERT INTO mmio_trace(region, seq, pc, addr, size, value, rw)"
+                " VALUES (?,?,?,?,?,?,?)",
+                [(self.name, s, pc, a, sz, v, rw)
+                 for (s, pc, a, sz, v, rw) in new])
+            self._conn.commit()
+            self._flushed = len(self.trace)
+        self._last_flush = time.monotonic()
+        # Drop the in-memory prefix we've persisted to bound memory on
+        # long-running (looping) firmware, keeping seq numbers intact.
+        if self._flushed > self.TRACE_HIGH_WATER:
+            self.trace = self.trace[self._flushed:]
+            self._flushed = 0
+
+    def shutdown(self) -> None:  # noqa: D401
+        try:
+            self.flush()
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+        except Exception:  # noqa: BLE001
+            log.exception("RecordingPeripheral flush failed")
+        super().shutdown() if hasattr(super(), "shutdown") else None
+
+
+class AutoPeripheral(RecordingPeripheral):
+    """RecordingPeripheral + busy-wait breaker + counters + output capture."""
+
+    def __init__(self, name: str, address: int, size: int,
+                 db_path: Optional[str] = None,
+                 stall_threshold: int = 16,
+                 counter_addrs: Optional[Iterable[int]] = None,
+                 counter64_addrs: Optional[Dict[int, int]] = None,
+                 counter_step: Optional[int] = None,
+                 mmio_log: Optional[bool] = None,
+                 **kwargs: Any) -> None:
+        super().__init__(name, address, size, db_path=db_path, **kwargs)
+        self.stall_threshold = stall_threshold
+        # (pc, addr) -> consecutive repeat count
+        self._repeat: Dict[Tuple[int, int], int] = {}
+        self._last_key: Optional[Tuple[int, int]] = None
+        # (pc, addr) -> cached value that broke the stall
+        self._cached: Dict[Tuple[int, int], int] = {}
+        # (pc, addr) -> running value for free-running-counter registers
+        self._counter: Dict[Tuple[int, int], int] = {}
+        # Addresses explicitly modelled as free-running counters: every read
+        # returns a monotonically increasing value (from the FIRST read, so a
+        # `start=REG; while(REG-start < N)` calibrated delay sees a real delta
+        # and elapses). Declare via HAL_AUTO_COUNTER_ADDRS=0xADDR[,0xADDR...]
+        # — the generic spin heuristic can't catch a counter polled in a loop
+        # that also reads other registers (the consecutive run keeps resetting).
+        self._counter_addrs: Set[int] = set()
+        if counter_addrs is None:
+            parsed, bad = parse_counter_addrs(os.environ.get(COUNTER_ADDRS_ENV))
+            self._counter_addrs |= parsed
+            for tok in bad:
+                log.warning("bad %s token %r", COUNTER_ADDRS_ENV, tok)
+        else:
+            self._counter_addrs |= set(counter_addrs)
+        self._free_counter: Dict[int, int] = {}   # addr -> running value
+        self._counter_step = (
+            counter_step if counter_step is not None
+            else parse_counter_step(os.environ.get(COUNTER_STEP_ENV)))
+        if self._counter_addrs:
+            hlog.info("AutoPeripheral: free-running counter regs: %s",
+                      ", ".join("0x%08x" % a for a in sorted(self._counter_addrs)))
+
+        # 64-bit free-running counter PAIRS. A single 64-bit up-counter exposed
+        # as two 32-bit MMIO registers (low word + high word) -- e.g. the
+        # Cortex-A9 MPCore global timer at PERIPHBASE+0x200(lo)/+0x204(hi). A
+        # 64-bit reader typically loops `do { hi1=HI; lo=LO; hi2=HI; } while
+        # (hi1 != hi2)`, so the HIGH word must be STABLE across consecutive
+        # reads (advancing ONLY when the low word overflows) or the loop never
+        # converges. Declare via HAL_AUTO_COUNTER64_ADDRS="0xLO:0xHI"
+        # (comma-separated; a bare "0xLO" implies HI=LO+4). A LOW read advances
+        # the shared 64-bit accumulator by HAL_AUTO_COUNTER_STEP and returns
+        # bits[31:0]; a HIGH read returns bits[63:32] WITHOUT advancing.
+        self._counter64_lo: Dict[int, int] = {}   # lo addr -> lo addr (pair id)
+        self._counter64_hi: Dict[int, int] = {}   # hi addr -> lo addr
+        self._counter64_val: Dict[int, int] = {}   # lo addr -> 64-bit accumulator
+        if counter64_addrs is None:
+            pairs, bad64 = parse_counter64_addrs(
+                os.environ.get(COUNTER64_ADDRS_ENV))
+            for tok in bad64:
+                log.warning("bad %s token %r", COUNTER64_ADDRS_ENV, tok)
+        else:
+            pairs = dict(counter64_addrs)
+        for hi, lo in pairs.items():
+            self._counter64_lo[lo] = lo
+            self._counter64_hi[hi] = lo
+        if self._counter64_hi:
+            hlog.info("AutoPeripheral: 64-bit counter pairs (hi/lo): %s",
+                      ", ".join("0x%08x/0x%08x" % (hi, lo)
+                                for hi, lo in sorted(self._counter64_hi.items())))
+        # addr -> accumulated printable output bytes
+        self._out: Dict[int, bytearray] = {}
+        # HAL_MMIO_LOG=1: log the FIRST read of each (pc,addr) hardware register
+        # and the value we hand back. These first-reads return 0 by default --
+        # the suspects for "firmware needed a 1 here, got 0, took the wrong
+        # branch". Diagnostic-only; deduped so it can't spam.
+        self._mmio_log = (mmio_log_enabled() if mmio_log is None
+                          else bool(mmio_log))
+        self._logged_reads: set = set()
+
+    def _mask(self, size: int) -> int:
+        return (1 << (8 * size)) - 1
+
+    def hw_read(self, offset: int, size: int, pc: int = 0xBAADBAAD, **kwargs: Any) -> int:
+        addr = self.address + offset
+        self._record(pc, addr, size, 0, "r")
+        key = (pc, addr)
+
+        # 64-bit free-running counter pair (see __init__): the LOW word advances
+        # the shared accumulator and returns bits[31:0]; the HIGH word returns
+        # bits[63:32] WITHOUT advancing, so a 64-bit read-consistency loop
+        # (hi1==hi2) converges.
+        if addr in self._counter64_lo:
+            lo = self._counter64_lo[addr]
+            cur = self._counter64_val.get(lo, 0) + self._counter_step
+            self._counter64_val[lo] = cur
+            return cur & self._mask(size)
+        if addr in self._counter64_hi:
+            lo = self._counter64_hi[addr]
+            return (self._counter64_val.get(lo, 0) >> 32) & self._mask(size)
+
+        # Free-running counter register: monotonically increasing every read.
+        if addr in self._counter_addrs:
+            cur = self._free_counter.get(addr, 0) + self._counter_step
+            self._free_counter[addr] = cur
+            return cur & self._mask(size)
+
+        if key in self._cached:
+            return self._cached[key]
+
+        if key == self._last_key:
+            self._repeat[key] = self._repeat.get(key, 0) + 1
+        else:
+            self._repeat[key] = 0
+            self._last_key = key
+
+        n = self._repeat[key]
+        if n >= self.stall_threshold:
+            t = self.stall_threshold
+            # Escalate through three tiers as the same read keeps spinning:
+            #   1. all-ones  — breaks `while(!(REG & READY))` (wait-for-SET,
+            #      the common case: HSERDY/PLLRDY/TXE/RXNE).
+            #   2. zero      — breaks `while(REG & BUSY)` (wait-while-BUSY).
+            #   3. monotonic counter — neither constant broke the stall, so
+            #      the firmware is timing against a FREE-RUNNING COUNTER
+            #      (`start=REG; while(REG-start < N)` calibrated delay). A
+            #      constant can never satisfy it; return an ever-increasing
+            #      value so the delay elapses. The step is large and grows
+            #      with the spin so any finite threshold is crossed quickly.
+            if n < t * 2:
+                val = self._mask(size)
+            elif n < t * 3:
+                val = 0
+            else:
+                cur = self._counter.get(key, 0) + (n - t * 3 + 1) * 0x10000
+                self._counter[key] = cur
+                val = cur & self._mask(size)
+            hlog.info(
+                "AutoPeripheral: busy-wait at pc=0x%08x addr=0x%08x -> 0x%x",
+                pc, addr, val)
+            return val
+        if self._mmio_log and key not in self._logged_reads:
+            self._logged_reads.add(key)
+            hlog.info("MMIO-READ pc=0x%08x addr=0x%08x size=%d -> 0x0 "
+                      "(first read, default)", pc, addr, size)
+        return 0
+
+    def hw_write(self, offset: int, size: int, value: int,
+                 pc: int = 0xBAADBAAD, **kwargs: Any) -> bool:
+        addr = self.address + offset
+        self._record(pc, addr, size, value, "w")
+        # Output capture: printable low byte => likely a data/TX register.
+        low = value & 0xFF
+        if size <= 4 and (low == 0x0A or low == 0x0D or 0x20 <= low < 0x7F):
+            buf = self._out.setdefault(addr, bytearray())
+            if low == 0x0A:  # newline -> emit the line
+                line = buf.decode("latin-1").rstrip("\r")
+                hlog.info("AutoPeripheral UART(0x%08x): %s", addr, line)
+                buf.clear()
+            elif low != 0x0D:
+                buf.append(low)
+        # A write to a polled status register usually clears the stall.
+        self._last_key = None
+        return True

--- a/test/pytest/peripheral_models/test_auto_model.py
+++ b/test/pytest/peripheral_models/test_auto_model.py
@@ -1,0 +1,157 @@
+"""
+Tests for halucinator.peripheral_models.auto_model
+(RecordingPeripheral and AutoPeripheral, plus the env-knob parsers).
+"""
+import pytest
+
+from halucinator.peripheral_models.auto_model import (
+    AutoPeripheral,
+    RecordingPeripheral,
+    parse_counter_addrs,
+    parse_counter64_addrs,
+    parse_counter_step,
+    trace_db_path,
+)
+from halucinator.peripheral_models.generic import GenericPeripheral
+
+
+# ===================== env-knob parsers =====================
+
+class TestEnvParsers:
+
+    def test_parse_counter_addrs_ok(self):
+        addrs, bad = parse_counter_addrs("0x10, 0x20,0x30")
+        assert addrs == {0x10, 0x20, 0x30}
+        assert bad == []
+
+    def test_parse_counter_addrs_reports_bad(self):
+        addrs, bad = parse_counter_addrs("0x10,nope")
+        assert addrs == {0x10}
+        assert bad == ["nope"]
+
+    def test_parse_counter_addrs_empty(self):
+        assert parse_counter_addrs(None) == (set(), [])
+
+    def test_parse_counter64_pair_explicit(self):
+        pairs, bad = parse_counter64_addrs("0x200:0x204")
+        assert pairs == {0x204: 0x200}  # hi -> lo
+        assert bad == []
+
+    def test_parse_counter64_pair_implicit_hi(self):
+        pairs, _ = parse_counter64_addrs("0x300")
+        assert pairs == {0x304: 0x300}  # bare lo implies hi = lo + 4
+
+    def test_parse_counter_step_default(self):
+        assert parse_counter_step(None) == 0x1000
+        assert parse_counter_step("garbage") == 0x1000
+
+    def test_parse_counter_step_value(self):
+        assert parse_counter_step("0x40") == 0x40
+
+    def test_trace_db_path_passthrough(self):
+        assert trace_db_path("x.sqlite", environ={}) == "x.sqlite"
+
+    def test_trace_db_path_suppressed(self):
+        assert trace_db_path("x.sqlite",
+                             environ={"HAL_NO_MMIO_TRACE": "1"}) is None
+
+
+# ===================== RecordingPeripheral =====================
+
+class TestRecordingPeripheral:
+
+    def test_is_a_generic_peripheral(self):
+        assert issubclass(RecordingPeripheral, GenericPeripheral)
+
+    def test_reads_return_zero_and_record(self):
+        p = RecordingPeripheral("rec", 0x40000000, 0x1000)
+        assert p.hw_read(0x0, 4, pc=0x8000) == 0
+        p.hw_write(0x4, 4, 0xdead, pc=0x8004)
+        assert len(p.trace) == 2
+        # (seq, pc, addr, size, value, rw)
+        assert p.trace[0][5] == "r"
+        assert p.trace[1] == (1, 0x8004, 0x40000004, 4, 0xdead, "w")
+
+
+# ===================== AutoPeripheral =====================
+
+class TestAutoPeripheral:
+
+    def test_mro_is_recording_then_generic(self):
+        mro = [c.__name__ for c in AutoPeripheral.__mro__]
+        assert mro[:3] == ["AutoPeripheral", "RecordingPeripheral",
+                           "GenericPeripheral"]
+
+    def test_class_name_is_stable(self):
+        # main._instantiate_peripheral name-checks "AutoPeripheral" for skip_svc;
+        # renaming the class silently breaks that hook.
+        assert AutoPeripheral.__name__ == "AutoPeripheral"
+
+    def test_busywait_breaker_escalates_off_zero(self):
+        p = AutoPeripheral("a", 0x40000000, 0x1000, stall_threshold=4)
+        # First reads return 0; once the same (pc,addr) spins past the
+        # threshold the breaker escalates to all-ones so a wait-for-SET exits.
+        vals = [p.hw_read(0x0, 4, pc=0x8000) for _ in range(12)]
+        assert vals[0] == 0
+        assert 0xFFFFFFFF in vals
+
+    def test_breaker_then_zero_tier(self):
+        p = AutoPeripheral("a", 0x40000000, 0x1000, stall_threshold=4)
+        seen = set(p.hw_read(0x0, 4, pc=0x8000) for _ in range(20))
+        # both tiers observed: all-ones (wait-for-SET) and zero (wait-while-BUSY)
+        assert 0xFFFFFFFF in seen
+        assert 0 in seen
+
+    def test_write_clears_stall_state(self):
+        p = AutoPeripheral("a", 0x40000000, 0x1000, stall_threshold=4)
+        for _ in range(6):
+            p.hw_read(0x0, 4, pc=0x8000)
+        p.hw_write(0x0, 4, 1, pc=0x8000)   # a write to the polled reg
+        assert p._last_key is None
+
+    def test_free_running_counter_monotonic(self):
+        p = AutoPeripheral("c", 0x50000000, 0x1000,
+                          counter_addrs=[0x50000000], counter_step=0x100)
+        vals = [p.hw_read(0x0, 4, pc=0x9000) for _ in range(3)]
+        assert vals == [0x100, 0x200, 0x300]
+
+    def test_counter64_high_word_stable_across_reads(self):
+        # hi must not advance on its own read, or a do/while(hi1!=hi2) loop
+        # never converges.
+        p = AutoPeripheral("c64", 0x60000000, 0x1000,
+                          counter64_addrs={0x60000004: 0x60000000},
+                          counter_step=0x1000)
+        hi1 = p.hw_read(0x4, 4, pc=0x9000)
+        hi2 = p.hw_read(0x4, 4, pc=0x9000)
+        assert hi1 == hi2   # stable
+
+    def test_output_capture_emits_line(self):
+        p = AutoPeripheral("uart", 0x40004400, 0x400)
+        for ch in b"HI\n":
+            p.hw_write(0x0, 1, ch, pc=0x8000)
+        # the newline flushes the buffer
+        assert p._out.get(0x40004400) == bytearray()
+
+
+# ===================== bare-name resolution in main =====================
+
+class TestBareNameResolution:
+    """`emulate: AutoPeripheral` (no dotted path) must resolve, via both
+    resolvers in halucinator.main."""
+
+    def test_instantiate_peripheral_resolves_bare_name(self):
+        import types
+        from halucinator import main
+        mem = types.SimpleNamespace(name="mmio", base_addr=0x40000000,
+                                    size=0x1000, properties=None)
+        periph = main._instantiate_peripheral("AutoPeripheral", mem, None)
+        assert periph is not None
+        assert periph.__class__.__name__ == "AutoPeripheral"
+
+    def test_instantiate_peripheral_bare_recording(self):
+        import types
+        from halucinator import main
+        mem = types.SimpleNamespace(name="mmio", base_addr=0x40000000,
+                                    size=0x1000, properties=None)
+        periph = main._instantiate_peripheral("RecordingPeripheral", mem, None)
+        assert periph.__class__.__name__ == "RecordingPeripheral"


### PR DESCRIPTION
## What

Adds a generic MMIO catch-all base peripheral to `peripheral_models`:

- **`RecordingPeripheral`** — logs every access at a catch-all region (to memory,
  and to a SQLite `mmio_trace` table when a db path is configured). Reads return 0.
- **`AutoPeripheral(RecordingPeripheral)`** — adds the runtime policy that lets
  unmodelled firmware boot without hand-written intercepts:
  - a **busy-wait breaker**: when the same instruction spins reading the same
    status address, escalate the returned value (all-ones → zero → a monotonic
    counter) so `while(!(REG & READY))` / `while(REG & BUSY)` / calibrated-delay
    loops all exit on the firmware's own terms;
  - opt-in **free-running counters** (32- and 64-bit) via `HAL_AUTO_COUNTER_ADDRS`
    / `HAL_AUTO_COUNTER64_ADDRS` / `HAL_AUTO_COUNTER_STEP`;
  - **output capture**: a register receiving a stream of printable byte writes is
    surfaced as console output (e.g. a bootloader banner) without knowing the
    driver.

It is a **base class**: concrete device peripheral models subclass
`AutoPeripheral` to add specific register behaviour while inheriting the recording
and busy-wait-breaker machinery — the same way models already subclass
`GenericPeripheral`.

Also lets `emulate: AutoPeripheral` resolve by **bare name** (no fully-qualified
path): both bare-name resolvers in `main.py` now search the `auto_model` module
alongside `at91`/`generic`. Fully-qualified `emulate:` paths are unaffected.

## Why

A catch-all that gets unmodelled firmware past boot-time register poking is
broadly useful for bringing up a new target — you model the peripherals that
matter and let `AutoPeripheral` absorb the rest (status polls, don't-care config
writes) instead of hand-writing a stub for every region.

## Tests

`test/pytest/peripheral_models/test_auto_model.py` — 21 unit tests (no emulator):
the env-knob parsers, the record path, the busy-wait breaker tiers, the 32- and
64-bit counter semantics, output capture, and bare-name resolution through
`main._instantiate_peripheral`. All pass.

## Notes

- Self-contained: one new module + its test + a two-line-each resolver change.
  Applies cleanly to `master`.
- The `main.py:_instantiate_peripheral` skip-svc hook already name-checks
  `"AutoPeripheral"`; this supplies the class that hook expects.
