### PR TITLE
unicorn/arm64: add the EL1 exception registers Arm64ExceptionDeliverer needs

### DIFF
--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -118,12 +118,38 @@ def _get_arm64_reg_map() -> Dict[str, int]:
         "sp": arm64_const.UC_ARM64_REG_SP,
         "pc": arm64_const.UC_ARM64_REG_PC,
     }
-    # x29 = fp, x30 = lr on AArch64
+    # x29 = fp, x30 = lr on AArch64. The EL1 exception registers below are what
+    # Arm64ExceptionDeliverer's FRAME path already reads/writes by name
+    # (`vbar_el1` to find the vector table, `elr_el1` to set the return address
+    # the handler's terminating `eret` consumes). Without them both lookups
+    # raised ValueError, which the deliverer catches and swallows -- so the
+    # FRAME path silently fell back to the configured vector_base and NEVER set
+    # ELR_EL1, and the ISR's `eret` returned to a stale address. Every name is
+    # added defensively (getattr) so an older Unicorn without a given constant
+    # degrades to "absent" rather than breaking import.
     for name, reg in (
         ("x29", "UC_ARM64_REG_X29"),
         ("x30", "UC_ARM64_REG_X30"),
         ("fp",  "UC_ARM64_REG_FP"),
         ("lr",  "UC_ARM64_REG_LR"),
+        # EL1 exception state (vector base, exception link, syndrome).
+        ("vbar_el1", "UC_ARM64_REG_VBAR_EL1"),
+        ("elr_el1",  "UC_ARM64_REG_ELR_EL1"),
+        ("esr_el1",  "UC_ARM64_REG_ESR_EL1"),
+        # Processor state (PSTATE carries DAIF/nRW; SPSR_EL1 has no dedicated
+        # Unicorn id, so callers that need it use the CP_REG path).
+        ("pstate", "UC_ARM64_REG_PSTATE"),
+        ("nzcv",   "UC_ARM64_REG_NZCV"),
+        # Other ELs, for images that boot through EL2/EL3 before dropping.
+        ("vbar_el2", "UC_ARM64_REG_VBAR_EL2"),
+        ("elr_el2",  "UC_ARM64_REG_ELR_EL2"),
+        ("vbar_el3", "UC_ARM64_REG_VBAR_EL3"),
+        ("elr_el3",  "UC_ARM64_REG_ELR_EL3"),
+        # MMU/control, useful to peripheral models and diagnostics.
+        ("sctlr_el1", "UC_ARM64_REG_SCTLR_EL1"),
+        ("ttbr0_el1", "UC_ARM64_REG_TTBR0_EL1"),
+        ("ttbr1_el1", "UC_ARM64_REG_TTBR1_EL1"),
+        ("cpacr_el1", "UC_ARM64_REG_CPACR_EL1"),
     ):
         v = getattr(arm64_const, reg, None)
         if v is not None:


### PR DESCRIPTION
## The fix

`_get_arm64_reg_map()` in `backends/unicorn_backend.py` defined only
`x0`-`x30`/`sp`/`pc`/`fp`/`lr`. But the FRAME path of `Arm64ExceptionDeliverer`
(`backends/irq/delivery.py`) reaches for two register names that were never in
that map:

```python
vbar = backend.read_register("vbar_el1")
backend.write_register("elr_el1", return_pc)
```

`read_register`/`write_register` raise `ValueError` on an unknown name, and the
deliverer catches and swallows both. So this was a **silent degradation, not an
error**:

* the vector base fell back to the configured `irq_delivery.vector_base`, and
* **`ELR_EL1` was never set at all** — the interrupted PC was lost, so the
  handler's terminating `eret` returned to a stale address.

Any AArch64 target using the documented `irq_delivery: {model: frame}` path hit
this. The deliverer's own contract simply could not be satisfied by the map.

This adds `vbar_el1`/`elr_el1`/`esr_el1`, `pstate`/`nzcv`, the EL2/EL3
vector+link registers, and the MMU control registers (`ttbr0_el1`, `ttbr1_el1`,
`cpacr_el1`). Every name is added defensively via `getattr`, so a Unicorn build
lacking a given constant degrades to "absent" rather than breaking import
(`sctlr_el1` has no Unicorn id today and is simply not present).

The map is **per-architecture**, so no other target is affected.

## How it was found / verified

Bringing up Zephyr RTOS 4.4 on Cortex-A53 (AArch64, QEMU `virt`), where the ARM
generic-timer PPI (INTID 27) must vector through `VBAR_EL1 + 0x280` and `eret`
back. Before the fix the interrupt was delivered but the return address was
stale; after it, the firmware's own
`_isr_wrapper` → `arm_arch_timer_compare_isr` → `sys_clock_announce` path runs
and the kernel clock advances monotonically (verified against the firmware's own
`kernel uptime` shell command: 55740 ms → 175910 ms).

## ⚠️ Caveat — please merge our existing stack first

**This is opened as a draft deliberately.** The branch is cut from our `dev`, so
the compare against `master` currently shows **39 commits**; the substantive
change here is the single commit
`unicorn/arm64: add the EL1 exception registers Arm64ExceptionDeliverer needs`
(one file, +27/-1).

`Arm64ExceptionDeliverer` and the `irq_delivery`/`DeliveryPlan` machinery this
depends on arrive with **#48 (IRQ framework consolidation)**, and
`backends/unicorn_backend.py` is also touched by **#56** and **#57**. Reviewing
or merging this ahead of those would be conflict-ridden and largely meaningless,
since the code it fixes is not on `master` yet.

Suggested order: land the existing stack (#46/#47/#48/#49/#50/#55/#56/#57), then
I will **rebase this onto `master` as a single-commit PR** and mark it ready for
review. Happy to do that rebase at any point on request.
