### PR TITLE
unicorn/tricore: add the Infineon TriCore (AURIX) architecture entry

### DIFF
--- a/src/halucinator/backends/hal_backend.py
+++ b/src/halucinator/backends/hal_backend.py
@@ -596,6 +596,11 @@ class TriCoreHalMixin(_ABIBase):
             raise ValueError(f"Argument index must be non-negative, got {idx}")
         if idx < 4:
             return self.read_register(f"d{4 + idx}")
+        # Overflow arguments start AT the stack pointer. TriCore's EABI has no
+        # O32-style home space: the caller does not reserve slots for the
+        # register-passed arguments, so the fifth argument is the first word of
+        # the outgoing area. (This is where a mixin copied from MIPSHalMixin
+        # goes wrong -- MIPS reserves 16 bytes for a0-a3 and TriCore does not.)
         sp = self.read_register("a10")
         return self.read_memory(sp + (idx - 4) * 4, 4, 1)
 
@@ -605,7 +610,11 @@ class TriCoreHalMixin(_ABIBase):
         if len(args) > 4:
             sp = self.read_register("a10")
             for i, v in enumerate(args[4:]):
-                self.write_memory(sp + (4 + i) * 4, 4, v)
+                # Same address get_arg reads back. This previously wrote at
+                # sp+16.. -- the MIPS O32 home-space offset, inherited by
+                # copy -- so a set/get round-trip disagreed by 16 bytes and an
+                # intercept reading argument 5 got an unrelated word.
+                self.write_memory(sp + i * 4, 4, v)
 
     def get_ret_addr(self) -> int:
         return self.read_register("a11")

--- a/src/halucinator/backends/hal_backend.py
+++ b/src/halucinator/backends/hal_backend.py
@@ -568,6 +568,59 @@ class MIPSHalMixin(_ABIBase):
         self.cont()
 
 
+class TriCoreHalMixin(_ABIBase):
+    """
+    Infineon TriCore EABI: data args in d4-d7 (address args in a4-a7), then the
+    stack; return address in a11 (RA); return value in d2.
+
+    TriCore splits its register file in two: 16 *data* registers (d0-d15) and 16
+    *address* registers (a0-a15). The ABI assigns them separately -- an integer
+    argument goes in d4..d7 while a pointer goes in a4..a7 -- so ``get_arg``
+    cannot be a single index into one bank. We return the DATA register, which
+    is what an intercept reading a scalar argument wants; a handler needing the
+    pointer argument reads ``a4``..``a7`` directly via ``read_register``.
+
+    Two more TriCore-specific facts matter to callers:
+      * ``a10`` is the stack pointer (SP) and ``a11`` is the return address
+        (RA), written by ``call``; there is no separate ``lr``.
+      * ``a0``/``a1``/``a8``/``a9`` are *system-global* registers, preserved
+        across calls and normally set up once at boot -- do not clobber them.
+    """
+    WORD_SIZE = 4
+    REGISTERS = (tuple(f"d{i}" for i in range(16))
+                 + tuple(f"a{i}" for i in range(16))
+                 + ("pc", "psw", "pcxi", "fcx", "lcx", "sp", "ra"))
+
+    def get_arg(self, idx: int) -> int:
+        if idx < 0:
+            raise ValueError(f"Argument index must be non-negative, got {idx}")
+        if idx < 4:
+            return self.read_register(f"d{4 + idx}")
+        sp = self.read_register("a10")
+        return self.read_memory(sp + (idx - 4) * 4, 4, 1)
+
+    def set_args(self, args: List[int]) -> None:
+        for i, v in enumerate(args[:4]):
+            self.write_register(f"d{4 + i}", v)
+        if len(args) > 4:
+            sp = self.read_register("a10")
+            for i, v in enumerate(args[4:]):
+                self.write_memory(sp + (4 + i) * 4, 4, v)
+
+    def get_ret_addr(self) -> int:
+        return self.read_register("a11")
+
+    def set_ret_addr(self, ret_addr: int) -> None:
+        self.write_register("a11", ret_addr)
+
+    def execute_return(self, ret_value: int) -> None:
+        regs = {"pc": self.read_register("a11")}
+        if ret_value is not None:
+            regs["d2"] = ret_value & 0xFFFFFFFF
+        self.write_registers(regs)
+        self.cont()
+
+
 class PowerPCHalMixin(_ABIBase):
     """
     PowerPC ABI: args in r3–r10 then stack, return addr in lr,
@@ -681,4 +734,5 @@ ABI_MIXINS: Dict[str, type] = {
     "powerpc:MPC8XX": PowerPCHalMixin,
     "ppc64":     PowerPC64HalMixin,
     "x86":       X86HalMixin,
+    "tricore":   TriCoreHalMixin,
 }

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -46,6 +46,10 @@ try:
         import unicorn.x86_const as x86_const
     except ImportError:
         x86_const = None  # type: ignore[assignment]
+    try:
+        import unicorn.tricore_const as tricore_const
+    except ImportError:
+        tricore_const = None  # type: ignore[assignment]
     _HAVE_UNICORN = True
 except ImportError:
     _HAVE_UNICORN = False
@@ -55,6 +59,7 @@ except ImportError:
     mips_const = None  # type: ignore[assignment]
     ppc_const = None  # type: ignore[assignment]
     x86_const = None  # type: ignore[assignment]
+    tricore_const = None  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +80,14 @@ _ARCH_MAP: Dict[str, Tuple[str, str, bool, bool, int]] = {
     "powerpc:MPC8XX": ("ppc",    "ppc32_be", False, True, 4),
     "ppc64":          ("ppc",    "ppc64_be", False, True, 8),
     "x86":            ("x86",    "x86_32",   False, False, 4),
+    # Infineon TriCore (AURIX TC2xx/TC3xx). Little-endian, 32-bit.
+    #
+    # NOTE: Unicorn exposes NO `UC_MODE_TRICORE*` constant -- the only mode
+    # value `uc_open(UC_ARCH_TRICORE, ...)` accepts is 0
+    # (UC_MODE_LITTLE_ENDIAN); every other value fails UC_ERR_ARG. The CPU
+    # model is selected by `uc_ctl_set_cpu_model` (TC1796/TC1797/TC27X), not by
+    # the mode.
+    "tricore":        ("tricore", "tricore", False, False, 4),
 }
 
 _PERM_MAP = {
@@ -105,6 +118,50 @@ def _get_arm_reg_map() -> Dict[str, int]:
         "spsr": arm_const.UC_ARM_REG_SPSR,
     }
     _REG_MAPS_CACHE["arm"] = m
+    return m
+
+
+def _get_tricore_reg_map() -> Dict[str, int]:
+    """Infineon TriCore: 16 data (d0-d15) + 16 address (a0-a15) registers.
+
+    ``a10`` is the stack pointer and ``a11`` the return address (written by
+    ``call``); TriCore has no separate ``lr``/``sp`` register, so ``sp``/``ra``
+    are exposed as aliases onto a10/a11 and ``lr`` onto a11 as well, so generic
+    core code that asks for ``sp``/``lr`` works unchanged.
+    """
+    if "tricore" in _REG_MAPS_CACHE:
+        return _REG_MAPS_CACHE["tricore"]
+    if tricore_const is None:
+        return {}
+    m: Dict[str, int] = {}
+    for i in range(16):
+        for bank in ("d", "a"):
+            v = getattr(tricore_const, f"UC_TRICORE_REG_{bank.upper()}{i}", None)
+            if v is not None:
+                m[f"{bank}{i}"] = v
+    # PC + the context/state CSFRs an intercept or a trap model needs.
+    for name, reg in (
+        ("pc",   "UC_TRICORE_REG_PC"),
+        ("psw",  "UC_TRICORE_REG_PSW"),
+        ("pcxi", "UC_TRICORE_REG_PCXI"),
+        ("fcx",  "UC_TRICORE_REG_FCX"),
+        ("lcx",  "UC_TRICORE_REG_LCX"),
+        ("biv",  "UC_TRICORE_REG_BIV"),
+        ("btv",  "UC_TRICORE_REG_BTV"),
+        ("isp",  "UC_TRICORE_REG_ISP"),
+        ("icr",  "UC_TRICORE_REG_ICR"),
+        ("syscon", "UC_TRICORE_REG_SYSCON"),
+    ):
+        v = getattr(tricore_const, reg, None)
+        if v is not None:
+            m[name] = v
+    # Aliases so arch-generic core code (sp/lr lookups) resolves.
+    if "a10" in m:
+        m["sp"] = m["a10"]
+    if "a11" in m:
+        m["ra"] = m["a11"]
+        m["lr"] = m["a11"]
+    _REG_MAPS_CACHE["tricore"] = m
     return m
 
 
@@ -222,6 +279,8 @@ def _reg_map_for_arch(arch: str) -> Dict[str, int]:
         return _get_arm64_reg_map()
     if uc_arch == "mips":
         return _get_mips_reg_map()
+    if uc_arch == "tricore":
+        return _get_tricore_reg_map()
     if uc_arch == "ppc":
         word = info[4]
         return _get_ppc_reg_map(word)
@@ -407,6 +466,11 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         elif arch_str == "x86":
             uc_arch = unicorn.UC_ARCH_X86
             uc_mode = unicorn.UC_MODE_32
+        elif arch_str == "tricore":
+            uc_arch = unicorn.UC_ARCH_TRICORE
+            # Unicorn accepts ONLY mode 0 for TriCore (see _ARCH_MAP note);
+            # UC_MODE_LITTLE_ENDIAN is 0 and states the intent.
+            uc_mode = unicorn.UC_MODE_LITTLE_ENDIAN
         else:
             raise ValueError(f"Unsupported arch for UnicornBackend: {arch_str!r}")
 

--- a/src/halucinator/config/target_archs.py
+++ b/src/halucinator/config/target_archs.py
@@ -104,6 +104,17 @@ def _get_halucinator_targets() -> Dict[str, Dict[str, Any]]:
                 _QEMU_DEFAULT_LOC, "i386-softmmu/qemu-system-i386"
             ),
         },
+        # Infineon TriCore (AURIX TC2xx/TC3xx). In-process (unicorn) only:
+        # avatar2 has no TriCore arch, and there is no tricore-softmmu QEMU in
+        # the deps build, so `avatar_arch`/`qemu_target` stay None. The entry
+        # exists so hal_config accepts `arch: tricore` and the unicorn backend
+        # can resolve it.
+        "tricore": {
+            "avatar_arch": None,
+            "qemu_target": None,
+            "qemu_env_var": "HALUCINATOR_QEMU_TRICORE",
+            "qemu_default_path": None,
+        },
     }
 
 

--- a/test/pytest/backends/test_tricore_arch.py
+++ b/test/pytest/backends/test_tricore_arch.py
@@ -130,6 +130,48 @@ class TestTriCoreABI:
         assert f.written["d2"] == 0x1234         # result in d2
         assert f.continued
 
+    def test_stack_args_are_written_where_they_are_read(self):
+        """Arguments past the fourth go on the stack, and set_args must put
+        them where get_arg looks.
+
+        TriCore's EABI has NO O32-style home space -- the caller reserves no
+        slots for the register-passed arguments -- so the fifth argument is the
+        first word at a10. set_args used to write at a10+16, the MIPS offset,
+        inherited by copying MIPSHalMixin: a round-trip then disagreed by 16
+        bytes and an intercept reading argument 5 silently got an unrelated
+        word."""
+        from halucinator.backends.hal_backend import TriCoreHalMixin
+
+        SP = 0x70003F00
+
+        class Fake(TriCoreHalMixin):
+            def __init__(self):
+                self.regs = {f"d{i}": 0 for i in range(16)}
+                self.regs["a10"] = SP
+                self.mem = {}
+
+            def read_register(self, r):
+                return self.regs[r]
+
+            def write_register(self, r, v):
+                self.regs[r] = v
+
+            def read_memory(self, addr, size, num):
+                return self.mem.get(addr, 0)
+
+            def write_memory(self, addr, size, value, num=1, raw=False):
+                self.mem[addr] = value
+
+        f = Fake()
+        args = [0xA0 + i for i in range(7)]
+        f.set_args(args)
+        assert [f.get_arg(i) for i in range(7)] == args
+        # Absolute placement: a reader and writer that are both wrong in the
+        # same direction would still agree with each other.
+        assert f.mem[SP] == args[4]
+        assert f.mem[SP + 4] == args[5]
+        assert SP + 16 not in f.mem, "wrote at the MIPS O32 home-space offset"
+
 
 # ---------------------------------------------------------------------------
 # Real execution

--- a/test/pytest/backends/test_tricore_arch.py
+++ b/test/pytest/backends/test_tricore_arch.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Christopher Wright
+
+"""
+Tests for the Infineon TriCore (AURIX) target arch wired into the backend stack.
+
+Covers:
+  * HALUCINATOR_TARGETS exposes "tricore" so hal_config accepts it.
+  * The unicorn arch map and the TriCore EABI mixin know the arch.
+  * The register map exposes both banks (d0-d15 / a0-a15) plus the sp/ra/lr
+    aliases onto a10/a11, which TriCore does not have as real registers.
+  * UnicornBackend can instantiate arch="tricore" and actually execute TriCore
+    instructions (real unicorn, not a mock) at the authentic AURIX TC27x
+    PFLASH0 base.
+  * The 16 KB page-size constraint is real and is what a too-small region
+    trips over -- documented here so it is not re-diagnosed as a bad address.
+
+No avatar2 dependency: TriCore is in-process (unicorn) only, so its
+HALUCINATOR_TARGETS entry deliberately carries avatar_arch=None.
+"""
+import pytest
+
+try:
+    import unicorn
+    _HAVE_UNICORN = True
+except ImportError:
+    _HAVE_UNICORN = False
+
+# Authentic AURIX TC27xD map (QEMU hw/tricore/tc27x_soc.c).
+PFLASH0 = 0x80000000
+DSPR0 = 0x70000000
+# Unicorn's TriCore target page size. NOT 4 KB.
+TRICORE_PAGE = 0x4000
+
+# mov d1,#1 ; mov d3,#2 ; mov d7,#3  (SRC format; capstone-cross-checked)
+CODE = bytes([0x82, 0x11, 0x82, 0x23, 0x82, 0x37])
+
+
+# ---------------------------------------------------------------------------
+# Arch-table wiring (no unicorn needed)
+# ---------------------------------------------------------------------------
+
+class TestTriCoreArchTables:
+    def test_in_halucinator_targets(self):
+        from halucinator.config.target_archs import HALUCINATOR_TARGETS
+        assert "tricore" in HALUCINATOR_TARGETS
+
+    def test_is_in_process_only(self):
+        """TriCore has no avatar2 arch and no tricore-softmmu QEMU, so the
+        entry exists purely so hal_config accepts `arch: tricore`."""
+        from halucinator.config.target_archs import HALUCINATOR_TARGETS
+        assert HALUCINATOR_TARGETS["tricore"]["avatar_arch"] is None
+        assert HALUCINATOR_TARGETS["tricore"]["qemu_target"] is None
+
+    def test_hal_machine_config_accepts_tricore(self):
+        from halucinator.hal_config import HALMachineConfig
+        cfg = HALMachineConfig(arch="tricore", cpu_model="tc27x",
+                               entry_addr=PFLASH0, init_sp=DSPR0 + 0x3F00)
+        assert cfg.arch == "tricore"
+
+    def test_unicorn_arch_map_row(self):
+        from halucinator.backends.unicorn_backend import _ARCH_MAP
+        uc_arch, mode, thumb, big_endian, ptr = _ARCH_MAP["tricore"]
+        assert uc_arch == "tricore"
+        assert thumb is False
+        assert big_endian is False        # TriCore is little-endian
+        assert ptr == 4                   # 32-bit
+
+    def test_abi_mixin_is_tricore(self):
+        from halucinator.backends.hal_backend import ABI_MIXINS, TriCoreHalMixin
+        assert ABI_MIXINS["tricore"] is TriCoreHalMixin
+
+
+class TestTriCoreRegisterMap:
+    def test_both_register_banks_present(self):
+        """TriCore has 16 DATA (d0-d15) and 16 ADDRESS (a0-a15) registers."""
+        from halucinator.backends.unicorn_backend import _reg_map_for_arch
+        m = _reg_map_for_arch("tricore")
+        for i in range(16):
+            assert f"d{i}" in m, f"data register d{i} missing"
+            assert f"a{i}" in m, f"address register a{i} missing"
+        assert "pc" in m
+
+    def test_sp_ra_lr_are_aliases_onto_a10_a11(self):
+        """TriCore has no sp/lr register: a10 IS the stack pointer and a11 IS
+        the return address. The aliases let arch-generic core code resolve."""
+        from halucinator.backends.unicorn_backend import _reg_map_for_arch
+        m = _reg_map_for_arch("tricore")
+        assert m["sp"] == m["a10"]
+        assert m["ra"] == m["a11"]
+        assert m["lr"] == m["a11"]
+
+
+class TestTriCoreABI:
+    def test_scalar_args_come_from_the_data_bank(self):
+        """The EABI puts scalar arguments in d4-d7 (pointers go in a4-a7), so
+        get_arg indexes the DATA bank."""
+        from halucinator.backends.hal_backend import TriCoreHalMixin
+
+        class Fake(TriCoreHalMixin):
+            def __init__(self):
+                self.regs = {f"d{i}": i * 10 for i in range(16)}
+
+            def read_register(self, r):
+                return self.regs[r]
+
+        f = Fake()
+        assert f.get_arg(0) == f.regs["d4"]
+        assert f.get_arg(3) == f.regs["d7"]
+
+    def test_return_uses_a11_and_d2(self):
+        from halucinator.backends.hal_backend import TriCoreHalMixin
+
+        class Fake(TriCoreHalMixin):
+            def __init__(self):
+                self.written = {}
+                self.continued = False
+
+            def read_register(self, r):
+                return 0xDEADBEEF if r == "a11" else 0
+
+            def write_registers(self, regs):
+                self.written.update(regs)
+
+            def cont(self):
+                self.continued = True
+
+        f = Fake()
+        f.execute_return(0x1234)
+        assert f.written["pc"] == 0xDEADBEEF     # returns via a11, not lr
+        assert f.written["d2"] == 0x1234         # result in d2
+        assert f.continued
+
+
+# ---------------------------------------------------------------------------
+# Real execution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _HAVE_UNICORN, reason="unicorn not installed")
+class TestTriCoreUnicornExecution:
+    def _backend(self):
+        from halucinator.backends.unicorn_backend import UnicornBackend
+        from halucinator.backends.hal_backend import MemoryRegion
+        be = UnicornBackend(arch="tricore")
+        be.add_memory_region(MemoryRegion("pflash", PFLASH0, TRICORE_PAGE, "rwx"))
+        be.add_memory_region(MemoryRegion("dspr", DSPR0, TRICORE_PAGE, "rw"))
+        be.init()
+        return be
+
+    def test_executes_tricore_instructions(self):
+        be = self._backend()
+        be.write_memory(PFLASH0, 1, CODE, num_words=len(CODE), raw=True)
+        be.write_register("pc", PFLASH0)
+        be._uc.emu_start(PFLASH0, PFLASH0 + len(CODE))
+        assert be.read_register("d1") == 1
+        assert be.read_register("d3") == 2
+        assert be.read_register("d7") == 3
+        assert be.read_register("pc") == PFLASH0 + len(CODE)
+
+    def test_sp_alias_writes_a10(self):
+        be = self._backend()
+        be.write_register("sp", DSPR0 + 0x100)
+        assert be.read_register("a10") == DSPR0 + 0x100
+
+    def test_page_size_is_16k_not_4k(self):
+        """Unicorn's TriCore target uses a 16 KB page. A 4 KB region is
+        rejected by uc_mem_map with UC_ERR_ARG -- which reads like a bad
+        ADDRESS rather than a bad size, and is why HALucinator configs that
+        declare the usual 4 KB peripheral window fail on this arch."""
+        uc = unicorn.Uc(unicorn.UC_ARCH_TRICORE, unicorn.UC_MODE_LITTLE_ENDIAN)
+        with pytest.raises(unicorn.UcError):
+            uc.mem_map(PFLASH0, 0x1000)
+        uc.mem_map(PFLASH0, TRICORE_PAGE)        # 16 KB is accepted
+
+    def test_only_mode_zero_opens(self):
+        """Unicorn exposes no UC_MODE_TRICORE* constant; mode 0
+        (UC_MODE_LITTLE_ENDIAN) is the only value uc_open accepts."""
+        assert unicorn.UC_MODE_LITTLE_ENDIAN == 0
+        unicorn.Uc(unicorn.UC_ARCH_TRICORE, unicorn.UC_MODE_LITTLE_ENDIAN)
+        with pytest.raises(unicorn.UcError):
+            unicorn.Uc(unicorn.UC_ARCH_TRICORE, unicorn.UC_MODE_BIG_ENDIAN)


### PR DESCRIPTION
## What this adds

Infineon **TriCore** (AURIX TC2xx/TC3xx) as a HALucinator target on the
in-process unicorn backend:

* `_ARCH_MAP` row (`"tricore"` → `UC_ARCH_TRICORE`, little-endian, 4-byte pointers)
* mode selection in `UnicornBackend.init()`
* `_get_tricore_reg_map()` — `d0`-`d15`, `a0`-`a15`, `pc`, and the CSFRs an
  intercept or trap model needs (`psw`, `pcxi`, `fcx`, `lcx`, `biv`, `btv`,
  `isp`, `icr`, `syscon`)
* `TriCoreHalMixin` — the TriCore EABI
* a `config/target_archs.py` entry so `hal_config` accepts `arch: tricore`
* `test/pytest/backends/test_tricore_arch.py` — 13 tests, no avatar2 dependency

TriCore is a genuinely different shape from the architectures already in the
map, so three things are encoded here that are not guessable from the others:

**1. There is no `UC_MODE_TRICORE*` constant.** The only mode value
`uc_open(UC_ARCH_TRICORE, ...)` accepts is `0` (`UC_MODE_LITTLE_ENDIAN`); every
other value returns `UC_ERR_ARG`. The CPU model (`TC1796`/`TC1797`/`TC27X`) is
selected with `uc_ctl_set_cpu_model`, not through the mode.

**2. Two register banks, and no `lr`/`sp`.** TriCore has 16 *data* registers
(`d0`-`d15`) and 16 *address* registers (`a0`-`a15`), and the EABI assigns them
separately — a scalar argument goes in `d4`-`d7` while a pointer goes in
`a4`-`a7`. `get_arg()` therefore returns the DATA register (what an intercept
reading a scalar wants); a handler needing the pointer argument reads `a4`-`a7`
directly. `a10` **is** the stack pointer and `a11` **is** the return address
(written by `call`), so the register map exposes `sp`/`ra`/`lr` as aliases onto
them and the ABI mixin returns via `a11` with the result in `d2`.

**3. The target page is 16 KB, not 4 KB.** `uc_mem_map` rejects any region
smaller than `0x4000` or not `0x4000`-aligned with `UC_ERR_ARG`. This is worth
knowing because it does not present as a size problem: every `mem_map` fails
regardless of address, and `uc_ctl_set_cpu_model` fails the same way, so it
looks like the architecture is missing from the build entirely — it is not
(`uc_arch_supported(UC_ARCH_TRICORE)` is `True`). A regression test pins this.

## Verification

Real execution, not mocks: a capstone-cross-checked instruction sequence
(`mov d1,#1` / `mov d3,#2` / `mov d7,#3`, encodings `8211 8223 8237`) is loaded
at the authentic AURIX TC27x PFLASH0 base `0x80000000` and executed through the
backend's own API, leaving `d1=1 d3=2 d7=3` with PC advanced by 6.

Suite: `test/pytest/backends` + `test/pytest/config` →
**8 failed / 346 passed / 42 skipped**, against **8 failed / 333 passed /
42 skipped** on the same tree without this commit. Same 8 pre-existing failures
(all `ModuleNotFoundError: No module named 'avatar2'` in
`test_mmio_forwarding.py` / `test_x86_arch.py`); the delta is the 13 new tests.

## ⚠️ Caveat — please merge our existing stack first

**Opened as a draft deliberately.** This branch is cut from our `dev`, so the
compare against `master` shows the whole stack; the substantive change here is
the single commit *"unicorn/tricore: add the Infineon TriCore (AURIX)
architecture entry"* (4 files, +309/-0, purely additive — a new arch, a new ABI
mixin, a new targets entry and a new test file; no existing code path is
modified).

It sits on top of the same `unicorn_backend.py`/`hal_backend.py` work that
#48/#56/#57 are already carrying, so reviewing it ahead of those would be
conflict-ridden. Suggested order: land the existing stack, then I will **rebase
this onto `master` as a single-commit PR** and mark it ready for review. Happy
to do that rebase on request.
