### PR TITLE
main: restore the --dap and --gdb-server debug entry points

### DIFF
--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -288,6 +288,8 @@ def emulate_binary(
     singlestep: bool = False,
     qemu_args: Optional[str] = None,
     gdb_server_port: Optional[int] = None,
+    dap_port: Optional[int] = None,
+    dap_bind: str = "127.0.0.1",
     print_qemu_command: Optional[bool] = None,
     emulator: str = "avatar2",
 ) -> None:  # pylint: disable=too-many-arguments,too-many-locals
@@ -299,6 +301,17 @@ def emulate_binary(
 
     # Non-avatar2 backends go through the new HalBackend factory path.
     if emulator != "avatar2":
+        if dap_port is not None:
+            # The DAP server drives bp_handlers.debugger.Debugger, which is
+            # built on avatar2's QemuTarget/TargetStates. Fail loudly rather
+            # than silently ignoring --dap and leaving a client hanging on a
+            # port that will never be bound.
+            log.error(
+                "--dap requires the avatar2 backend (got %r). Re-run with "
+                "--emulator avatar2, or use --gdb-server for an in-process "
+                "backend.", emulator,
+            )
+            sys.exit(-1)
         return _emulate_with_backend(
             config=config,
             emulator=emulator,
@@ -358,7 +371,15 @@ def emulate_binary(
     if gdb_server_port is not None and gdb_server_port >= 0:
         avatar.load_plugin("gdbserver")
         # pylint: disable=no-member
-        avatar.spawn_gdb_server(qemu, gdb_server_port, do_forwarding=False)
+        # stop_filter tells the RSP server which stops belong to HALucinator's
+        # own HAL intercepts rather than to a client breakpoint, so it can
+        # resume them instead of reporting them to the attached debugger.
+        avatar.spawn_gdb_server(
+            qemu,
+            gdb_server_port,
+            do_forwarding=False,
+            stop_filter=lambda target, pc: intercepts.check_hal_bp(pc),
+        )
 
     register_intercepts(config, avatar, qemu)
 
@@ -384,7 +405,51 @@ def emulate_binary(
     except Exception:  # noqa: BLE001
         qemu._irq_controller = None
 
-    _start_execution(avatar, qemu, rx_port, tx_port, gdb_server_port)
+    if dap_port is not None:
+        _start_dap_server(avatar, qemu, dap_port, dap_bind)
+
+    _start_execution(avatar, qemu, rx_port, tx_port, gdb_server_port,
+                     dap_port=dap_port)
+
+
+def _start_dap_server(
+    avatar: Avatar, qemu: Any, dap_port: int, dap_bind: str,
+) -> None:
+    """
+    Start the Debug Adapter Protocol server so an IDE (the halucinator-vscode
+    extension, or any DAP client) can attach.
+
+    Imported lazily: halucinator.debug_adapter pulls in bp_handlers.debugger,
+    which imports avatar2 at module scope. A module-level import here would
+    make avatar2 a hard dependency of main.py again and break the
+    avatar2-optional install that the unicorn/ghidra/renode backends rely on.
+    """
+    # pylint: disable=import-outside-toplevel
+    from .debug_adapter.debug_adapter import DAPServer
+    from .bp_handlers.debugger import Debugger
+
+    debugger = Debugger(qemu, avatar, None)
+    # Tell the intercept machinery we're in a debug session. HAL intercept
+    # handlers then wait for the monitor thread's emulation_detected ack
+    # before calling target.cont(), which removes the race where
+    # monitor_running observes STOPPED, takes the post-loop branch, and then
+    # finds the target RUNNING again by the time it reads the PC.
+    intercepts.debug_session = True
+    # Start the monitor thread now so request_queue is always being serviced.
+    # Without this, send_request from a DAP handler blocks forever waiting on
+    # a queue nobody is draining.
+    debugger.start_monitoring(add_shell_callback=False)
+    dap_thread = threading.Thread(
+        target=DAPServer(debugger, dap_port, bind_addr=dap_bind),
+        daemon=True,
+    )
+    dap_thread.start()
+    log.info(
+        "DAP server listening on %s:%d%s",
+        dap_bind,
+        dap_port,
+        "" if dap_bind == "127.0.0.1" else " (EXPOSED: no authentication)",
+    )
 
 
 def _start_execution(
@@ -393,6 +458,7 @@ def _start_execution(
     rx_addr: int,
     tx_addr: int,
     gdb_server_port: Optional[int],
+    dap_port: Optional[int] = None,
 ) -> None:
     """
     Starts the actual execution of qemu,
@@ -428,12 +494,18 @@ def _start_execution(
 
     signal.signal(signal.SIGINT, int_signal_handler)
     qemu.halucinator_shutdown = halucinator_shutdown
-    log.info("Letting QEMU Run")
 
-    if gdb_server_port is not None:
-        print(f"GDB Server Running on localhost:{gdb_server_port}")
-        print("Connect GDB and continue to run")
+    if gdb_server_port is not None or dap_port is not None:
+        # With a debug server enabled, leave QEMU paused at the entry point so
+        # the client can attach and set breakpoints before anything runs.
+        # Resuming here would race the client past the code it wants to stop on.
+        if gdb_server_port is not None:
+            print(f"GDB Server Running on localhost:{gdb_server_port}")
+        if dap_port is not None:
+            print(f"DAP Server Running on localhost:{dap_port}")
+        print("QEMU paused at entry - connect a debug client to start execution")
     else:
+        log.info("Letting QEMU Run")
         qemu.cont()
     try:
         periph_server.run_server()  # Blocks Forever
@@ -1513,6 +1585,42 @@ def main() -> None:
         help="Port to run GDB Server port",
     )
     parser.add_argument(
+        "--gdb-server",
+        type=int,
+        nargs="?",
+        const=3333,
+        default=None,
+        metavar="PORT",
+        dest="gdb_server",
+        help=(
+            "Start GDB RSP server for external debuggers (default port: 3333). "
+            "Alias for --gdb_server_port, kept for the halucinator-vscode "
+            "extension and existing launch configs."
+        ),
+    )
+    parser.add_argument(
+        "--dap",
+        type=int,
+        nargs="?",
+        const=34157,
+        default=None,
+        metavar="PORT",
+        help="Start Debug Adapter Protocol server (default port: 34157)",
+    )
+    parser.add_argument(
+        "--dap-bind",
+        type=str,
+        default="127.0.0.1",
+        metavar="ADDR",
+        dest="dap_bind",
+        help=(
+            "Interface for the DAP server to bind. Defaults to 127.0.0.1 "
+            "(loopback-only) because no authentication is implemented. "
+            "Use 0.0.0.0 to accept remote connections - only on trusted "
+            "networks."
+        ),
+    )
+    parser.add_argument(
         "-e", "--elf", default=None, help="Elf file, required to use recorder"
     )
     parser.add_argument(
@@ -1565,6 +1673,13 @@ def main() -> None:
     # emulator key can come from YAML config options or CLI
     emulator = getattr(args, "emulator", None) or config.options.get("emulator", "avatar2")
 
+    # --gdb-server and -d/--gdb_server_port are two spellings of one setting.
+    # --gdb-server wins when both are given; it's the explicit, newer spelling
+    # and the one the halucinator-vscode extension emits.
+    gdb_server_port = (
+        args.gdb_server if args.gdb_server is not None else args.gdb_server_port
+    )
+
     emulate_binary(
         config,
         args.name,
@@ -1575,7 +1690,9 @@ def main() -> None:
         gdb_port=args.gdb_port,
         singlestep=args.singlestep,
         qemu_args=qemu_args,
-        gdb_server_port=args.gdb_server_port,
+        gdb_server_port=gdb_server_port,
+        dap_port=args.dap,
+        dap_bind=args.dap_bind,
         print_qemu_command=args.print_qemu_command,
         emulator=emulator,
     )

--- a/test/pytest/test_main_debug_flags.py
+++ b/test/pytest/test_main_debug_flags.py
@@ -1,0 +1,110 @@
+"""Regression tests for the debug-server CLI flags.
+
+Commit 2aa29b826d ("main.py + hal_config: per-backend orchestration +
+--emulator routing") silently dropped ``--dap``/``--dap-bind`` and renamed
+``--gdb-server`` to ``-d``/``--gdb_server_port``. Both flags are emitted by the
+released halucinator-vscode extension, so the extension could no longer launch
+HALucinator at all -- one flag was gone, the other unrecognised.
+
+Nothing covered the CLI surface, so the breakage was invisible to CI. These
+tests pin the flags and, more importantly, assert they are *plumbed through* to
+``emulate_binary`` -- parsing alone would not have caught the original bug.
+"""
+import os
+from unittest import mock
+
+import pytest
+
+from halucinator import main
+
+
+EXAMPLE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "test", "STM32", "example",
+)
+CONFIG_ARGS = [
+    "-c", os.path.join(EXAMPLE, "Uart_Hyperterminal_IT_O0_config.yaml"),
+    "-c", os.path.join(EXAMPLE, "Uart_Hyperterminal_IT_O0_addrs.yaml"),
+    "-c", os.path.join(EXAMPLE, "Uart_Hyperterminal_IT_O0_memory.yaml"),
+]
+
+
+def run_main(argv):
+    """Invoke main.main() with argv, capturing the emulate_binary kwargs."""
+    with mock.patch.object(main, "emulate_binary") as emulate:
+        with mock.patch("sys.argv", ["halucinator"] + argv):
+            main.main()
+    assert emulate.call_count == 1, "emulate_binary was not reached"
+    return emulate.call_args.kwargs
+
+
+class Test_dap_flags:
+    def test_dap_defaults_to_none(self):
+        """Without --dap no DAP server is requested."""
+        kwargs = run_main(CONFIG_ARGS)
+        assert kwargs["dap_port"] is None
+
+    def test_dap_bare_uses_default_port(self):
+        """--dap with no value uses the well-known 34157 the extension expects."""
+        kwargs = run_main(CONFIG_ARGS + ["--dap"])
+        assert kwargs["dap_port"] == 34157
+
+    def test_dap_explicit_port(self):
+        kwargs = run_main(CONFIG_ARGS + ["--dap", "40000"])
+        assert kwargs["dap_port"] == 40000
+
+    def test_dap_bind_defaults_to_loopback(self):
+        """The DAP server has no auth, so it must not bind the world by default."""
+        kwargs = run_main(CONFIG_ARGS + ["--dap"])
+        assert kwargs["dap_bind"] == "127.0.0.1"
+
+    def test_dap_bind_override(self):
+        kwargs = run_main(CONFIG_ARGS + ["--dap", "--dap-bind", "0.0.0.0"])
+        assert kwargs["dap_bind"] == "0.0.0.0"
+
+
+class Test_gdb_server_flags:
+    def test_gdb_server_bare_uses_default_port(self):
+        """--gdb-server with no value is what halucinator-vscode emits."""
+        kwargs = run_main(CONFIG_ARGS + ["--gdb-server"])
+        assert kwargs["gdb_server_port"] == 3333
+
+    def test_gdb_server_explicit_port(self):
+        kwargs = run_main(CONFIG_ARGS + ["--gdb-server", "1234"])
+        assert kwargs["gdb_server_port"] == 1234
+
+    def test_legacy_underscore_spelling_still_works(self):
+        """-d/--gdb_server_port must keep working for existing scripts."""
+        kwargs = run_main(CONFIG_ARGS + ["-d", "4444"])
+        assert kwargs["gdb_server_port"] == 4444
+
+    def test_gdb_server_wins_over_legacy_spelling(self):
+        """Both given: the explicit --gdb-server spelling takes precedence."""
+        kwargs = run_main(CONFIG_ARGS + ["-d", "4444", "--gdb-server", "3333"])
+        assert kwargs["gdb_server_port"] == 3333
+
+    def test_no_flag_means_no_server(self):
+        kwargs = run_main(CONFIG_ARGS)
+        assert kwargs["gdb_server_port"] is None
+
+
+class Test_dap_requires_avatar2:
+    """--dap needs avatar2's QemuTarget; the in-process backends can't host it.
+
+    It must fail loudly rather than leaving a DAP client waiting on a port
+    nothing ever binds.
+    """
+
+    @pytest.mark.parametrize("emulator", ["unicorn", "ghidra", "renode"])
+    def test_dap_on_in_process_backend_exits(self, emulator):
+        with pytest.raises(SystemExit) as exc:
+            main.emulate_binary(
+                mock.MagicMock(), dap_port=34157, emulator=emulator,
+            )
+        assert exc.value.code != 0
+
+    def test_no_dap_on_in_process_backend_is_fine(self):
+        """Sanity: the guard only fires for --dap, not for every backend call."""
+        with mock.patch.object(main, "_emulate_with_backend") as backend:
+            main.emulate_binary(mock.MagicMock(), emulator="unicorn")
+        assert backend.call_count == 1


### PR DESCRIPTION
## The problem

Commit 2aa29b826d (*"main.py + hal_config: per-backend orchestration + `--emulator` routing"*, mine) dropped the CLI surface the debug servers were driven through:

- **`--dap` / `--dap-bind` were deleted outright**, along with the `DAPServer` import and the startup block. `halucinator.debug_adapter` survived and is still unit-tested — but nothing can start it.
- **`--gdb-server` was renamed** to `-d` / `--gdb_server_port`.

The released [`GrammaTech/halucinator-vscode`](https://github.com/GrammaTech/halucinator-vscode) v1.0.0 extension emits **both** spellings — `--dap <port>` in its default mode, `--gdb-server <port>` in gdb mode. So on current master **the extension cannot launch HALucinator at all**: one flag is unrecognised, the other no longer exists.

```
$ halucinator --gdb-server 3333 -c ...
halucinator: error: unrecognized arguments: --gdb-server 3333
```

Nothing covered the CLI surface, so CI stayed green through the entire regression. It has been broken since May.

## The fix

Restores both entry points while keeping what the backend refactor got right:

- **`--dap [PORT]`** (default `34157`) and **`--dap-bind ADDR`** (default `127.0.0.1` — the DAP server implements no authentication, so it must not bind the world by default).
- **`--gdb-server [PORT]`** (default `3333`) as an alias for `--gdb_server_port`. Both spellings work; `--gdb-server` wins if both are given. Existing scripts using `-d` are unaffected.
- **`DAPServer`/`Debugger` are imported lazily** inside `_start_dap_server`, not at module scope. `bp_handlers.debugger` imports avatar2 at import time, so a top-level import would undo the avatar2-optional install that the unicorn/ghidra/renode backends rely on. Verified the branch is byte-for-byte equivalent to master under a simulated missing-avatar2 import.
- **`--dap` on a non-avatar2 backend exits with an explanatory error.** The DAP server is built on avatar2's `QemuTarget`/`TargetStates`; silently ignoring the flag would leave a client waiting forever on a port nothing binds.
- **QEMU is left paused at entry** when either server is enabled, so the client can attach and set breakpoints before anything executes.
- **Restores the `stop_filter` argument** to `spawn_gdb_server`, which tells the RSP server which stops are HAL intercepts rather than client breakpoints.

## Tests

`test/pytest/test_main_debug_flags.py` pins the flags **and asserts they reach `emulate_binary`** — parsing alone would not have caught the original break, since the flags were removed from the call site too.

**11 of the 14 new tests fail on the unfixed tree.**

Full suite: `28942 passed, 5 failed`. The 5 failures are in `peripheral_models/test_adc.py` and `test_gpio.py`, reproduce identically on unmodified master, and are untouched by this PR.

## Verified end-to-end

Against the avatar2 backend with the STM32 UART example, using the exact flags the extension emits (no workarounds):

**`--gdb-server 3333`**
```
GDB Server Running on localhost:3333
QEMU paused at entry - connect a debug client to start execution
pc  0x8000808  <Reset_Handler>
Breakpoint 1, Reset_Handler () at ../startup_stm32f469xx.s:100
pc  0x8000828  <Reset_Handler+32>          # after stepi
```

**`--dap 34157`**
```
DAP Server Running on localhost:34157
initialize -> success=True  capabilities=6 keys
threads    -> success=True  [{'id': 1, 'name': 'thread1'}]
```

## Note on scope

This branches from `master` and is independent of the #33 → #57 stack, so it can merge at any point in that order. I'd suggest **before #47** — shipping a PyPI release with the IDE entry point missing would bake the regression into a versioned artifact.

One thing this PR does **not** fix: with a GDB client attached, `continue` past a HAL intercept still drops the RSP connection. Restoring `stop_filter` alone does not resolve it (I tested); the root cause is deeper and no HAL intercept fires before the connection closes. Filing separately rather than conflating it here.
