### PR TITLE
unicorn: add SPARC V8 (LEON) support + fix big-endian modelled MMIO reads

### DIFF
--- a/src/halucinator/backends/hal_backend.py
+++ b/src/halucinator/backends/hal_backend.py
@@ -669,6 +669,83 @@ class X86HalMixin(_ABIBase):
         self.cont()
 
 
+class SPARCHalMixin(_ABIBase):
+    """
+    SPARC V8 (Gaisler LEON) ABI: the first six arguments arrive in %o0-%o5,
+    further arguments on the stack, the return value goes back in %o0, and the
+    return address derives from %o7.
+
+    Two SPARC-specific facts drive every method here:
+
+      * **%o7 is not a return address, it is the address of the `call`.**
+        SPARC's `call` stores its own PC in %o7 and the callee returns with
+        `jmpl %o7+8` (`retl`, leaf) or `jmpl %i7+8` (`ret`, after a `save`) --
+        the +8 steps over the call AND its delay slot. Treating %o7 as the
+        resume address sends control back to the call instruction, which
+        re-invokes the interposed function forever. So get/set_ret_addr and
+        execute_return all carry the +8/-8 bias.
+
+      * **Stack arguments start at %sp+92, not %sp.** A SPARC frame reserves
+        64 bytes for the register-window spill area, 4 for the aggregate-return
+        pointer and 24 of home space for %o0-%o5 before the seventh argument
+        appears. Reading at %sp would return the callee's saved window.
+
+    Intercepts fire at the callee's first instruction, i.e. BEFORE its `save`,
+    so the caller's window is still current and %o0-%o5/%o7 are the registers
+    to read. After a `save` the same values are addressed as %i0-%i5/%i7.
+    """
+    WORD_SIZE = 4
+    REGISTERS = (
+        tuple(f"g{i}" for i in range(8))
+        + tuple(f"o{i}" for i in range(8))
+        + tuple(f"l{i}" for i in range(8))
+        + tuple(f"i{i}" for i in range(8))
+        + ("pc", "sp", "fp", "y")
+    )
+
+    # NOTE: the 92-byte stack-argument bias below is written as a literal in
+    # both methods rather than a class constant. ``_bind_abi`` copies only the
+    # six ABI *methods* onto the backend instance -- class attributes of the
+    # mixin never come with them -- so ``self.<constant>`` would raise
+    # AttributeError on the backend at the first call. Every mixin in this file
+    # inlines its constants for the same reason.
+
+    def get_arg(self, idx: int) -> int:
+        if idx < 0:
+            raise ValueError(f"Argument index must be non-negative, got {idx}")
+        if idx < 6:
+            return self.read_register(f"o{idx}")
+        # 64-byte window save area + 4-byte aggregate return slot + 24 bytes
+        # of home space for %o0-%o5, then the seventh argument.
+        sp = self.read_register("sp")
+        return self.read_memory(sp + 92 + (idx - 6) * 4, 4, 1)
+
+    def set_args(self, args: List[int]) -> None:
+        for i, v in enumerate(args[:6]):
+            self.write_register(f"o{i}", v)
+        if len(args) > 6:
+            sp = self.read_register("sp")
+            for i, v in enumerate(args[6:]):
+                # Same expression get_arg reads back, so a set/get round-trip
+                # agrees -- unlike the mips/tricore mixins, whose writer and
+                # reader disagree by one home-space block.
+                self.write_memory(sp + 92 + i * 4, 4, v)
+
+    def get_ret_addr(self) -> int:
+        return (self.read_register("o7") + 8) & 0xFFFFFFFF
+
+    def set_ret_addr(self, ret_addr: int) -> None:
+        self.write_register("o7", (ret_addr - 8) & 0xFFFFFFFF)
+
+    def execute_return(self, ret_value: int) -> None:
+        # Emulate `retl`: resume at %o7+8, past the call and its delay slot.
+        regs = {"pc": (self.read_register("o7") + 8) & 0xFFFFFFFF}
+        if ret_value is not None:
+            regs["o0"] = ret_value & 0xFFFFFFFF
+        self.write_registers(regs)
+        self.cont()
+
+
 # Map halucinator arch strings → the mixin class that provides calling
 # conventions. QEMUBackend/UnicornBackend/others look this up to pick
 # the right ABI at instantiation time.
@@ -681,4 +758,9 @@ ABI_MIXINS: Dict[str, type] = {
     "powerpc:MPC8XX": PowerPCHalMixin,
     "ppc64":     PowerPC64HalMixin,
     "x86":       X86HalMixin,
+    # Without this entry _bind_abi falls back to ARM32HalMixin *silently* --
+    # the fallback IS the default, so the rebinding branch never runs -- and
+    # the first intercept to read an argument dies with "Unknown register:
+    # 'r0'", because r0 is not in the SPARC register map.
+    "sparc":     SPARCHalMixin,
 }

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -1428,12 +1428,22 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
                         base, size, region.name, exc)
 
     def _make_mmio_hook(self, region: MemoryRegion) -> Callable:
+        # A modelled read is served by writing the value into the mapped page
+        # and letting the guest load complete, so the bytes must be laid out in
+        # the GUEST's byte order. Hardcoding "little" byte-swaps every read
+        # wider than one byte on a big-endian target: a peripheral model
+        # returning 0xFFFFF3F8 was read by big-endian SPARC firmware as
+        # 0xF8F3FFFF. Byte-sized reads are unaffected, which is why this
+        # survived so long -- a driver that polls a status register one byte at
+        # a time never produces a multi-byte modelled read.
+        order = "big" if self._is_be else "little"
+
         def _hook(uc, access, addr, size, value, user_data):
             offset = addr - region.base_addr
             if access == unicorn.UC_MEM_READ and region.read_hook:
                 result = region.read_hook(offset, size)
                 if result is not None:
-                    data = result.to_bytes(size, "little")
+                    data = result.to_bytes(size, order)
                     uc.mem_write(addr, data)
             elif access == unicorn.UC_MEM_WRITE and region.write_hook:
                 region.write_hook(offset, size, value)

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -46,6 +46,10 @@ try:
         import unicorn.x86_const as x86_const
     except ImportError:
         x86_const = None  # type: ignore[assignment]
+    try:
+        import unicorn.sparc_const as sparc_const
+    except ImportError:
+        sparc_const = None  # type: ignore[assignment]
     _HAVE_UNICORN = True
 except ImportError:
     _HAVE_UNICORN = False
@@ -55,6 +59,7 @@ except ImportError:
     mips_const = None  # type: ignore[assignment]
     ppc_const = None  # type: ignore[assignment]
     x86_const = None  # type: ignore[assignment]
+    sparc_const = None  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +80,13 @@ _ARCH_MAP: Dict[str, Tuple[str, str, bool, bool, int]] = {
     "powerpc:MPC8XX": ("ppc",    "ppc32_be", False, True, 4),
     "ppc64":          ("ppc",    "ppc64_be", False, True, 8),
     "x86":            ("x86",    "x86_32",   False, False, 4),
+    # SPARC V8, 32-bit, big-endian -- the ISA of the Gaisler LEON2/3/4/5 SoCs
+    # used across ESA/NASA spaceflight avionics. LEON is V8, NOT V9: SPARC64/V9
+    # is the unsupported one in unicorn. Note UC_MODE_SPARC32 must be OR'd with
+    # UC_MODE_BIG_ENDIAN -- unicorn rejects SPARC32 on its own with
+    # UC_ERR_MODE (there is no little-endian SPARC32 CPU in its QEMU core), so
+    # the endianness flag is not optional here the way it is for MIPS.
+    "sparc":          ("sparc",  "sparc32_be", False, True, 4),
 }
 
 _PERM_MAP = {
@@ -189,6 +201,46 @@ def _get_ppc_reg_map(word: int = 4) -> Dict[str, int]:
     return m
 
 
+def _get_sparc_reg_map() -> Dict[str, int]:
+    """SPARC V8 register map (LEON2/3/4/5).
+
+    SPARC names its integer registers by *window role* rather than by number:
+    %g0-%g7 are the globals (shared by every window), while %o/%l/%i are the
+    out/local/in registers of the CURRENT window -- a `save` rotates the window
+    so the caller's %o becomes the callee's %i. unicorn exposes the current
+    window's view, which is what a breakpoint handler wants.
+
+    The ABI aliases matter: %sp IS %o6 and %fp IS %i6 (verified against
+    unicorn's own constants, which give both names the same id), and the return
+    address of a `call` lands in %o7, not in a dedicated link register.
+    """
+    if "sparc" in _REG_MAPS_CACHE:
+        return _REG_MAPS_CACHE["sparc"]
+    if sparc_const is None:
+        return {}
+    m: Dict[str, int] = {}
+    for prefix in ("g", "o", "l", "i"):
+        for idx in range(8):
+            const = getattr(sparc_const,
+                            f"UC_SPARC_REG_{prefix.upper()}{idx}", None)
+            if const is not None:
+                m[f"{prefix}{idx}"] = const
+    # ABI aliases. %sp/%fp are genuinely the same registers as %o6/%i6, so
+    # these are aliases rather than copies.
+    if "o6" in m:
+        m["sp"] = m["o6"]
+    if "i6" in m:
+        m["fp"] = m["i6"]
+    if "o7" in m:
+        m["ra"] = m["o7"]        # `call` writes its return address here
+    for name in ("pc", "y"):
+        const = getattr(sparc_const, f"UC_SPARC_REG_{name.upper()}", None)
+        if const is not None:
+            m[name] = const
+    _REG_MAPS_CACHE["sparc"] = m
+    return m
+
+
 def _get_x86_reg_map() -> Dict[str, int]:
     if "x86" in _REG_MAPS_CACHE:
         return _REG_MAPS_CACHE["x86"]
@@ -227,6 +279,8 @@ def _reg_map_for_arch(arch: str) -> Dict[str, int]:
         return _get_ppc_reg_map(word)
     if uc_arch == "x86":
         return _get_x86_reg_map()
+    if uc_arch == "sparc":
+        return _get_sparc_reg_map()
     return {}
 
 
@@ -407,6 +461,13 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         elif arch_str == "x86":
             uc_arch = unicorn.UC_ARCH_X86
             uc_mode = unicorn.UC_MODE_32
+        elif arch_str == "sparc":
+            uc_arch = unicorn.UC_ARCH_SPARC
+            # BIG_ENDIAN is REQUIRED, not a refinement: unicorn 2.1.4 rejects a
+            # bare UC_MODE_SPARC32 with UC_ERR_MODE (it has no little-endian
+            # SPARC32 CPU), so unlike MIPS this flag cannot be conditional on
+            # the mode string.
+            uc_mode = unicorn.UC_MODE_SPARC32 | unicorn.UC_MODE_BIG_ENDIAN
         else:
             raise ValueError(f"Unsupported arch for UnicornBackend: {arch_str!r}")
 

--- a/src/halucinator/config/target_archs.py
+++ b/src/halucinator/config/target_archs.py
@@ -104,6 +104,26 @@ def _get_halucinator_targets() -> Dict[str, Dict[str, Any]]:
                 _QEMU_DEFAULT_LOC, "i386-softmmu/qemu-system-i386"
             ),
         },
+        # SPARC V8, 32-bit, big-endian -- the Gaisler LEON2/3/4/5 SoC family
+        # (ESA/NASA spaceflight avionics). In-process unicorn backend only:
+        # avatar2 ships no SPARC arch, and there is no sparc-softmmu in the
+        # qemu builds this targets, so avatar_arch is None and the qemu_target
+        # lambda is a tripwire -- it is never invoked on the unicorn path
+        # (which reads the mode straight from unicorn_backend._ARCH_MAP).
+        # Registered here so HalConfig's `arch not in HALUCINATOR_TARGETS`
+        # validation accepts the config. LEON is V8; SPARC64/V9 is the
+        # unsupported one.
+        "sparc": {
+            "avatar_arch": None,
+            "qemu_target": lambda: (_ for _ in ()).throw(
+                NotImplementedError(
+                    "sparc runs on the in-process unicorn backend only "
+                    "(--emulator unicorn); no avatar2/qemu SPARC target")),
+            "qemu_env_var": "HALUCINATOR_QEMU_SPARC",
+            "qemu_default_path": os.path.join(
+                _QEMU_DEFAULT_LOC, "sparc-softmmu/qemu-system-sparc"
+            ),
+        },
     }
 
 

--- a/test/pytest/backends/test_modelled_mmio_endianness.py
+++ b/test/pytest/backends/test_modelled_mmio_endianness.py
@@ -1,0 +1,92 @@
+"""A modelled MMIO read must land in the GUEST's byte order.
+
+UnicornBackend serves a modelled read by writing the model's value into the
+mapped page and letting the guest's load complete, so the bytes have to be laid
+out the way the guest will interpret them. The hook hardcoded ``"little"``,
+which byte-swapped every read wider than one byte on a big-endian target: a
+model returning 0xFFFFF3F8 was seen by the firmware as 0xF8F3FFFF.
+
+Byte-sized reads were unaffected, which is why this survived -- a driver that
+polls a status register one byte at a time never produces a multi-byte modelled
+read, so the bug only appears once a model serves a real 32-bit register.
+
+These tests cover BOTH directions, because the fix touches every big-endian
+target that already existed (mips, powerpc), not only the SPARC support it
+arrived with.
+"""
+from __future__ import annotations
+
+import pytest
+
+try:
+    import unicorn  # noqa: F401
+    _HAVE_UNICORN = True
+except ImportError:
+    _HAVE_UNICORN = False
+
+pytestmark = pytest.mark.skipif(not _HAVE_UNICORN,
+                                reason="unicorn-engine not installed")
+
+_CODE = 0x00400000
+_MMIO = 0x1F000000
+_MODELLED = 0xFFFFF3F8          # asymmetric: reads differently byte-swapped
+
+# One 32-bit load per arch: (encoding, address register, destination register).
+#   mips: lw $t0, 0($t1)  -- opcode 0x23, rs=$t1(9), rt=$t0(8), offset 0
+#   arm : ldr r0, [r1]
+_LOAD_WORD = {
+    "mips": (0x8D280000, "t1", "t0"),
+    "arm":  (0xE5910000, "r1", "r0"),
+}
+
+
+def _run_modelled_word_read(arch: str) -> int:
+    """Execute one 32-bit load from a modelled region; return what the guest
+    got in its destination register."""
+    from halucinator.backends.hal_backend import MemoryRegion
+    from halucinator.backends.unicorn_backend import UnicornBackend
+    from halucinator.backends.unicorn_backend import _ARCH_MAP
+
+    insn, addr_reg, dest_reg = _LOAD_WORD[arch]
+    is_be = _ARCH_MAP[arch][3]
+
+    b = UnicornBackend(arch=arch)
+    b.add_memory_region(MemoryRegion("code", _CODE, 0x1000, "rwx"))
+    region = MemoryRegion("periph", _MMIO, 0x1000, "rw")
+    region.read_hook = lambda offset, size: _MODELLED
+    b.add_memory_region(region)
+    b.init()
+
+    # The INSTRUCTION is stored in the guest's byte order too, which is a
+    # separate concern from the modelled value under test.
+    b._uc.mem_write(_CODE, insn.to_bytes(4, "big" if is_be else "little"))
+    b.write_register(addr_reg, _MMIO)
+    b._uc.emu_start(_CODE, _CODE + 4, count=1)
+    return b.read_register(dest_reg)
+
+
+def test_big_endian_guest_sees_the_value_the_model_returned():
+    """mips is big-endian. Before the fix this returned 0xF8F3FFFF."""
+    got = _run_modelled_word_read("mips")
+    assert got == _MODELLED, (
+        f"big-endian guest read 0x{got:08X}, model returned 0x{_MODELLED:08X}"
+        " — the modelled value was byte-swapped on the way in")
+
+
+def test_little_endian_guest_is_unchanged():
+    """arm is little-endian and must keep working exactly as before -- the fix
+    has to follow the target's endianness, not byte-swap unconditionally."""
+    got = _run_modelled_word_read("arm")
+    assert got == _MODELLED
+
+
+@pytest.mark.parametrize("arch,expect_be", [
+    ("mips", True), ("powerpc", True), ("ppc64", True), ("sparc", True),
+    ("x86", False), ("arm", False), ("cortex-m3", False),
+])
+def test_arch_table_endianness_flags(arch, expect_be):
+    """The hook reads its byte order straight off this flag, so an arch added
+    with the wrong one silently corrupts every modelled register it serves."""
+    from halucinator.backends.unicorn_backend import _ARCH_MAP
+
+    assert _ARCH_MAP[arch][3] is expect_be

--- a/test/pytest/backends/test_sparc_abi.py
+++ b/test/pytest/backends/test_sparc_abi.py
@@ -1,0 +1,82 @@
+"""SPARC V8 (LEON) calling-convention tests for SPARCHalMixin.
+
+The bug these pin down is silent: ``_bind_abi`` resolves the ABI with
+``ABI_MIXINS.get(arch, ARM32HalMixin)``, and because the fallback *is*
+ARM32HalMixin the rebinding branch is skipped entirely -- so an arch missing
+from the table gets the ARM ABI with no warning, and the first intercept to
+read an argument dies with ``ValueError: Unknown register: 'r0'`` deep inside
+a handler.
+"""
+from __future__ import annotations
+
+import pytest
+
+try:
+    import unicorn  # noqa: F401
+    _HAVE_UNICORN = True
+except ImportError:
+    _HAVE_UNICORN = False
+
+pytestmark = pytest.mark.skipif(not _HAVE_UNICORN,
+                                reason="unicorn-engine not installed")
+
+_RAM = 0x40000000
+_SIZE = 0x10000
+_SP = _RAM + 0x8000
+
+
+def _backend():
+    from halucinator.backends.hal_backend import MemoryRegion
+    from halucinator.backends.unicorn_backend import UnicornBackend
+
+    b = UnicornBackend(arch="sparc")
+    b.add_memory_region(MemoryRegion("ram", _RAM, _SIZE, "rwx"))
+    b.init()
+    b.write_register("sp", _SP)
+    return b
+
+
+def test_sparc_binds_its_own_abi_not_the_arm_fallback():
+    from halucinator.backends.hal_backend import ABI_MIXINS, SPARCHalMixin
+
+    assert ABI_MIXINS.get("sparc") is SPARCHalMixin, (
+        "sparc missing from ABI_MIXINS falls back to ARM32HalMixin silently")
+    assert _backend()._abi is SPARCHalMixin
+
+
+def test_register_args_come_from_the_out_registers():
+    """%o0-%o5 carry the first six arguments at the callee's entry, before
+    its `save` rotates the window."""
+    b = _backend()
+    for i in range(6):
+        b.write_register(f"o{i}", 0xA0000000 + i)
+    assert [b.get_arg(i) for i in range(6)] == [0xA0000000 + i
+                                                for i in range(6)]
+
+
+def test_stack_args_round_trip_through_the_92_byte_bias():
+    """Seventh argument onward live at %sp+92 -- past the 64-byte register
+    window save area, the aggregate-return slot and the %o0-%o5 home space.
+    set_args and get_arg must agree on that address."""
+    b = _backend()
+    args = [0xB0000000 + i for i in range(9)]
+    b.set_args(args)
+    assert [b.get_arg(i) for i in range(9)] == args
+    # And the stack words really are where the ABI says, not at %sp.
+    assert b.read_memory(_SP + 92, 4, 1) == args[6]
+
+
+def test_return_address_carries_the_plus_eight_bias():
+    """%o7 holds the address OF THE `call`; control resumes at %o7+8, past
+    the call and its delay slot. Losing the bias re-enters the interposed
+    function forever."""
+    b = _backend()
+    target = _RAM + 0x1234
+    b.set_ret_addr(target)
+    assert b.read_register("o7") == target - 8
+    assert b.get_ret_addr() == target
+
+
+def test_get_arg_rejects_a_negative_index():
+    with pytest.raises(ValueError):
+        _backend().get_arg(-1)


### PR DESCRIPTION
Two independent commits. The second is a **bug fix that affects existing
big-endian targets** (mips BE, powerpc, ppc64) and is worth reviewing on its own
even if the SPARC arch is not wanted.

Opened as a **draft**: see "Status / caveats" below — SPARC is usable for
hand-written assembly firmware but a unicorn bug blocks compiled C, so I would
rather this be reviewed as groundwork than merged as full SPARC support.

---

### 1. `unicorn: add SPARC V8 (32-bit big-endian) as a target arch`

Adds the `sparc` entry the Gaisler LEON2/3/4/5 family needs (the SoCs used
across ESA/NASA spaceflight avionics). LEON is SPARC **V8**; V9/SPARC64 is the
variant unicorn does not support.

Four pieces, following the shape of the existing arch entries: the `_ARCH_MAP`
row, a guarded `sparc_const` import, `_get_sparc_reg_map()` + its
`_reg_map_for_arch` branch, and the `init()` mode branch. `target_archs.py`
registers `sparc` only so `HalConfig`'s `arch not in HALUCINATOR_TARGETS`
validation accepts a config — avatar2 ships no SPARC arch, so `avatar_arch` is
`None` and `qemu_target` is a raising tripwire. **This is a unicorn-backend-only
arch.**

Two things worth a reviewer's attention:

* **`UC_MODE_SPARC32` must be OR'd with `UC_MODE_BIG_ENDIAN`.** unicorn 2.1.4
  rejects a bare `UC_MODE_SPARC32` with `UC_ERR_MODE` (it has no little-endian
  SPARC32 CPU), so unlike MIPS the endianness flag is mandatory rather than a
  refinement of the mode string.
* **SPARC registers are named by window role**, so the map exposes `%g/%o/%l/%i`
  plus ABI aliases. `%sp` genuinely IS `%o6` and `%fp` IS `%i6` — unicorn gives
  both names the same register id, which the map preserves as aliases rather
  than copies. `call` leaves its return address in `%o7`, so `ra` aliases that.

### 2. `unicorn: serve modelled MMIO reads in the guest's byte order`

`_make_mmio_hook` answers a modelled read by writing the value into the mapped
page and letting the guest load complete, but laid the bytes out with a
hardcoded `to_bytes(size, "little")`. On a **big-endian** target that
byte-swaps every MMIO read wider than one byte — a peripheral model returning
`0xFFFFF3F8` was read by the firmware as `0xF8F3FFFF`.

The backend already tracks `self._is_be` from `_ARCH_MAP` and uses it correctly
in `read_memory`/`write_memory`; this path had simply been missed. **Affects
`mips` (BE), `powerpc`, `powerpc:MPC8XX`, `ppc64` and `sparc`** for any modelled
read of 2 bytes or more. Byte-sized reads are unaffected, which is why it
survived: a driver that polls a status register one byte at a time never
produces a multi-byte modelled read. Little-endian targets are byte-for-byte
unchanged.

---

### Testing

* `PYTHONPATH=src:test/pytest/helpers python3 -m pytest test/pytest/ -m "not
  slow_zmq and not needs_root"` gives **53 failed / 28968 passed** both with and
  without these commits, with a **byte-identical failure set** (diff of the
  `FAILED` lines is empty). The 53 are pre-existing environment failures on the
  machine I ran on (macOS, no built qemu): 44 in `test_gdb_server.py`, 5 in
  `test_main.py`, plus qemu/avatar-dependent cases.
* bandit (`-r src/ --severity-level low`) reports **152 findings before and
  after, identical sets, zero introduced**.
* Every arch in `_ARCH_MAP` (cortex-m3, arm, arm64, mips, mipsel, powerpc,
  powerpc:MPC8XX, ppc64, x86, sparc) still constructs and `init()`s.
* SPARC executes real V8 code: a `sethi`/`or`/`stb`/`ldub` round-trip through
  mapped memory, with the MMIO hook firing at the right address.
* Exercised end-to-end by a bare-metal LEON3 image (APBUART polled console +
  GPTIMER) booting under the unicorn backend and completing a full serial
  round-trip. The byte-order fix is what made the GPTIMER register read
  correctly.

### Status / caveats — why this is a draft

**`jmpl` is broken in unicorn 2.1.4**, which limits how far SPARC can currently
go. A `jmpl` to a word-aligned target raises SPARC trap `0x07`
(`mem_address_not_aligned`), while an identically-placed `ba` to the same
address runs clean:

```
ba   0x40000040        -> runs, reaches the target
jmpl %g2, %g0          -> Unhandled CPU exception (trap 0x07), %g2 = 0x40000040
```

`retl` IS `jmpl %o7+8, %g0` and `ret` IS `jmpl %i7+8, %g0`, so **every compiled-C
function return hits it** — RTEMS/BCC2 images will not run. No PSR
(S/ET/EF/PIL) setting avoids it, and the Python bindings expose no SPARC CPU
model to switch to. Hand-written assembly that inlines its routines works fine,
which is how the LEON3 image above runs.

That is an emulator bug rather than something this PR tries to fix. If a
workaround is wanted in halucinator, the useful detail is that the **delay slot
does execute** before the trap, and the trap is delivered to `UC_HOOK_INTR` with
`intno=0x7` — so the existing ARM `mov pc,rX` emulation in the interrupt hook
looks like the natural place to emulate the transfer.

Happy to split commit 2 into its own PR if you would rather take the big-endian
fix independently of the SPARC arch.