### PR TITLE
unicorn/x86: port-I/O handler registry + per-IRQ vectoring

### DIFF
--- a/src/halucinator/backends/irq/delivery.py
+++ b/src/halucinator/backends/irq/delivery.py
@@ -427,18 +427,33 @@ class X86ExceptionDeliverer(ExceptionDeliverer):
     kernel stub fields in ``extra`` (``int_ent``/``int_exit``/``stub_addr``/
     ``isr_arg``). The assembled-stub cache lives on the backend
     (``_x86_stub_*``), not the deliverer, so a single deliverer instance is
-    stateless across backends. ``num`` is unused (a single clock tick)."""
+    stateless across backends.
+
+    ``num`` selects the entry point when the plan carries a per-IRQ vector
+    map in ``extra["vectors"]`` (``{irq_num: entry_addr}``) — a PC has 16
+    IRQ lines and an OS that installs one IDT stub per line (NuttX's
+    ``vector_irqN``), so a device that needs both the 8254 tick and, say, a
+    16550 receive interrupt cannot be served by a single ``isr_addr``. An
+    unmapped ``num`` falls back to ``isr_addr``, which is what a
+    single-clock target (the VxWorks RTU) configures."""
 
     arch = "x86"
 
     def deliver(self, backend: "HalBackend", num: int,
                 plan: DeliveryPlan) -> bool:
         setattr(backend, "_last_delivered_irq", int(num))
+        vectors = plan.extra.get("vectors") or {}
         isr_addr = plan.isr_addr
+        if vectors:
+            # YAML mapping keys may arrive as str ("4:") or int (4:).
+            for key, addr in vectors.items():
+                if int(str(key), 0) == int(num):
+                    isr_addr = int(addr)
+                    break
         if isr_addr is None:
-            log.warning("x86_pic: tick fired but no clock ISR known yet "
-                        "(sysClkConnect not seen, no isr_addr configured) "
-                        "— dropping")
+            log.warning("x86_pic: IRQ %s fired but no ISR known yet "
+                        "(sysClkConnect not seen, no isr_addr/vectors "
+                        "configured) — dropping", num)
             return False
         eflags = backend.read_register("eflags")
         if not (eflags & _EFLAGS_IF):
@@ -452,7 +467,12 @@ class X86ExceptionDeliverer(ExceptionDeliverer):
         cs = backend.read_register("cs")
         esp = backend.read_register("esp")
 
-        target = self._ensure_stub(backend, plan)
+        # The int_ent/int_exit stub wraps the plan's single `isr_addr`; a
+        # per-IRQ vector from the map is an IDT stub in its own right and is
+        # entered directly.
+        target = None
+        if isr_addr == plan.isr_addr:
+            target = self._ensure_stub(backend, plan)
         if target is None:
             target = isr_addr
 

--- a/src/halucinator/backends/irq/delivery.py
+++ b/src/halucinator/backends/irq/delivery.py
@@ -414,6 +414,33 @@ class ShadowExceptionDeliverer(ExceptionDeliverer):
 _EFLAGS_IF = 1 << 9   # interrupt-enable flag
 
 
+def _parse_vector_key(key) -> Optional[int]:
+    """An IRQ number from a ``vectors:`` mapping key, or None if unusable.
+
+    The keys come from user YAML, so they arrive as ints (``4:``) or as any
+    string a human might type (``"4"``, ``"0x4"``, ``" 4 "``, ``"04"``).
+    ``int(s, 0)`` alone is not enough: base 0 applies Python's *literal* rules
+    and REJECTS a leading zero, so a perfectly reasonable ``"04":`` raised
+    ValueError out of the middle of interrupt delivery and took the run down.
+    Fall back to base 10 for that case, and skip a key that is not a number at
+    all with a warning rather than letting it propagate -- one typo in a config
+    should not kill the emulation.
+    """
+    if isinstance(key, bool):          # bool is an int subclass; not a vector
+        return None
+    if isinstance(key, int):
+        return key
+    text = str(key).strip()
+    for base in (0, 10):
+        try:
+            return int(text, base)
+        except ValueError:
+            continue
+    log.warning("x86_pic: vectors: key %r is not an IRQ number — ignoring",
+                key)
+    return None
+
+
 class X86ExceptionDeliverer(ExceptionDeliverer):
     """Synthesised x86/i386 PC interrupt entry for in-process unicorn
     (replaces ``X86PicController.deliver``). Unicorn's x86 model does not
@@ -447,7 +474,10 @@ class X86ExceptionDeliverer(ExceptionDeliverer):
         if vectors:
             # YAML mapping keys may arrive as str ("4:") or int (4:).
             for key, addr in vectors.items():
-                if int(str(key), 0) == int(num):
+                parsed = _parse_vector_key(key)
+                if parsed is None:
+                    continue
+                if parsed == int(num):
                     isr_addr = int(addr)
                     break
         if isr_addr is None:

--- a/src/halucinator/backends/irq/in_process.py
+++ b/src/halucinator/backends/irq/in_process.py
@@ -137,19 +137,49 @@ class InProcessIrqMixin:
             self._apply_pending_irq_shadow(irq_num)
             return
         if arch == "x86":
-            # x86 delivery lives in X86ExceptionDeliverer; the configured
-            # X86PicController.deliver is a thin shim over it that carries the
-            # runtime-learned clock ISR. Runs on the dispatch thread here, so
-            # mutating EIP/ESP is safe.
-            ctrl = getattr(self, "_irq_controller", None)
-            if ctrl is not None and hasattr(ctrl, "deliver"):
-                ctrl.deliver(self)
-            else:
-                log.warning("inject_irq(%d): x86 has no X86PicController "
-                            "configured; tick dropped", irq_num)
+            self._apply_pending_irq_x86(irq_num)
             return
         # Cortex-M (and any un-migrated arch): backend-provided frame push.
         self._apply_cortex_m_fallback(irq_num)
+
+    # -- x86 FRAME delivery -----------------------------------------------
+    def _apply_pending_irq_x86(self, irq_num: int) -> None:
+        """Deliver an x86 IRQ by building the hardware interrupt frame and
+        vectoring at the firmware's IDT stub.
+
+        Resolves the DeliveryPlan the same way every other arch here does
+        (``machine.irq_delivery`` first, legacy ``interrupt_controller``
+        fields second), and passes ``irq_num`` through, so a plan carrying a
+        per-IRQ ``vectors`` map can land IRQ0 and IRQ4 on different stubs.
+        A clock ISR learned at run time (VxWorks ``sysClkConnect`` calls the
+        controller's ``register_clock_isr``) still wins when the plan has no
+        ``isr_addr`` of its own."""
+        from halucinator.backends.irq.delivery import (
+            DeliveryModel, DeliveryPlan, X86ExceptionDeliverer)
+
+        ctrl = getattr(self, "_irq_controller", None)
+
+        def _legacy(controller):
+            return DeliveryPlan(
+                model=DeliveryModel.FRAME,
+                isr_addr=getattr(controller, "isr_addr", None) if controller else None,
+                extra={
+                    "int_ent": getattr(controller, "int_ent", None) if controller else None,
+                    "int_exit": getattr(controller, "int_exit", None) if controller else None,
+                    "stub_addr": getattr(controller, "stub_addr", 0x7000) if controller else 0x7000,
+                    "isr_arg": getattr(controller, "isr_arg", 0) if controller else 0,
+                },
+            )
+
+        plan = self._resolve_delivery_plan(_legacy)
+        if plan is None:
+            log.warning("inject_irq(%d): x86 has no delivery plan or "
+                        "interrupt controller configured; IRQ dropped", irq_num)
+            return
+        if plan.isr_addr is None and ctrl is not None:
+            # Run-time-learned ISR (register_clock_isr).
+            plan.isr_addr = getattr(ctrl, "isr_addr", None)
+        X86ExceptionDeliverer().deliver(self, irq_num, plan)
 
     # -- shared SHADOW delivery -------------------------------------------
     def _apply_pending_irq_shadow(self, irq_num: int) -> None:

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -1140,9 +1140,52 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
                     "(unicorn binding lacks aux1/arg1); IN/OUT may fault",
                     insn_id)
 
+    def register_port_handler(self, lo: int, hi: int,
+                              reader: Optional[Callable[[int, int], Optional[int]]] = None,
+                              writer: Optional[Callable[[int, int, int], None]] = None,
+                              name: str = "") -> None:
+        """Claim the x86 I/O-port range [lo, hi] for a peripheral model.
+
+        On x86 the chipset lives in *port* space, not memory, so a model
+        registered through the `peripherals:` memory map can never see it —
+        the catch-all IN/OUT hooks below absorb the access instead. This is
+        the port-space equivalent of mapping a peripheral: a model (usually
+        from a bp_handler's `register_handler`, which is handed the backend)
+        claims a range and then serves it.
+
+          reader(port, size) -> int | None   None = "not mine, fall through"
+          writer(port, size, value) -> None
+
+        Handlers are consulted in registration order and take precedence
+        over the built-in absorb, so a real 16550 model can answer RBR/LSR/
+        IIR while unclaimed ports keep the old behaviour."""
+        if not hasattr(self, "_port_handlers"):
+            self._port_handlers: List[Tuple[int, int, Any, Any, str]] = []
+        self._port_handlers.append((int(lo), int(hi), reader, writer, name))
+        hlog.info("UnicornBackend: port handler %s claims 0x%x-0x%x",
+                  name or "<unnamed>", lo, hi)
+
+    def _port_handler_for(self, port: int):
+        """The (reader, writer) pair claiming `port`, or (None, None)."""
+        for lo, hi, reader, writer, _name in getattr(self, "_port_handlers", ()):
+            if lo <= port <= hi:
+                return reader, writer
+        return None, None
+
     def _x86_in_hook(self, uc, port, size, user_data):
         """Handle an `in` from an I/O port. Return value is written back
         into the destination register by unicorn (return it from here)."""
+        reader, _writer = self._port_handler_for(port)
+        if reader is not None:
+            try:
+                val = reader(port, size)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("x86 IN  port=0x%x: handler raised %s", port, exc)
+                val = None
+            if val is not None:
+                log.debug("x86 IN  port=0x%x size=%d -> 0x%x (modelled)",
+                          port, size, val)
+                return int(val)
         val = 0
         for base in self._X86_UART_BASES:
             if port == base + 5:  # Line Status Register
@@ -1155,6 +1198,15 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         """Handle an `out` to an I/O port. Capture printable bytes written
         to a UART transmit-holding register (base+0) as console output;
         otherwise drop the write (no-op, like the MMIO catch-all)."""
+        _reader, writer = self._port_handler_for(port)
+        if writer is not None:
+            try:
+                writer(port, size, value)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("x86 OUT port=0x%x: handler raised %s", port, exc)
+            log.debug("x86 OUT port=0x%x size=%d value=0x%x (modelled)",
+                      port, size, value)
+            return
         for base in self._X86_UART_BASES:
             if port == base:  # Transmit Holding Register
                 low = value & 0xFF

--- a/test/pytest/backends/irq/test_x86_vector_keys.py
+++ b/test/pytest/backends/irq/test_x86_vector_keys.py
@@ -1,0 +1,48 @@
+"""Parsing of the x86 ``vectors:`` mapping keys.
+
+These keys come straight from user YAML, so they arrive as ints or as any
+string a human might type. The parser runs inside interrupt delivery, where an
+uncaught exception takes the whole emulation down -- a config typo must degrade
+to "that entry is ignored", never to a traceback.
+
+The specific trap: ``int(s, 0)`` applies Python's integer-*literal* rules, which
+forbid a leading zero, so ``"04"`` raised ValueError even though it is an
+obvious way to write IRQ 4 in a table aligned with ``"14"``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from halucinator.backends.irq.delivery import _parse_vector_key
+
+
+@pytest.mark.parametrize("key,expected", [
+    (4, 4),               # YAML int key
+    ("4", 4),             # quoted decimal
+    ("0x4", 4),           # hex, the natural way to write a vector
+    ("0x1f", 31),
+    (" 4 ", 4),           # stray whitespace from a quoted key
+    ("04", 4),            # THE REGRESSION: base-0 rejects the leading zero
+    ("007", 7),
+    ("0", 0),             # IRQ 0 is the PC clock — must not be falsy-dropped
+])
+def test_usable_keys_parse(key, expected):
+    assert _parse_vector_key(key) == expected
+
+
+@pytest.mark.parametrize("key", ["clock", "", "   ", "4.5", None, "0x", True,
+                                 False])
+def test_unusable_keys_are_ignored_not_raised(key):
+    """A bad key yields None so the caller skips it. Booleans are excluded on
+    purpose: bool subclasses int, so True would otherwise read as IRQ 1."""
+    assert _parse_vector_key(key) is None
+
+
+def test_a_bad_key_does_not_hide_a_good_one():
+    """A junk entry earlier in the mapping must not stop the real vector from
+    being found -- dict order is insertion order, so this is the realistic
+    case of a commented-out or mistyped row above the one that matters."""
+    vectors = {"clock": 0xDEAD, "04": 0xB000, 4: 0xB000}
+    resolved = [addr for key, addr in vectors.items()
+                if _parse_vector_key(key) == 4]
+    assert resolved == [0xB000, 0xB000]


### PR DESCRIPTION
> **Draft** — held until the rehostry device fleet is re-tested against this branch and we've confirmed nothing the fleet needs is missing.

Adds an x86 port-I/O (`in`/`out`) handler registry and per-IRQ vectoring to the in-process IRQ path, so x86 firmware that talks to the legacy PIC/8259 and port-mapped devices can be modelled. Touches the x86 arch path only. +117/-15.