### PR TITLE
build(pypi): add trusted-publishing workflow and fix packaging metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,101 @@
+name: Publish
+
+# Publishing uses PyPI Trusted Publishing (OIDC): no API token is stored in the
+# repo. PyPI is configured with owner=halucinator, repo=halucinator,
+# workflow=publish.yml, environment=pypi (and environment=testpypi for the
+# dry run), so only this workflow file, in this repo, can mint an upload token.
+#
+#   Release to PyPI      -- publish a GitHub Release (tag vX.Y.Z).
+#   Dry run to TestPyPI  -- run this workflow manually (Actions -> Publish -> Run).
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      # Submodules are deliberately not fetched: deps/avatar2 is installed
+      # separately and never enters the distributions.
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tooling
+        run: python -m pip install --quiet --upgrade build twine
+
+      - name: Check the release tag matches halucinator.__version__
+        if: github.event_name == 'release'
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(python -c "import re,pathlib; \
+            print(re.search(r'__version__ = \"([^\"]+)\"', \
+            pathlib.Path('src/halucinator/__init__.py').read_text()).group(1))")
+          if [ "$tag" != "$pkg" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match __version__ $pkg" >&2
+            exit 1
+          fi
+
+      - name: Build
+        run: python -m build
+
+      - name: Validate metadata
+        run: twine check dist/*
+
+      - name: Confirm the sdist carries the runtime data files
+        run: |
+          tar tzf dist/*.tar.gz | grep -q 'src/halucinator/logging.cfg'
+          tar tzf dist/*.tar.gz | grep -q 'src/halucinator/py.typed'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/halucinator
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # TestPyPI accumulates dry runs; a re-run of the same version should
+          # not fail the workflow.
+          skip-existing: true
+
+  pypi:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/halucinator
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/virtual-environment-tests.yml
+++ b/.github/workflows/virtual-environment-tests.yml
@@ -535,13 +535,13 @@ jobs:
   # yields a working rehosting install. This job deliberately does NOT check out
   # submodules or build QEMU, so any failure here is unambiguously a packaging or
   # unicorn-backend regression rather than a toolchain problem. It is also the
-  # matrix that validates the declared `requires-python = ">=3.9"`.
+  # matrix that validates the declared `requires-python = ">=3.10"`.
   pip-install-unicorn:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.11', '3.13']
+        python: ['3.10', '3.11', '3.13']
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/virtual-environment-tests.yml
+++ b/.github/workflows/virtual-environment-tests.yml
@@ -530,9 +530,9 @@ jobs:
         path: deps/build-qemu-upstream-v11.0.0
         key: upstream-qemu-overlay-v11.0.0-${{ matrix.os }}-${{ steps.overlay-ref.outputs.sha }}
 
-  # Proves the packaging story end-to-end: a plain `pip install halucinator[unicorn]`
-  # into a clean virtualenv -- no avatar2, no externally-built QEMU, no submodules --
-  # yields a working rehosting install. This job deliberately does NOT check out
+  # Proves the packaging story end-to-end: a plain `pip install halucinator`
+  # into a clean virtualenv -- no extras, no avatar2, no externally-built QEMU,
+  # no submodules -- yields a working rehosting install. This job deliberately does NOT check out
   # submodules or build QEMU, so any failure here is unambiguously a packaging or
   # unicorn-backend regression rather than a toolchain problem. It is also the
   # matrix that validates the declared `requires-python = ">=3.10"`.
@@ -558,21 +558,29 @@ jobs:
         python -m build
         ls -l dist/
 
-    - name: Install the wheel into a clean venv (with the [unicorn] extra)
+    - name: Install the wheel into a clean venv (no extras -- the default path)
       run: |
         set -e
         set -x
         python -m venv /tmp/wheelenv
         /tmp/wheelenv/bin/pip install --upgrade pip
-        /tmp/wheelenv/bin/pip install "$(ls dist/*.whl)[unicorn]"
+        # Deliberately NO extras: unicorn/capstone are core deps, so a bare
+        # install must already be able to emulate.
+        /tmp/wheelenv/bin/pip install "$(ls dist/*.whl)"
 
     - name: Assert the install is avatar2-free, complete and typed
       run: |
         set -e
         set -x
-        # The whole point of the [unicorn] tier: avatar2 must NOT be pulled in.
+        # A default install must be able to emulate without any extra.
+        /tmp/wheelenv/bin/python -c "import unicorn, capstone" \
+          || { echo "FATAL: default install cannot emulate"; exit 1; }
+        # ...and must NOT drag in avatar2 or the MCP server stack.
         if /tmp/wheelenv/bin/python -c "import avatar2" 2>/dev/null; then
-          echo "FATAL: avatar2 was installed by halucinator[unicorn]"; exit 1
+          echo "FATAL: avatar2 was installed by a default halucinator install"; exit 1
+        fi
+        if /tmp/wheelenv/bin/python -c "import mcp" 2>/dev/null; then
+          echo "FATAL: the MCP SDK leaked into the default install"; exit 1
         fi
         # Console scripts must resolve (qemulog2trace regressed silently for
         # years because `tools` was not a packaged subpackage).
@@ -613,7 +621,7 @@ jobs:
         set -x
         python -m venv /tmp/sdistenv
         /tmp/sdistenv/bin/pip install --upgrade pip
-        /tmp/sdistenv/bin/pip install "$(ls dist/*.tar.gz)[unicorn]"
+        /tmp/sdistenv/bin/pip install "$(ls dist/*.tar.gz)"
         /tmp/sdistenv/bin/halucinator --help > /dev/null
         echo "sdist install OK"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and makes the project installable as a real Python distribution.
 
 ### Packaging
 
-Prepares HALucinator for a PyPI release. `pip install halucinator[unicorn]`
-now yields a working rehosting install with no avatar2 and no hand-built QEMU.
+Prepares HALucinator for a PyPI release. `pip install halucinator` now yields a
+working rehosting install with no avatar2 and no hand-built QEMU.
 
 - Replaced `src/setup.py` with a PEP 621 `pyproject.toml` at the repo root,
   keeping the importable tree under `src/` via `package-dir`. Consequence:
@@ -34,8 +34,12 @@ now yields a working rehosting install with no avatar2 and no hand-built QEMU.
   all imported but never declared; dropped `angr<9`, `protobuf<=3.20` and
   `deprecated`, none of which is imported anywhere in the package; unpinned
   `scapy`
-- Added extras: `[unicorn]`, `[net]`, `[symbols]`, `[mcp]`, `[dev]`, and
-  `[all]` for everything installable on the >=3.9 baseline
+- `unicorn` and `capstone` are core dependencies, so the default install can
+  emulate immediately; `[unicorn]` remains as a no-op alias for older
+  instructions
+- Added extras: `[net]`, `[symbols]`, `[mcp]`, `[dev]`, and `[all]`
+- Baseline is Python >=3.10 (3.9 reached end-of-life in October 2025), which
+  also lets `[mcp]` be part of `[all]` instead of needing its own interpreter
 - Ship `LICENSE` in the built distributions — the wheel previously contained
   no license file at all, a compliance problem for GPL-3.0 code
 - Ship `logging.cfg` as package data; without it a non-editable install

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,9 @@
 # LICENSE up automatically for the dist-info, and it is listed again here so the
 # sdist carries it too.
 include LICENSE
+# README-PyPI.md is the long_description (see pyproject.toml); README.md ships
+# too so the sdist is a faithful copy of the source tree.
+include README-PyPI.md
 include README.md
 include CHANGELOG.md
 

--- a/README-PyPI.md
+++ b/README-PyPI.md
@@ -12,20 +12,22 @@ hardware, which makes firmware reachable for debugging, analysis, and fuzzing.
 ## Install
 
 ```sh
-pip install halucinator[unicorn]
+pip install halucinator
 ```
 
-The `unicorn` extra is the self-contained install: it is the only backend that
-needs no externally-built binary, so this yields a working rehosting setup from
-pip alone.
+That is a complete, working rehosting setup. The unicorn backend ships by
+default because it is the only one that needs no externally-built binary, so
+there is nothing else to install before emulating a binary.
 
 | Extra | Installs | For |
 | --- | --- | --- |
-| `[unicorn]` | unicorn, capstone | The pip-only backend. Start here. |
 | `[net]` | scapy, pyserial | Host network / serial external devices |
 | `[symbols]` | cle | ELF symbol extraction via `hal_make_addr` |
 | `[mcp]` | mcp[cli] | The `halucinator-mcp` server |
 | `[all]` | all of the above | Everything except the dev tooling |
+
+`[unicorn]` still resolves as a no-op alias, so older instructions saying
+`pip install halucinator[unicorn]` keep working.
 
 Requires Python 3.10 or newer.
 

--- a/README-PyPI.md
+++ b/README-PyPI.md
@@ -129,10 +129,20 @@ integration, and the developer setup live in the source repository:
 
 GPL-3.0-or-later.
 
-HALucinator was created at Sandia National Laboratories by Abraham Clements and
-the Sandia HALucinator team, with later contributions from the GrammaTech
-HALucinator team and Christopher Wright. The complete contributor list is the
-project's git history.
+HALucinator was initially created by Abraham Clements and Eric Gustafson at
+Sandia National Laboratories, together with their collaborators and PhD
+advisors at Purdue University, UC Santa Barbara, and EPFL. The work was
+published at the 29th USENIX Security Symposium:
+
+> [HALucinator: Firmware Re-hosting Through Abstraction Layer
+> Emulation](https://www.usenix.org/conference/usenixsecurity20/presentation/clements).
+> Abraham Clements, Eric Gustafson, Tobias Scharnowski, Paul Grosen, David
+> Fritz, Christopher Kruegel, Giovanni Vigna, Saurabh Bagchi, and Mathias
+> Payer. 29th USENIX Security Symposium (USENIX Security '20), August 2020.
+
+It has since been developed by the Sandia HALucinator team, with later
+contributions from the GrammaTech HALucinator team and Christopher Wright. The
+complete contributor list is the project's git history.
 
 Sandia National Laboratories is a multimission laboratory managed and operated
 by National Technology & Engineering Solutions of Sandia, LLC, a wholly owned

--- a/README-PyPI.md
+++ b/README-PyPI.md
@@ -1,0 +1,140 @@
+# HALucinator
+
+**Firmware rehosting through abstraction layer modeling.**
+
+HALucinator runs embedded firmware binaries without the original hardware. Rather
+than emulating every peripheral register, it intercepts calls to the firmware's
+*hardware abstraction layer* — `HAL_UART_Transmit`, `spi_write`, and friends —
+and answers them in Python. Replacing a handful of HAL functions is usually
+enough to boot a binary that would otherwise fault immediately on missing
+hardware, which makes firmware reachable for debugging, analysis, and fuzzing.
+
+## Install
+
+```sh
+pip install halucinator[unicorn]
+```
+
+The `unicorn` extra is the self-contained install: it is the only backend that
+needs no externally-built binary, so this yields a working rehosting setup from
+pip alone.
+
+| Extra | Installs | For |
+| --- | --- | --- |
+| `[unicorn]` | unicorn, capstone | The pip-only backend. Start here. |
+| `[net]` | scapy, pyserial | Host network / serial external devices |
+| `[symbols]` | cle | ELF symbol extraction via `hal_make_addr` |
+| `[mcp]` | mcp[cli] | The `halucinator-mcp` server (needs Python ≥3.10) |
+| `[all]` | all of the above except `[mcp]` | Everything on the ≥3.9 baseline |
+
+Requires Python 3.9 or newer.
+
+### Other backends
+
+HALucinator supports several execution backends, selected with `--emulator`:
+`unicorn`, `qemu`, `avatar2`, `libafl-qemu`, `renode`, and `ghidra`. Only
+`unicorn` is installable purely from PyPI — the others depend on an external
+QEMU build, a Renode install, or the avatar2 fork tracked in the source
+repository. See the [repository
+README](https://github.com/halucinator/halucinator#readme) for those setups.
+
+## Usage
+
+Emulation is driven by YAML configuration. Configs are conventionally split into
+three files — memory layout, intercepts, and a symbol/address map — which
+HALucinator concatenates, with later files taking precedence:
+
+```sh
+halucinator -c memory.yaml -c intercepts.yaml -c addresses.yaml --emulator unicorn
+```
+
+Splitting them this way keeps the intercept list portable across builds of the
+same firmware: only the address map changes when the binary is recompiled.
+
+### Configuration sketch
+
+Memory layout and emulated peripherals:
+
+```yaml
+memories:
+  flash: {base_addr: 0x8000000, size: 0x200000, permissions: r-x, file: firmware.bin}
+  ram:   {base_addr: 0x20000000, size: 0x51000}
+peripherals:
+  logger: {base_addr: 0x40000000, size: 0x20000000, permissions: rw-, emulate: GenericPeripheral}
+```
+
+What to intercept, and which handler answers it:
+
+```yaml
+intercepts:
+  - class: halucinator.bp_handlers.stm32f4.stm32f4_uart.STM32F4UART
+    function: HAL_UART_Transmit
+    symbol: HAL_UART_Transmit
+  - class: halucinator.bp_handlers.generic.common.ReturnZero
+    function: HAL_RCC_OscConfig
+    symbol: HAL_RCC_OscConfig
+```
+
+`function` selects the handler method (matched against the handler's
+`@bp_handler` decorator); `symbol` resolves the address from the symbol map, so
+prefer it over hardcoding `addr`. Handlers accept `class_args` for
+per-intercept configuration.
+
+The full schema — machine settings, watchpoints, `registration_args`,
+`run_once`, and the peripheral model list — is documented in the [repository
+README](https://github.com/halucinator/halucinator#readme).
+
+## Handler families
+
+Prebuilt intercept handlers ship for common HALs and RTOSes:
+
+- **generic** — `ReturnZero`, `ReturnConstant`, `SkipFunc`, counters, timers
+- **stm32f4** — STM32F4 HAL: UART, GPIO, SPI, ethernet, timers, WiFi
+- **libopencm3** — ADC, DMA, flash, GPIO, RCC, SPI, timer, USART
+- **atmel_asf_v3** — Atmel ASF: contiki, ethernet, radio, SD/MMC, timers, USART
+- **mbed** — Mbed OS: boot, serial, timer
+- **vxworks** — VxWorks: boot, filesystem, ethernet, interrupts, scheduler, tasks
+- **zephyr** — Zephyr: filesystem, UART
+
+## Command-line tools
+
+| Command | Purpose |
+| --- | --- |
+| `halucinator` | Run an emulation from config files |
+| `hal_make_addr` | Extract a symbol/address map from an ELF (needs `[symbols]`) |
+| `hal_dev_uart` | UART external device — the interactive console |
+| `hal_dev_host_eth`, `hal_dev_host_eth_server` | Bridge emulated ethernet to the host |
+| `hal_dev_virt_hub`, `hal_dev_eth_wireless` | Virtual network hub and wireless link |
+| `hal_dev_802_15_4` | IEEE 802.15.4 radio device |
+| `hal_dev_irq_trigger` | Inject interrupts into a running emulation |
+| `halucinator-mcp` | MCP server for agent-driven rehosting (needs `[mcp]`) |
+| `qemulog2trace` | Convert QEMU logs to execution traces |
+
+External devices communicate with the emulator over ZeroMQ, so they run as
+separate processes — typically one terminal for `hal_dev_uart` and another for
+`halucinator` itself.
+
+## Supported architectures
+
+ARM Cortex-M · ARM (full, e.g. arm926) · AArch64 · MIPS · PowerPC · PowerPC64
+
+## Documentation
+
+Full documentation, worked examples, the VSCode extension and debug-adapter
+integration, and the developer setup live in the source repository:
+
+**https://github.com/halucinator/halucinator**
+
+## License and credit
+
+GPL-3.0-or-later.
+
+HALucinator was created at Sandia National Laboratories by Abraham Clements and
+the Sandia HALucinator team, with later contributions from the GrammaTech
+HALucinator team and Christopher Wright. The complete contributor list is the
+project's git history.
+
+Sandia National Laboratories is a multimission laboratory managed and operated
+by National Technology & Engineering Solutions of Sandia, LLC, a wholly owned
+subsidiary of Honeywell International Inc., for the U.S. Department of Energy's
+National Nuclear Security Administration under contract DE-NA0003525.

--- a/README-PyPI.md
+++ b/README-PyPI.md
@@ -148,3 +148,7 @@ Sandia National Laboratories is a multimission laboratory managed and operated
 by National Technology & Engineering Solutions of Sandia, LLC, a wholly owned
 subsidiary of Honeywell International Inc., for the U.S. Department of Energy's
 National Nuclear Security Administration under contract DE-NA0003525.
+
+Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.

--- a/README-PyPI.md
+++ b/README-PyPI.md
@@ -24,10 +24,10 @@ pip alone.
 | `[unicorn]` | unicorn, capstone | The pip-only backend. Start here. |
 | `[net]` | scapy, pyserial | Host network / serial external devices |
 | `[symbols]` | cle | ELF symbol extraction via `hal_make_addr` |
-| `[mcp]` | mcp[cli] | The `halucinator-mcp` server (needs Python ≥3.10) |
-| `[all]` | all of the above except `[mcp]` | Everything on the ≥3.9 baseline |
+| `[mcp]` | mcp[cli] | The `halucinator-mcp` server |
+| `[all]` | all of the above | Everything except the dev tooling |
 
-Requires Python 3.9 or newer.
+Requires Python 3.10 or newer.
 
 ### Other backends
 

--- a/README.md
+++ b/README.md
@@ -537,3 +537,31 @@ and the full pytest suite with coverage reporting.
 - **mbed**: Mbed OS (boot, serial, timer)
 - **vxworks**: VxWorks RTOS (boot, filesystem, ethernet, interrupts, scheduler, tasks)
 - **zephyr**: Zephyr RTOS (filesystem, UART)
+
+## License and credit
+
+GPL-3.0-or-later.
+
+HALucinator was initially created by Abraham Clements and Eric Gustafson at
+Sandia National Laboratories, together with their collaborators and PhD
+advisors at Purdue University, UC Santa Barbara, and EPFL. The work was
+published at the 29th USENIX Security Symposium:
+
+> [HALucinator: Firmware Re-hosting Through Abstraction Layer
+> Emulation](https://www.usenix.org/conference/usenixsecurity20/presentation/clements).
+> Abraham Clements, Eric Gustafson, Tobias Scharnowski, Paul Grosen, David
+> Fritz, Christopher Kruegel, Giovanni Vigna, Saurabh Bagchi, and Mathias
+> Payer. 29th USENIX Security Symposium (USENIX Security '20), August 2020.
+
+It has since been developed by the Sandia HALucinator team, with later
+contributions from the GrammaTech HALucinator team and Christopher Wright. The
+complete contributor list is the project's git history.
+
+Sandia National Laboratories is a multimission laboratory managed and operated
+by National Technology & Engineering Solutions of Sandia, LLC, a wholly owned
+subsidiary of Honeywell International Inc., for the U.S. Department of Energy's
+National Nuclear Security Administration under contract DE-NA0003525.
+
+Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.

--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ Or from Ghidra's Debugger tool, use the **gdb** launcher with
 The `--gdb-server` and `--dap` flags can be combined to run both servers
 simultaneously.
 
-See [doc/debugging.md](doc/debugging.md) for a full walkthrough,
-architecture-specific notes, and troubleshooting.
+See [doc/debugging.md](https://github.com/halucinator/halucinator/blob/master/doc/debugging.md)
+for a full walkthrough, architecture-specific notes, and troubleshooting.
 
 ## Running
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,13 +76,24 @@ classifiers = [
     "Topic :: System :: Emulators",
 ]
 
-# The core runtime set: exactly what importing halucinator.main pulls in.
+# What a working default install needs -- not merely what `import
+# halucinator.main` pulls in. A bare `pip install halucinator` that cannot
+# actually emulate anything is a trap, so the one backend that needs no
+# externally-built binary ships by default.
 #   PyYAML     -- hal_stats/hal_config parse every config file
 #   pyzmq      -- peripheral_server + the hal_dev_* external devices.
 #                 (The import is `zmq`; the DISTRIBUTION providing it is pyzmq.)
 #   pyelftools -- config/elf_program.py (ELFFile) on the import path
 #   IPython    -- bp_handlers/generic/debug.py imports it at module scope, and
 #                 bp_handlers/__init__ star-imports that package
+#   unicorn    -- the `--emulator unicorn` backend, imported lazily
+#   capstone   -- disassembly for that backend's tracing/diagnostics
+#
+# unicorn + capstone add ~48 MB but only those two distributions: no transitive
+# tree. The MCP SDK is deliberately NOT here -- it pulls ~35 packages including
+# an ASGI server (starlette/uvicorn), httpx, pydantic, cryptography and PyJWT,
+# which is a large supply-chain surface for a feature most users never touch.
+# It stays behind [mcp] (and is included in [all]).
 #
 # avatar2 is deliberately absent. HALucinator tracks a FORK installed from the
 # pinned submodule (`pip install -e deps/avatar2/`); declaring `avatar2` here
@@ -93,6 +104,8 @@ dependencies = [
     "pyzmq",
     "pyelftools",
     "IPython",
+    "unicorn>=2.0",
+    "capstone>=4.0",
 ]
 
 [project.urls]
@@ -103,9 +116,10 @@ Documentation = "https://github.com/halucinator/halucinator/tree/master/doc"
 Issues = "https://github.com/halucinator/halucinator/issues"
 
 [project.optional-dependencies]
-# The unicorn backend (`--emulator unicorn`) is the only one that needs no
-# externally-built binary, so this is the self-contained install:
-#     pip install halucinator[unicorn]
+# Retained as a no-op alias: unicorn + capstone are core dependencies as of
+# 1.9.0, so `pip install halucinator` already includes them. Existing docs,
+# scripts and CI that say `halucinator[unicorn]` keep working rather than
+# tripping pip's unknown-extra warning.
 unicorn = ["unicorn>=2.0", "capstone>=4.0"]
 
 # Host-network / serial external devices: hal_dev_host_eth,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ description = "Firmware emulation and rehosting framework"
 # that audience and is what renders on the project page; README.md stays the
 # GitHub landing page and is unaffected.
 readme = "README-PyPI.md"
-requires-python = ">=3.9"
+# 3.10 is the floor because 3.9 reached end-of-life in October 2025, and
+# because the MCP SDK requires it -- keeping the baseline there lets [mcp] be
+# part of [all] instead of a carve-out needing its own interpreter.
+requires-python = ">=3.10"
 # PEP 639: an SPDX expression, not a TOML table. The old `{ text = ... }` form
 # and the matching "License :: OSI Approved ::" classifier are both deprecated
 # and warn at build time, so neither appears here.
@@ -64,7 +67,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -116,18 +118,18 @@ net = ["scapy", "pyserial"]
 symbols = ["cle"]
 
 # MCP server (`halucinator-mcp`). Upper-bounded below 2.0: the FastMCP API the
-# server uses is 1.x. Verified against mcp 1.27. Needs Python >=3.10 (the SDK's
-# floor), which is why it is not part of `all`.
+# server uses is 1.x. Verified against mcp 1.27. The SDK's Python floor is
+# 3.10, which is now the package baseline too, so this is a plain extra.
 mcp = ["mcp[cli]>=1.2,<2", "capstone>=4.0"]
 
-# Everything runnable on the >=3.9 baseline, in one shot. Excludes [mcp]
-# (Python >=3.10) and [dev].
+# Everything runnable, in one shot. Excludes only [dev].
 all = [
     "unicorn>=2.0",
     "capstone>=4.0",
     "scapy",
     "pyserial",
     "cle",
+    "mcp[cli]>=1.2,<2",
 ]
 
 # Lint + test tooling. pycparser is used only by halucinator/tools/, never by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "halucinator"
 description = "Firmware emulation and rehosting framework"
-readme = "README.md"
+# PyPI gets its own front page. README.md is the contributor-facing document --
+# Docker builds, submodule clones, building QEMU -- none of which applies to
+# someone who just ran `pip install halucinator`. README-PyPI.md is written for
+# that audience and is what renders on the project page; README.md stays the
+# GitHub landing page and is unaffected.
+readme = "README-PyPI.md"
 requires-python = ">=3.9"
 # PEP 639: an SPDX expression, not a TOML table. The old `{ text = ... }` form
 # and the matching "License :: OSI Approved ::" classifier are both deprecated
@@ -36,8 +41,8 @@ keywords = [
 # with no role qualifiers -- so `authors` lists the principal authors and the
 # contributing organizations, ordered with the original author first, and
 # `maintainers` is who carries the project now. The narrative credit (who
-# created it, who wrote which era of the code) is in README.md, which is the
-# long_description and therefore what actually renders on the project page.
+# created it, who wrote which era of the code) is in README-PyPI.md, which is
+# the long_description and therefore what actually renders on the project page.
 # The complete contributor list is the git history. Emails are deliberately
 # omitted from published metadata.
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@
 # stays under src/ via the package-dir mapping below.
 
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+# >=77 for PEP 639 (`license` as an SPDX expression + `license-files`).
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -15,7 +16,22 @@ name = "halucinator"
 description = "Firmware emulation and rehosting framework"
 readme = "README.md"
 requires-python = ">=3.9"
-license = { text = "GPL-3.0-or-later" }
+# PEP 639: an SPDX expression, not a TOML table. The old `{ text = ... }` form
+# and the matching "License :: OSI Approved ::" classifier are both deprecated
+# and warn at build time, so neither appears here.
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
+keywords = [
+    "firmware",
+    "emulation",
+    "rehosting",
+    "embedded",
+    "fuzzing",
+    "reverse-engineering",
+    "hal",
+    "qemu",
+    "unicorn",
+]
 # Core metadata has no "original author" field -- only Author and Maintainer,
 # with no role qualifiers -- so `authors` lists the principal authors and the
 # contributing organizations, ordered with the original author first, and
@@ -41,7 +57,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -77,6 +92,8 @@ dependencies = [
 Homepage = "https://github.com/halucinator/halucinator"
 Repository = "https://github.com/halucinator/halucinator"
 Changelog = "https://github.com/halucinator/halucinator/blob/master/CHANGELOG.md"
+Documentation = "https://github.com/halucinator/halucinator/tree/master/doc"
+Issues = "https://github.com/halucinator/halucinator/issues"
 
 [project.optional-dependencies]
 # The unicorn backend (`--emulator unicorn`) is the only one that needs no

--- a/src/halucinator/mcp/README.md
+++ b/src/halucinator/mcp/README.md
@@ -34,19 +34,25 @@ wire codec).
 
 ## Install
 
-The MCP layer needs **Python 3.10+** (the MCP SDK's floor); the rest of
-HALucinator runs on 3.9. Use a dedicated virtualenv:
+The MCP SDK's Python floor is 3.10, which is HALucinator's baseline too, so no
+separate interpreter or virtualenv is needed -- the extra installs alongside
+everything else:
 
 ```sh
-python3.10 -m venv .venv-mcp
-.venv-mcp/bin/pip install -e '.[mcp]'      # mcp[cli] + capstone
-# Plus HALucinator's own runtime deps (not pulled by the extra):
-.venv-mcp/bin/pip install -r src/requirements.txt
-.venv-mcp/bin/pip install -e deps/avatar2/ --no-deps
+pip install -e '.[mcp]'        # mcp[cli] + capstone
+pip install -e '.[all]'        # or everything at once; [all] includes [mcp]
+```
+
+For the avatar2/QEMU backends, also install the forked avatar2 and the pinned
+runtime deps:
+
+```sh
+pip install -r src/requirements.txt
+pip install -e deps/avatar2/ --no-deps
 ```
 
 The `requirements.txt` pin of `setuptools<81` provides the `distutils` shim
-that the forked `avatar2` imports, so 3.10–3.12 all work; 3.10 or 3.11 are the
+that the forked `avatar2` imports, so 3.10-3.12 all work; 3.10 or 3.11 are the
 safest choices.
 
 ## Run
@@ -185,13 +191,12 @@ returns `state="timeout"` if it doesn't halt in time.
 ## Tests
 
 ```sh
-.venv-mcp/bin/python -m pytest test/pytest/mcp_server/ -q     # 3.10+: all
-PYTHONPATH=src python3 -m pytest test/pytest/mcp_server/ -q   # 3.9: SDK tests skip
+python -m pytest test/pytest/mcp_server/ -q
 ```
 
 `test_session.py`, `test_codec.py`, `test_worker.py`, `test_manager.py` are
-SDK-free and run on 3.9; `test_server.py` self-skips (`importorskip`) without
-the MCP SDK.
+SDK-free; `test_server.py` self-skips (`importorskip`) when the MCP SDK is not
+installed, so the suite still passes without the `[mcp]` extra.
 
 ## Notes
 


### PR DESCRIPTION
Adds the release automation needed to publish HALucinator to PyPI, plus the packaging-metadata fixes found while verifying the built artifacts.

## Workflow

New `.github/workflows/publish.yml`:

- **PyPI** on a published GitHub Release.
- **TestPyPI** on manual `workflow_dispatch`, for dry runs.

Both use Trusted Publishing (OIDC) against dedicated `pypi` / `testpypi` environments, so no API token is stored in the repo. The upload is gated on:

- the release tag matching `halucinator.__version__`,
- `twine check` passing, and
- `logging.cfg` and `py.typed` actually being present in the sdist — a wheel missing `logging.cfg` crashes at import with `KeyError: 'formatters'`.

## Metadata fixes

- **License moved to PEP 639** — an SPDX expression plus `license-files`, replacing the `{ text = ... }` table and the redundant `License :: OSI Approved ::` classifier. Setuptools 80 emits a deprecation warning for both older forms. Built metadata now carries `License-Expression: GPL-3.0-or-later` and `License-File: LICENSE`; the effective license is unchanged. Build-system floor bumped to `setuptools>=77`, where PEP 639 landed.
- **Fixed a README link** — `doc/debugging.md` was repo-relative and would 404 on the project page, since `doc/` is not part of the distribution.
- **Added `keywords`**, plus `Documentation` and `Issues` project URLs (these render as sidebar links on the project page).

## Verification

- Builds clean with no deprecation warnings.
- `twine check` passes on both sdist and wheel.
- sdist is 518 KB / wheel 648 KB with no stray artifacts — no logs, binaries, `tmp/`, `virtualenvs/`, or `deps/` leakage.
- The wheel installs into a bare Python 3.9 venv; `halucinator`, `hal_make_addr`, and `hal_dev_uart` all run, and `halucinator-mcp` without the `[mcp]` extra fails with its intended actionable message rather than an ImportError traceback.

## Note for maintainers

Trusted Publishing requires a matching publisher registered on PyPI (Owner `halucinator`, repo `halucinator`, workflow `publish.yml`, environment `pypi`). The first release also needs someone with write access to run the TestPyPI dry run, since `workflow_dispatch` requires write permission.