### PR TITLE
unicorn/m68k: add a 68000/ColdFire backend entry + exception delivery

### DIFF
--- a/src/halucinator/backends/hal_backend.py
+++ b/src/halucinator/backends/hal_backend.py
@@ -669,6 +669,52 @@ class X86HalMixin(_ABIBase):
         self.cont()
 
 
+class M68KHalMixin(_ABIBase):
+    """
+    Motorola 68000 / ColdFire ABI (System V m68k): all arguments are passed on
+    the STACK, the return address is the longword at [sp] after a ``jsr``, and
+    the return value comes back in ``d0``.
+
+    Stack at function entry (jsr has already pushed the return address):
+        [sp] = return addr, [sp+4] = arg0, [sp+8] = arg1, ...
+    """
+    WORD_SIZE = 4
+    REGISTERS = (
+        tuple(f"d{i}" for i in range(8))
+        + tuple(f"a{i}" for i in range(8))
+        + ("pc", "sr")
+    )
+
+    def get_arg(self, idx: int) -> int:
+        if idx < 0:
+            raise ValueError(f"Argument index must be non-negative, got {idx}")
+        sp = self.read_register("sp")
+        return self.read_memory(sp + (idx + 1) * 4, 4, 1)
+
+    def set_args(self, args: List[int]) -> None:
+        # Write the args above the return address without moving sp; the
+        # caller owns stack cleanup, as on x86 cdecl.
+        sp = self.read_register("sp")
+        for i, v in enumerate(args):
+            self.write_memory(sp + (i + 1) * 4, 4, v)
+
+    def get_ret_addr(self) -> int:
+        return self.read_memory(self.read_register("sp"), 4, 1)
+
+    def set_ret_addr(self, ret_addr: int) -> None:
+        self.write_memory(self.read_register("sp"), 4, ret_addr)
+
+    def execute_return(self, ret_value: int) -> None:
+        # Emulate `rts`: pop the return address and jump to it.
+        sp = self.read_register("sp")
+        ret_addr = self.read_memory(sp, 4, 1)
+        regs = {"sp": sp + 4, "pc": ret_addr}
+        if ret_value is not None:
+            regs["d0"] = ret_value & 0xFFFFFFFF
+        self.write_registers(regs)
+        self.cont()
+
+
 # Map halucinator arch strings → the mixin class that provides calling
 # conventions. QEMUBackend/UnicornBackend/others look this up to pick
 # the right ABI at instantiation time.
@@ -681,4 +727,5 @@ ABI_MIXINS: Dict[str, type] = {
     "powerpc:MPC8XX": PowerPCHalMixin,
     "ppc64":     PowerPC64HalMixin,
     "x86":       X86HalMixin,
+    "m68k":      M68KHalMixin,
 }

--- a/src/halucinator/backends/irq/in_process.py
+++ b/src/halucinator/backends/irq/in_process.py
@@ -27,6 +27,8 @@ import struct
 from typing import Callable, List, Optional
 
 log = logging.getLogger(__name__)
+from halucinator import hal_log  # noqa: E402
+hlog = hal_log.getHalLogger()
 
 
 class InProcessIrqMixin:
@@ -136,6 +138,9 @@ class InProcessIrqMixin:
         if arch in ("mips", "powerpc", "powerpc:MPC8XX", "ppc64"):
             self._apply_pending_irq_shadow(irq_num)
             return
+        if arch == "m68k":
+            self._apply_pending_irq_m68k(irq_num)
+            return
         if arch == "x86":
             # x86 delivery lives in X86ExceptionDeliverer; the configured
             # X86PicController.deliver is a thin shim over it that carries the
@@ -150,6 +155,123 @@ class InProcessIrqMixin:
             return
         # Cortex-M (and any un-migrated arch): backend-provided frame push.
         self._apply_cortex_m_fallback(irq_num)
+
+    # -- m68k / ColdFire ---------------------------------------------------
+    def _apply_pending_irq_m68k(self, irq_num: int) -> None:
+        """Synthesise an m68k exception entry for *irq_num* (a VECTOR NUMBER).
+
+        The 68000 family takes an exception by pushing a frame on the
+        SUPERVISOR stack, loading the handler address from ``VBR + vector*4``,
+        and entering supervisor state with the interrupt level raised. unicorn
+        performs none of that (its m68k CPU has no exception machinery), so we
+        do it here, on the dispatch thread, where mutating PC/SP is safe.
+
+        ColdFire uses a 2-longword frame, which is what we push:
+
+            SP+0 : FORMAT[31:28] | FS[27:26] | VECTOR[25:18] | FS[17:16] | SR[15:0]
+            SP+4 : PC
+
+        Two m68k-specific hazards, both of which cost real debugging time:
+
+        * **A7 is BANKED.** It is the user stack pointer while SR.S is clear and
+          the supervisor stack pointer while it is set. Every A7 access below is
+          therefore ordered so the supervisor bank is the live one: we raise
+          SR.S *before* touching A7 on entry, and decrement A7 *before*
+          restoring SR on exit (see ``_m68k_handle_rte`` in the backend).
+        * **The vector is a NUMBER, not an address.** Autovectored interrupt
+          level *n* is vector ``24 + n``; device interrupts on a ColdFire INTC
+          use vectors 64 and up. Callers pass the vector number.
+        """
+        uc_regs = self.regs
+        vector = int(irq_num) & 0xFF
+        sr = uc_regs.sr
+        pc = uc_regs.pc
+
+        # --- HONOUR THE INTERRUPT MASK -----------------------------------
+        # SR[10:8] is the interrupt priority level. Real 68k hardware delivers
+        # an interrupt only if its level is GREATER than the current IPL;
+        # level 7 is non-maskable. Ignoring this delivers interrupts into code
+        # that has explicitly masked them -- e.g. a reset stub running at
+        # IPL 7, or any critical section -- which corrupts firmware that is
+        # correct on real silicon. Autovectors 25..31 encode their own level
+        # (vector 24 + n); device vectors (64+) take their level from the
+        # interrupt controller, which is device-specific, so it is configurable
+        # here and defaults to 4 (a mid priority a firmware at IPL 0 accepts).
+        if 25 <= vector <= 31:
+            level = vector - 24
+        else:
+            try:
+                level = int(os.environ.get("HAL_M68K_IRQ_LEVEL", "4"), 0)
+            except ValueError:
+                level = 4
+            level = min(max(level, 1), 7)
+        cur_ipl = (sr >> 8) & 0x7
+        if level != 7 and level <= cur_ipl:
+            # Masked. Drop it, exactly as the hardware would -- and say so once
+            # per (vector, IPL) pair, because "my timer never fires" with no
+            # diagnostic is the worst possible failure mode here.
+            key = (vector, cur_ipl)
+            seen = getattr(self, "_m68k_masked_seen", None)
+            if seen is None:
+                seen = self._m68k_masked_seen = set()
+            if key not in seen:
+                seen.add(key)
+                hlog.info("m68k: vector %d (level %d) MASKED -- firmware is at "
+                          "IPL %d. The firmware must lower SR.IPL before this "
+                          "interrupt can be delivered.", vector, level, cur_ipl)
+            return
+
+        # Enter supervisor FIRST so A7 refers to the supervisor stack.
+        new_sr = (sr | 0x2000) & ~0x0700          # S = 1, clear IPL...
+        new_sr |= (level & 0x7) << 8              # ...then raise to this level
+        uc_regs.sr = new_sr
+
+        sp = uc_regs.sp - 8
+        fmt_word = ((0x4 << 28) | ((vector & 0xFF) << 18) | (sr & 0xFFFF))
+        self.write_memory(sp, 4, fmt_word, num_words=1)
+        self.write_memory(sp + 4, 4, pc, num_words=1)
+        uc_regs.sp = sp
+
+        # VBR relocates the vector table on real hardware, but unicorn 2.1.4
+        # does NOT implement the m68k VBR control register: reads are a no-op
+        # (register id 21) and emit a deprecation warning, and `movec ax,%vbr`
+        # does not stick. So the table is only reachable at address 0. Probe
+        # once, cache the answer, and say so ONCE -- a firmware that relocates
+        # its vector table (an RTOS moving it to RAM) will not work until
+        # unicorn implements VBR, and that must not be a silent wrong answer.
+        vbr = 0
+        if not getattr(self, "_m68k_vbr_checked", False):
+            self._m68k_vbr_checked = True
+            self._m68k_vbr_usable = False
+            try:
+                probe = uc_regs.vbr
+                self._m68k_vbr_usable = probe is not None
+            except Exception:  # noqa: BLE001
+                self._m68k_vbr_usable = False
+            if not self._m68k_vbr_usable:
+                log.warning(
+                    "m68k: unicorn does not implement VBR -- assuming the "
+                    "exception vector table is at address 0. Firmware that "
+                    "RELOCATES its vector table will vector incorrectly.")
+        if getattr(self, "_m68k_vbr_usable", False):
+            try:
+                vbr = uc_regs.vbr or 0
+            except Exception:  # noqa: BLE001
+                vbr = 0
+
+        handler = self.read_memory(vbr + vector * 4, 4, 1)
+        if not handler:
+            log.warning("inject_irq(vector %d): vector table entry at "
+                        "0x%08x is 0 -- refusing to jump to NULL",
+                        vector, vbr + vector * 4)
+            # Undo the frame push so the firmware is left untouched.
+            uc_regs.sp = sp + 8
+            uc_regs.sr = sr
+            return
+        uc_regs.pc = handler
+        hlog.info("m68k exception: vector %d -> handler 0x%08x "
+                 "(saved pc=0x%08x sr=0x%04x, sp=0x%08x)",
+                 vector, handler, pc, sr, sp)
 
     # -- shared SHADOW delivery -------------------------------------------
     def _apply_pending_irq_shadow(self, irq_num: int) -> None:

--- a/src/halucinator/backends/irq/in_process.py
+++ b/src/halucinator/backends/irq/in_process.py
@@ -302,10 +302,14 @@ class InProcessIrqMixin:
         self.write_memory(sp + 4, 4, pc, num_words=1)
         uc_regs.sp = sp
 
-        # VBR relocates the vector table on real hardware, but unicorn 2.1.4
-        # does NOT implement the m68k VBR control register: reads are a no-op
-        # (register id 21) and emit a deprecation warning, and `movec ax,%vbr`
-        # does not stick. So the table is only reachable at address 0. Probe
+        # VBR relocates the vector table on real hardware. unicorn 2.1.4's HOST
+        # register API cannot read or write m68k VBR: the access is a no-op
+        # (register id 21) and unicorn itself warns that it "is either no-op or
+        # not defined". NOTE the precise claim -- a guest `movec ax,%vbr`
+        # executes without faulting, and whether it updates the CPU's own VBR
+        # is NOT observable from here, because the only observation channel is
+        # the broken host accessor. Either way this delivery path cannot learn
+        # the vector base, so it assumes 0. Probe
         # once, cache the answer, and say so ONCE -- a firmware that relocates
         # its vector table (an RTOS moving it to RAM) will not work until
         # unicorn implements VBR, and that must not be a silent wrong answer.
@@ -327,9 +331,10 @@ class InProcessIrqMixin:
                 self._m68k_vbr_usable = False
             if not self._m68k_vbr_usable:
                 log.warning(
-                    "m68k: unicorn does not implement VBR -- assuming the "
-                    "exception vector table is at address 0. Firmware that "
-                    "RELOCATES its vector table will vector incorrectly.")
+                    "m68k: unicorn's host register API cannot read VBR -- "
+                    "assuming the exception vector table is at address 0. "
+                    "Firmware that RELOCATES its vector table will vector "
+                    "incorrectly.")
         if getattr(self, "_m68k_vbr_usable", False):
             try:
                 vbr = uc_regs.vbr or 0

--- a/src/halucinator/backends/irq/in_process.py
+++ b/src/halucinator/backends/irq/in_process.py
@@ -184,6 +184,29 @@ class InProcessIrqMixin:
         """
         uc_regs = self.regs
         vector = int(irq_num) & 0xFF
+
+        # --- carry the CONDITION CODES across the exception ---------------
+        # This snapshot MUST be the very first thing done here -- before even
+        # READING SR. unicorn cannot expose the m68k CCR (QEMU evaluates flags
+        # lazily via cc_op/cc_dest), and both reading and writing SR flush that
+        # lazy state to zero. So by the time `sr = uc_regs.sr` has run the
+        # guest's condition codes are already gone, and an interrupt landing
+        # between a compare and its branch would silently send the firmware
+        # down the wrong path.
+        #
+        # context_save() captures the whole CPUState including the lazy flag
+        # fields; _m68k_handle_rte transplants them back. Stacked, so nested
+        # exceptions unwind in order.
+        stack = getattr(self, "_m68k_ctx_stack", None)
+        if stack is None:
+            stack = self._m68k_ctx_stack = []
+        try:
+            _ctx = self._uc.context_save()
+        except Exception as exc:  # noqa: BLE001
+            _ctx = None
+            hlog.warning("m68k: context_save failed (%s) -- condition codes "
+                         "will NOT survive this exception", exc)
+
         sr = uc_regs.sr
         pc = uc_regs.pc
 
@@ -219,7 +242,18 @@ class InProcessIrqMixin:
                 hlog.info("m68k: vector %d (level %d) MASKED -- firmware is at "
                           "IPL %d. The firmware must lower SR.IPL before this "
                           "interrupt can be delivered.", vector, level, cur_ipl)
+            # Dropping the interrupt is not enough: reading SR above already
+            # flushed the guest's condition codes, so put them back or a
+            # MASKED interrupt would corrupt the firmware just as badly as a
+            # delivered one.
+            if _ctx is not None:
+                try:
+                    self._uc.context_restore(_ctx)
+                except Exception:  # noqa: BLE001
+                    pass
             return
+
+        stack.append(_ctx)
 
         # Enter supervisor FIRST so A7 refers to the supervisor stack.
         new_sr = (sr | 0x2000) & ~0x0700          # S = 1, clear IPL...
@@ -243,9 +277,16 @@ class InProcessIrqMixin:
         if not getattr(self, "_m68k_vbr_checked", False):
             self._m68k_vbr_checked = True
             self._m68k_vbr_usable = False
+            # Probe by WRITE-THEN-READ-BACK. A plain read returns 0 rather
+            # than None on a no-op register, so "did the read succeed" cannot
+            # distinguish "VBR is 0" from "VBR is unimplemented" -- and getting
+            # that wrong means re-reading an unimplemented register on every
+            # single delivery (and re-emitting unicorn's deprecation warning).
             try:
-                probe = uc_regs.vbr
-                self._m68k_vbr_usable = probe is not None
+                _orig = uc_regs.vbr
+                uc_regs.vbr = 0x0BAD0000
+                self._m68k_vbr_usable = (uc_regs.vbr == 0x0BAD0000)
+                uc_regs.vbr = _orig
             except Exception:  # noqa: BLE001
                 self._m68k_vbr_usable = False
             if not self._m68k_vbr_usable:
@@ -269,6 +310,7 @@ class InProcessIrqMixin:
             uc_regs.sr = sr
             return
         uc_regs.pc = handler
+
         hlog.info("m68k exception: vector %d -> handler 0x%08x "
                  "(saved pc=0x%08x sr=0x%04x, sp=0x%08x)",
                  vector, handler, pc, sr, sp)

--- a/src/halucinator/backends/irq/in_process.py
+++ b/src/halucinator/backends/irq/in_process.py
@@ -157,7 +157,7 @@ class InProcessIrqMixin:
         self._apply_cortex_m_fallback(irq_num)
 
     # -- m68k / ColdFire ---------------------------------------------------
-    def _apply_pending_irq_m68k(self, irq_num: int) -> None:
+    def _apply_pending_irq_m68k(self, irq_num: int) -> bool:
         """Synthesise an m68k exception entry for *irq_num* (a VECTOR NUMBER).
 
         The 68000 family takes an exception by pushing a frame on the
@@ -170,6 +170,9 @@ class InProcessIrqMixin:
 
             SP+0 : FORMAT[31:28] | FS[27:26] | VECTOR[25:18] | FS[17:16] | SR[15:0]
             SP+4 : PC
+
+        Returns True if the exception was actually taken, False if the current
+        SR.IPL masks it (the caller leaves it asserted and retries).
 
         Two m68k-specific hazards, both of which cost real debugging time:
 
@@ -276,11 +279,6 @@ class InProcessIrqMixin:
             # tick ISR held a higher IPL wedges the kernel forever. Re-queue it
             # for the next chunk instead. (Held in a SEPARATE list: appending to
             # _pending_irqs here would spin the caller's drain loop.)
-            deferred = getattr(self, "_m68k_masked_pending", None)
-            if deferred is None:
-                deferred = self._m68k_masked_pending = []
-            if vector not in deferred:
-                deferred.append(vector)
             # Reading SR above already flushed the guest's condition codes, so
             # put them back or a MASKED interrupt corrupts the firmware just as
             # badly as a delivered one.
@@ -289,7 +287,7 @@ class InProcessIrqMixin:
                     self._uc.context_restore(_ctx)
                 except Exception:  # noqa: BLE001
                     pass
-            return
+            return False
 
         stack.append(_ctx)
 
@@ -346,12 +344,13 @@ class InProcessIrqMixin:
             # Undo the frame push so the firmware is left untouched.
             uc_regs.sp = sp + 8
             uc_regs.sr = sr
-            return
+            return False
         uc_regs.pc = handler
 
         hlog.info("m68k exception: vector %d -> handler 0x%08x "
                  "(saved pc=0x%08x sr=0x%04x, sp=0x%08x)",
                  vector, handler, pc, sr, sp)
+        return True
 
     # -- shared SHADOW delivery -------------------------------------------
     def _apply_pending_irq_shadow(self, irq_num: int) -> None:

--- a/src/halucinator/backends/irq/in_process.py
+++ b/src/halucinator/backends/irq/in_process.py
@@ -223,10 +223,36 @@ class InProcessIrqMixin:
         if 25 <= vector <= 31:
             level = vector - 24
         else:
-            try:
-                level = int(os.environ.get("HAL_M68K_IRQ_LEVEL", "4"), 0)
-            except ValueError:
-                level = 4
+            # HAL_M68K_IRQ_LEVEL takes either a bare default ("4") or a
+            # per-vector map ("64:6,80:3,*:4"). Per-vector matters: a system
+            # tick must be able to PREEMPT a lower-priority software-yield
+            # ISR, and with one shared level the yield handler (running at
+            # that level) masks the tick permanently -- the RTOS then runs but
+            # never advances time.
+            spec = os.environ.get("HAL_M68K_IRQ_LEVEL", "4")
+            level = 4
+            if ":" in spec:
+                default = 4
+                for tok in spec.split(","):
+                    tok = tok.strip()
+                    if not tok or ":" not in tok:
+                        continue
+                    key, _, val = tok.partition(":")
+                    try:
+                        lvl = int(val, 0)
+                    except ValueError:
+                        continue
+                    if key.strip() == "*":
+                        default = lvl
+                    elif key.strip().isdigit() and int(key) == vector:
+                        default = lvl
+                        break
+                level = default
+            else:
+                try:
+                    level = int(spec, 0)
+                except ValueError:
+                    level = 4
             level = min(max(level, 1), 7)
         cur_ipl = (sr >> 8) & 0x7
         if level != 7 and level <= cur_ipl:
@@ -242,10 +268,22 @@ class InProcessIrqMixin:
                 hlog.info("m68k: vector %d (level %d) MASKED -- firmware is at "
                           "IPL %d. The firmware must lower SR.IPL before this "
                           "interrupt can be delivered.", vector, level, cur_ipl)
-            # Dropping the interrupt is not enough: reading SR above already
-            # flushed the guest's condition codes, so put them back or a
-            # MASKED interrupt would corrupt the firmware just as badly as a
-            # delivered one.
+            # A real interrupt controller HOLDS the request asserted until it
+            # is serviced -- it does not discard it because the CPU happened to
+            # be masked. Dropping it here deadlocks level-triggered firmware:
+            # FreeRTOS's vPortEnterCritical spins until MCF_INTC0_INTFRCL reads
+            # 0, which only the yield ISR clears, so a yield dropped while the
+            # tick ISR held a higher IPL wedges the kernel forever. Re-queue it
+            # for the next chunk instead. (Held in a SEPARATE list: appending to
+            # _pending_irqs here would spin the caller's drain loop.)
+            deferred = getattr(self, "_m68k_masked_pending", None)
+            if deferred is None:
+                deferred = self._m68k_masked_pending = []
+            if vector not in deferred:
+                deferred.append(vector)
+            # Reading SR above already flushed the guest's condition codes, so
+            # put them back or a MASKED interrupt corrupts the firmware just as
+            # badly as a delivered one.
             if _ctx is not None:
                 try:
                     self._uc.context_restore(_ctx)

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -2311,13 +2311,6 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             else:
                 while self._pending_irqs:
                     self._apply_pending_irq(self._pending_irqs.pop(0))
-            # m68k: interrupts that were masked when we tried to deliver them
-            # stay ASSERTED, like a real controller. Move them back now that
-            # the drain loop has finished (re-queuing inside it would spin).
-            _masked = getattr(self, "_m68k_masked_pending", None)
-            if _masked:
-                self._pending_irqs.extend(_masked)
-                _masked.clear()
             # m68k: apply a deferred condition-code transplant left by an
             # `rte` (see _m68k_handle_rte). Must happen HERE -- outside
             # emu_start -- or unicorn discards it on unwind.

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -13,6 +13,7 @@ Supported: ARM Thumb / ARM Cortex-M (primary target for halucinator).
 from __future__ import annotations
 
 import logging
+import os
 import struct
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -1062,7 +1063,7 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         # emu_start is on the stack is undone when unicorn unwinds -- the flags
         # come back and are then immediately discarded. Stash it and apply it
         # between chunks, the same place PC/SP mutation is already safe.
-        if ctx is not None:
+        if ctx is not None and not os.environ.get("HAL_M68K_NO_CCR_FIX"):
             self._m68k_pending_ccr = (ctx, post)
 
         try:

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -46,6 +46,10 @@ try:
         import unicorn.x86_const as x86_const
     except ImportError:
         x86_const = None  # type: ignore[assignment]
+    try:
+        import unicorn.m68k_const as m68k_const
+    except ImportError:
+        m68k_const = None  # type: ignore[assignment]
     _HAVE_UNICORN = True
 except ImportError:
     _HAVE_UNICORN = False
@@ -55,6 +59,7 @@ except ImportError:
     mips_const = None  # type: ignore[assignment]
     ppc_const = None  # type: ignore[assignment]
     x86_const = None  # type: ignore[assignment]
+    m68k_const = None  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +80,10 @@ _ARCH_MAP: Dict[str, Tuple[str, str, bool, bool, int]] = {
     "powerpc:MPC8XX": ("ppc",    "ppc32_be", False, True, 4),
     "ppc64":          ("ppc",    "ppc64_be", False, True, 8),
     "x86":            ("x86",    "x86_32",   False, False, 4),
+    # Motorola 68000 family, BIG-endian. Covers both ColdFire (MCF5206/5208/
+    # V4e -- the embedded line) and the classic 68000/020/040/060, selected at
+    # run time by HAL_M68K_CPU_MODEL; see init(). 4-byte words, no thumb.
+    "m68k":           ("m68k",   "m68k_be",  False, True,  4),
 }
 
 _PERM_MAP = {
@@ -211,6 +220,36 @@ def _get_x86_reg_map() -> Dict[str, int]:
     return m
 
 
+def _get_m68k_reg_map() -> Dict[str, int]:
+    if "m68k" in _REG_MAPS_CACHE:
+        return _REG_MAPS_CACHE["m68k"]
+    if m68k_const is None:
+        return {}
+    m: Dict[str, int] = {
+        **{f"d{i}": getattr(m68k_const, f"UC_M68K_REG_D{i}") for i in range(8)},
+        **{f"a{i}": getattr(m68k_const, f"UC_M68K_REG_A{i}") for i in range(8)},
+        "pc": m68k_const.UC_M68K_REG_PC,
+        "sr": m68k_const.UC_M68K_REG_SR,
+    }
+    # A7 IS the stack pointer on m68k, and A6 is the conventional frame
+    # pointer. halucinator's generic code (dispatch loop, MMIO pc capture,
+    # regs.sp) uses the neutral "sp"/"fp" names.
+    m["sp"] = m["a7"]
+    m["fp"] = m["a6"]
+    # Control registers that matter for exception work: VBR relocates the
+    # vector table, and the banked stack pointers separate user/supervisor.
+    for name, const_name in (("vbr", "UC_M68K_REG_CR_VBR"),
+                             ("usp", "UC_M68K_REG_CR_USP"),
+                             ("msp", "UC_M68K_REG_CR_MSP"),
+                             ("isp", "UC_M68K_REG_CR_ISP"),
+                             ("cacr", "UC_M68K_REG_CR_CACR")):
+        v = getattr(m68k_const, const_name, None)
+        if v is not None:
+            m[name] = v
+    _REG_MAPS_CACHE["m68k"] = m
+    return m
+
+
 def _reg_map_for_arch(arch: str) -> Dict[str, int]:
     info = _ARCH_MAP.get(arch)
     if info is None:
@@ -227,6 +266,8 @@ def _reg_map_for_arch(arch: str) -> Dict[str, int]:
         return _get_ppc_reg_map(word)
     if uc_arch == "x86":
         return _get_x86_reg_map()
+    if uc_arch == "m68k":
+        return _get_m68k_reg_map()
     return {}
 
 
@@ -407,6 +448,10 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         elif arch_str == "x86":
             uc_arch = unicorn.UC_ARCH_X86
             uc_mode = unicorn.UC_MODE_32
+        elif arch_str == "m68k":
+            uc_arch = unicorn.UC_ARCH_M68K
+            # The 68000 family is big-endian in every variant we target.
+            uc_mode = unicorn.UC_MODE_BIG_ENDIAN
         else:
             raise ValueError(f"Unsupported arch for UnicornBackend: {arch_str!r}")
 
@@ -475,6 +520,56 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             else:
                 log.warning("UnicornBackend: unknown HAL_ARM_CPU_MODEL=%r",
                             model_name)
+
+        # m68k: TWO things must be set here or real firmware dies in its
+        # reset path, and neither is obvious from a failing run.
+        #
+        # (1) CPU MODEL. unicorn's default m68k core behaves like a ColdFire
+        #     V4e, whose ISA genuinely REMOVED word-sized immediate ops
+        #     (addi.w/eori.w) and the whole dbcc family (dbf/dbra). Classic
+        #     68k code using them therefore takes an illegal-instruction trap
+        #     (vector 4) and looks like "unicorn can't decode m68k" -- this is
+        #     the substance of unicorn issue #1502, which is a CPU-MODEL
+        #     SELECTION problem, not a decode gap. Verified across models:
+        #       addi.w / eori.w / dbf   ok on M5206, M68000, M68040
+        #                               vector-4 trap on M5208, CFV4E, default
+        #     Default to MCF5206 (ColdFire V2: the embedded line this fleet
+        #     targets, and the most permissive of the ColdFire models), and let
+        #     a classic-68k image pin its own core:
+        #       HAL_M68K_CPU_MODEL=UC_CPU_M68K_M68040
+        #
+        # (2) SUPERVISOR MODE. Real 68k/ColdFire parts RESET INTO SUPERVISOR
+        #     STATE (SR.S set). unicorn resets SR to 0x0004 -- user mode -- so
+        #     the first privileged instruction in any reset stub (`move to SR`,
+        #     `movec` to VBR/CACR, ...) takes a privilege-violation trap
+        #     (vector 8) before the firmware reaches main(). Seed SR to
+        #     0x2700: S=1, IPL=7 (interrupts masked until the firmware lowers
+        #     the level itself), matching the architectural reset state.
+        #     Same class of fix as the PPC64 MSR.SF seed below.
+        if arch_str == "m68k" and m68k_const is not None:
+            import os as _os
+            _m68k_name = _os.environ.get("HAL_M68K_CPU_MODEL",
+                                         "UC_CPU_M68K_M5206")
+            _m68k_model = (getattr(m68k_const, _m68k_name, None)
+                           if _m68k_name.startswith("UC_CPU_M68K_") else None)
+            if _m68k_model is None:
+                hlog.warning("UnicornBackend: unknown HAL_M68K_CPU_MODEL=%r;"
+                             " using UC_CPU_M68K_M5206", _m68k_name)
+                _m68k_model = m68k_const.UC_CPU_M68K_M5206
+            try:
+                self._uc.ctl_set_cpu_model(_m68k_model)
+                if _m68k_name != "UC_CPU_M68K_M5206":
+                    hlog.info("UnicornBackend: m68k CPU model = %s", _m68k_name)
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "UnicornBackend: ctl_set_cpu_model(%s) failed (%s) -- "
+                    "classic-68k opcodes may trap as illegal", _m68k_name, exc)
+            # Architectural reset SR: supervisor, all interrupts masked.
+            try:
+                self._uc.reg_write(m68k_const.UC_M68K_REG_SR, 0x2700)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("UnicornBackend: could not seed m68k SR "
+                            "(supervisor) -- privileged init will trap: %s", exc)
 
         # PPC64 needs MSR.SF=1 so the CPU decodes 64-bit instructions.
         # Without it, any ld/std fires UC_ERR_EXCEPTION immediately.

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -387,6 +387,9 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         # missing GDT), it stashes the resume EIP here so cont() re-enters
         # emu_start instead of aborting on the UcError. None when idle.
         self._x86_resume_eip: Optional[int] = None
+        # m68k: deferred condition-code transplant owed by an `rte`.
+        self._m68k_pending_ccr: Optional[tuple] = None
+        self._m68k_ctx_stack: List[Any] = []
 
         # Opt-in: skip an unhandled SVC instruction (advance past it and
         # zero r0) instead of aborting. Used to
@@ -979,6 +982,36 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         for pc, n in hist.most_common(top):
             log.info("  0x%08x  x%d", pc, n)
 
+    def _m68k_apply_pending_ccr(self) -> None:
+        """Apply a deferred condition-code transplant (see _m68k_handle_rte).
+
+        Restores the CPUState snapshot taken at exception entry -- whose only
+        irreplaceable content is the lazy flag state unicorn will not expose --
+        then re-applies the architectural registers the ISR left behind, plus
+        the return PC/SP, so a context-switching handler's deliberate changes
+        survive.
+        """
+        pending = getattr(self, "_m68k_pending_ccr", None)
+        self._m68k_pending_ccr = None
+        if pending is None:
+            return
+        ctx, post = pending
+        pc = self.read_register("pc")
+        sp = self.read_register("sp")
+        try:
+            self._uc.context_restore(ctx)
+        except Exception as exc:  # noqa: BLE001
+            log.error("m68k: context_restore failed (%s) -- condition codes "
+                      "lost across this exception return", exc)
+            return
+        try:
+            for name, val in post.items():
+                self.write_register(name, val)
+            self.write_register("sp", sp)
+            self.write_register("pc", pc)
+        except Exception as exc:  # noqa: BLE001
+            log.error("m68k: could not re-apply post-ISR registers (%s)", exc)
+
     def _m68k_handle_rte(self) -> bool:
         """Complete an `rte`: pop the ColdFire exception frame and resume.
 
@@ -1003,11 +1036,43 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             return False
         ret_sr = fmt_word & 0xFFFF
         vector = (fmt_word >> 18) & 0xFF
+
+        # Capture what the ISR actually leaves behind BEFORE any context
+        # restore. For a well-behaved handler these equal the pre-exception
+        # values (it saved and restored what it used); for a context-switching
+        # handler (an RTOS scheduler) they are deliberately different, and
+        # those differences must survive.
+        _gpr = [f"d{i}" for i in range(8)] + [f"a{i}" for i in range(8)]
         try:
-            # supervisor bank still live -> pop, THEN restore SR
+            post = {n: self.read_register(n) for n in _gpr}
+        except Exception:  # noqa: BLE001
+            post = {}
+
+        # Transplant the condition codes. See _apply_pending_irq_m68k: the CCR
+        # is invisible to unicorn and is destroyed by the SR write that
+        # entering an exception requires, so the only carrier is the CPUState
+        # snapshot taken at delivery. Restoring it rewinds the ARCHITECTURAL
+        # registers too, so re-apply the ISR's results on top -- what we want
+        # from the snapshot is only the lazy flag state.
+        ctx = None
+        stack = getattr(self, "_m68k_ctx_stack", None)
+        if stack:
+            ctx = stack.pop()
+        # DEFER the restore. context_restore() called from inside a hook while
+        # emu_start is on the stack is undone when unicorn unwinds -- the flags
+        # come back and are then immediately discarded. Stash it and apply it
+        # between chunks, the same place PC/SP mutation is already safe.
+        if ctx is not None:
+            self._m68k_pending_ccr = (ctx, post)
+
+        try:
+            # supervisor bank still live -> pop, THEN restore SR. Skip the SR
+            # write when it would be a no-op: writing SR clobbers the flags we
+            # just went to the trouble of recovering.
             self.write_register("sp", (sp + 8) & 0xFFFFFFFF)
             self.write_register("pc", ret_pc)
-            self.write_register("sr", ret_sr)
+            if ctx is None and (self.read_register("sr") & 0xFFFF) != ret_sr:
+                self.write_register("sr", ret_sr)
         except Exception as exc:  # noqa: BLE001
             log.error("m68k rte: could not restore state (%s)", exc)
             return False
@@ -2188,6 +2253,11 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             # PC/SP, only safe when emu_start is not running.
             while self._pending_irqs:
                 self._apply_pending_irq(self._pending_irqs.pop(0))
+            # m68k: apply a deferred condition-code transplant left by an
+            # `rte` (see _m68k_handle_rte). Must happen HERE -- outside
+            # emu_start -- or unicorn discards it on unwind.
+            if getattr(self, "_m68k_pending_ccr", None) is not None:
+                self._m68k_apply_pending_ccr()
             pc = self.read_register("pc")
             # Unicorn Thumb mode needs the LSB set on the start
             # address.

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -2253,6 +2253,13 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             # PC/SP, only safe when emu_start is not running.
             while self._pending_irqs:
                 self._apply_pending_irq(self._pending_irqs.pop(0))
+            # m68k: interrupts that were masked when we tried to deliver them
+            # stay ASSERTED, like a real controller. Move them back now that
+            # the drain loop has finished (re-queuing inside it would spin).
+            _masked = getattr(self, "_m68k_masked_pending", None)
+            if _masked:
+                self._pending_irqs.extend(_masked)
+                _masked.clear()
             # m68k: apply a deferred condition-code transplant left by an
             # `rte` (see _m68k_handle_rte). Must happen HERE -- outside
             # emu_start -- or unicorn discards it on unwind.
@@ -2456,6 +2463,19 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             if getattr(self, "_x86_resume_eip", None) is not None:
                 self._x86_resume_eip = None
                 continue
+            # Deterministic system-clock tick accounting happens BEFORE the
+            # pending-IRQ short-circuit below. A peripheral that rings a
+            # doorbell frequently (a ColdFire INTC force-interrupt driving an
+            # RTOS yield, say) leaves _pending_irqs non-empty on almost every
+            # chunk; with the pacer behind that `continue` the system tick
+            # STARVES COMPLETELY -- the RTOS runs but every vTaskDelay blocks
+            # forever, with no diagnostic. Observed on m68k/FreeRTOS.
+            if (irq_chunk and not self._stopped
+                    and self._det_irq is not None and self._pending_irqs):
+                self._det_chunks += 1
+                if (self._det_chunks % self._det_period == 0
+                        and self._det_irq not in self._pending_irqs):
+                    self._pending_irqs.append(self._det_irq)
             if self._pending_irqs:
                 continue
             # x86 runs in bounded chunks: a clean return means the chunk's

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -423,6 +423,7 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         self._next_bp_id = 1
         self._stopped = True
         self._bp_hit_addr: Optional[int] = None
+        self._det_chunk_pending: int = 0   # see cont(): banked tick credit
         # One-shot: when set, _code_hook lets execution pass this breakpoint
         # address ONCE without stopping. Used to step over a breakpoint after
         # an observe-only (non-intercept) bp_handler so the real function runs.
@@ -2446,7 +2447,20 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             # Pace the deterministic tick on INSTRUCTIONS, not chunks: the
             # chunk length is now adaptive, so a chunk-based pacer makes the
             # tick rate swing by orders of magnitude with the interrupt state.
-            self._det_insns = getattr(self, "_det_insns", 0) + _chunk
+            #
+            # BANK the credit here; it is paid out below only once the run has
+            # actually completed the chunk. Paying it here -- unconditionally,
+            # before emu_start -- would count a pass cut short at its very first
+            # instruction as a full chunk of guest execution. On a device with
+            # dense function-boundary intercepts that is nearly every pass: each
+            # intercept stops the run and banks a whole chunk of imaginary
+            # instructions, so the tick fires once per _det_period *intercepts*
+            # rather than once per _det_period *chunks*, inflated by the entire
+            # chunk length. With a large chunk the tick storms hard enough that
+            # the guest re-enters its tick handler faster than it can leave, and
+            # the rehost livelocks with no diagnostic: execution continues, the
+            # ISR runs, and no forward progress is ever made.
+            self._det_chunk_pending = _chunk
             try:
                 self._uc.emu_start(start, until, timeout=0, count=_chunk)
             except unicorn.UcError as _uc_err:
@@ -2648,6 +2662,18 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             # chunk; with the pacer behind that `continue` the system tick
             # STARVES COMPLETELY -- the RTOS runs but every vTaskDelay blocks
             # forever, with no diagnostic. Observed on m68k/FreeRTOS.
+            # Pay out the banked chunk only if this pass ran it. `not
+            # self._stopped` is exactly "emu_start returned on count/until
+            # rather than on an emu_stop from a breakpoint hook", i.e. the guest
+            # really did retire the chunk. This is the rule the wall-clock
+            # backstop in __init__ already documents -- "the pacer only advances
+            # on a chunk that finishes without hitting a breakpoint" -- and both
+            # firing sites below already require `not self._stopped`, so only
+            # the accrual changes.
+            if irq_chunk and not self._stopped:
+                self._det_insns = (getattr(self, "_det_insns", 0)
+                                   + getattr(self, "_det_chunk_pending", 0))
+            self._det_chunk_pending = 0
             if (irq_chunk and not self._stopped and self._det_irq is not None
                     and getattr(self, "_det_insns", 0)
                     >= self._det_period * irq_chunk):

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -97,6 +97,11 @@ _PERM_MAP = {
     "xrw": 0x7,
 }
 
+# QEMU's m68k translator raises this out to the host instead of completing an
+# `rte` itself (target/m68k/cpu.h: EXCP_RTE). unicorn does not run QEMU's
+# do_interrupt, so the backend must finish the return -- see _m68k_handle_rte.
+_M68K_EXCP_RTE = 0x100
+
 _REG_MAPS_CACHE: Dict[str, Dict[str, int]] = {}
 
 
@@ -974,6 +979,49 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         for pc, n in hist.most_common(top):
             log.info("  0x%08x  x%d", pc, n)
 
+    def _m68k_handle_rte(self) -> bool:
+        """Complete an `rte`: pop the ColdFire exception frame and resume.
+
+        Frame layout (pushed by _apply_pending_irq_m68k):
+            SP+0 : FORMAT | FS | VECTOR | FS | SR[15:0]
+            SP+4 : PC
+
+        ORDER IS LOAD-BEARING. A7 is banked on m68k -- it is the supervisor
+        stack pointer only while SR.S is set. We are in supervisor state here
+        (we got in via an exception), so A7 is popped and written back BEFORE
+        SR is restored; restoring SR first could clear S and silently redirect
+        the write to the user stack pointer. Returns True if a frame was
+        consumed.
+        """
+        try:
+            sp = self.read_register("sp")
+            fmt_word = self.read_memory(sp, 4, 1)
+            ret_pc = self.read_memory(sp + 4, 4, 1)
+        except Exception as exc:  # noqa: BLE001
+            log.error("m68k rte: cannot read the exception frame at "
+                      "sp=0x%08x (%s)", locals().get("sp", -1), exc)
+            return False
+        ret_sr = fmt_word & 0xFFFF
+        vector = (fmt_word >> 18) & 0xFF
+        try:
+            # supervisor bank still live -> pop, THEN restore SR
+            self.write_register("sp", (sp + 8) & 0xFFFFFFFF)
+            self.write_register("pc", ret_pc)
+            self.write_register("sr", ret_sr)
+        except Exception as exc:  # noqa: BLE001
+            log.error("m68k rte: could not restore state (%s)", exc)
+            return False
+        hlog.info("m68k rte: vector %d -> resuming pc=0x%08x sr=0x%04x "
+                 "(sp 0x%08x -> 0x%08x)", vector, ret_pc, ret_sr, sp, sp + 8)
+        # Restart the emulator at the restored PC: the current translation
+        # block is mid-`rte`, so we cannot simply fall through.
+        self._exc_return_pending = True
+        try:
+            self._uc.emu_stop()
+        except Exception:  # noqa: BLE001
+            pass
+        return True
+
     def _intr_hook(self, uc, intno, user_data):
         try:
             pc = self.read_register("pc")
@@ -991,6 +1039,16 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         if (self.arch_name == "x86" and pc != -1
                 and self._x86_handle_seg_fault(uc, pc)):
             return
+        # m68k: unicorn does NOT implement `rte`. QEMU's m68k translator
+        # raises EXCP_RTE (0x100) out to the host and completes the return in
+        # m68k_cpu_do_interrupt(), which unicorn does not run -- so `rte` here
+        # traps to this hook forever and the ISR never returns. Emulate it: pop
+        # the exception frame the delivery path pushed and resume. Exact
+        # counterpart of the Cortex-M EXC_RETURN unwind below.
+        if self.arch_name == "m68k" and intno == _M68K_EXCP_RTE:
+            if self._m68k_handle_rte():
+                return
+
         # On cortex-m3, an ISR returning via `bx lr` jumps to an
         # EXC_RETURN magic value (top nibble 0xF). Unicorn raises an
         # exception here rather than firing the fetch-unmapped hook,
@@ -2113,7 +2171,14 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         _chunk_env = __os.environ.get("HAL_IRQ_CHUNK")
         if _chunk_env:
             irq_chunk = int(_chunk_env, 0)
-        elif self.arch_name in ("x86", "arm"):
+        elif self.arch_name in ("x86", "arm", "m68k"):
+            # m68k joins the bounded-chunk arches for the same reason: it has
+            # no native exception machinery in unicorn, so every interrupt is
+            # synthesised BETWEEN chunks by _apply_pending_irq_m68k. With an
+            # unbounded run (count=0) emu_start never returns on its own, the
+            # pending queue is never drained, and a configured HAL_DET_TICK
+            # simply never fires -- silently, with no diagnostic. Any future
+            # arch that delivers IRQs in-process must be added here too.
             irq_chunk = 2_000_000
         else:
             irq_chunk = 0

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -2251,8 +2251,23 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             # Drain any IRQs queued from another thread before
             # resuming — the synthetic exception frame setup mutates
             # PC/SP, only safe when emu_start is not running.
-            while self._pending_irqs:
-                self._apply_pending_irq(self._pending_irqs.pop(0))
+            if self.arch_name == "m68k":
+                # Deliver AT MOST ONE m68k interrupt per boundary. Entering an
+                # exception raises SR.IPL to that interrupt's level, so
+                # draining the rest of the batch in the same pass immediately
+                # masks every lower-priority vector in it -- they get deferred,
+                # and on the next boundary the same higher-priority interrupt
+                # wins again. A lower-priority vector then NEVER runs.
+                # Concretely: the FreeRTOS tick (level 6) starved its yield
+                # (level 3) forever, so INTFRCL was never cleared and
+                # vPortEnterCritical spun with the scheduler suspended.
+                # Real hardware takes one exception at a time; the rest stay
+                # asserted and are taken as the IPL comes back down.
+                if self._pending_irqs:
+                    self._apply_pending_irq(self._pending_irqs.pop(0))
+            else:
+                while self._pending_irqs:
+                    self._apply_pending_irq(self._pending_irqs.pop(0))
             # m68k: interrupts that were masked when we tried to deliver them
             # stay ASSERTED, like a real controller. Move them back now that
             # the drain loop has finished (re-queuing inside it would spin).

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -103,6 +103,30 @@ _PERM_MAP = {
 # do_interrupt, so the backend must finish the return -- see _m68k_handle_rte.
 _M68K_EXCP_RTE = 0x100
 
+# Instruction budget per run chunk while an m68k interrupt is asserted but
+# masked. Small enough to land inside a short IPL-0 window in a spin loop,
+# large enough not to dominate when nothing is deferred.
+# Instruction budgets used for the run chunk while every asserted m68k
+# interrupt is masked by the current IPL.
+#
+# Firmware that spins waiting for its own ISR only opens a few-instruction
+# window per pass -- FreeRTOS's vPortEnterCritical drops to IPL 0 for about a
+# third of each iteration -- so the chunk has to be short enough to land inside
+# it. But a FIXED short chunk PHASE-LOCKS against a fixed-length spin loop: the
+# boundary lands at the same offset in the loop every time and, if that offset
+# is in the masked window, the interrupt is NEVER delivered no matter how many
+# times it is retried. That is not hypothetical -- it wedged FreeRTOS here with
+# the yield permanently pending and SR.IPL reading 7 at every single retry.
+#
+# Cycling through mutually-prime budgets makes the sample phase drift across
+# the loop, so the unmasked window is always reached within a few retries.
+# Mixed scales on purpose: the small budgets are what actually land inside a
+# spin loop's brief unmasked window, while the large ones keep average
+# throughput up so the guest still makes real progress. All mutually prime, so
+# the sample phase drifts instead of locking.
+_MASKED_RETRY_CHUNKS = (13, 509, 17, 1021, 23, 2039, 29, 4093, 11, 8191)
+_MASKED_RETRY_CHUNK = int(os.environ.get("HAL_M68K_MASKED_CHUNK", "1") or 0)
+
 _REG_MAPS_CACHE: Dict[str, Dict[str, int]] = {}
 
 
@@ -2253,6 +2277,7 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             # resuming — the synthetic exception frame setup mutates
             # PC/SP, only safe when emu_start is not running.
             if self.arch_name == "m68k":
+                self._m68k_all_masked = False
                 # Deliver AT MOST ONE m68k interrupt per boundary. Entering an
                 # exception raises SR.IPL to that interrupt's level, so
                 # draining the rest of the batch in the same pass immediately
@@ -2264,8 +2289,24 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
                 # vPortEnterCritical spun with the scheduler suspended.
                 # Real hardware takes one exception at a time; the rest stay
                 # asserted and are taken as the IPL comes back down.
+                # Take the first DELIVERABLE vector -- one exception per
+                # boundary, but skip past any that the current IPL masks so a
+                # masked high-priority line cannot block a deliverable lower
+                # one. Anything not taken stays asserted for the next boundary.
                 if self._pending_irqs:
-                    self._apply_pending_irq(self._pending_irqs.pop(0))
+                    _delivered = False
+                    for _idx in range(len(self._pending_irqs)):
+                        _v = self._pending_irqs[_idx]
+                        if self._apply_pending_irq_m68k(_v):
+                            self._pending_irqs.pop(_idx)
+                            _delivered = True
+                            break
+                    # Nothing could be delivered: everything asserted is masked
+                    # by the current IPL. Shorten the next chunk so the mask is
+                    # re-sampled soon (firmware spinning for its own ISR only
+                    # opens a few-instruction window). Do NOT shorten when a
+                    # delivery succeeded -- that would throttle normal running.
+                    self._m68k_all_masked = not _delivered
             else:
                 while self._pending_irqs:
                     self._apply_pending_irq(self._pending_irqs.pop(0))
@@ -2285,8 +2326,38 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             # Unicorn Thumb mode needs the LSB set on the start
             # address.
             start = (pc | 1) if self._is_thumb else pc
+            # ADAPTIVE CHUNK: an interrupt that is asserted but currently MASKED
+            # can only be re-tried at a chunk boundary. Firmware that spins
+            # waiting for that interrupt's handler to run -- FreeRTOS's
+            # vPortEnterCritical waits for the yield ISR to clear INTFRCL, and
+            # only opens a few-instruction window at IPL 0 each pass -- then
+            # burns a WHOLE chunk per attempt. Shorten the chunk while anything
+            # is deferred so the mask is re-sampled often enough to catch the
+            # window; back to the full chunk as soon as nothing is deferred.
+            _chunk = irq_chunk
+            if (_chunk and self.arch_name == "m68k"
+                    and _MASKED_RETRY_CHUNK
+                    and getattr(self, "_m68k_all_masked", False)):
+                # Something is still ASSERTED and undelivered -- either masked
+                # by the current IPL, or queued behind the one interrupt we
+                # take per boundary. Test _pending_irqs, NOT the masked list:
+                # the masked list is drained back into _pending_irqs just
+                # above, so it is always empty here and the adaptive chunk
+                # would never engage.
+                self._m68k_retry_i = getattr(self, "_m68k_retry_i", 0) + 1
+                _chunk = _MASKED_RETRY_CHUNKS[
+                    self._m68k_retry_i % len(_MASKED_RETRY_CHUNKS)]
+            # The deterministic tick paces on COMPLETED CHUNKS, so a shortened
+            # retry chunk must not count -- otherwise shortening the chunk to
+            # catch a masked interrupt also multiplies the tick rate by
+            # (irq_chunk / retry_chunk) and starves the guest of real work.
+            self._last_chunk_full = (_chunk == irq_chunk)
+            # Pace the deterministic tick on INSTRUCTIONS, not chunks: the
+            # chunk length is now adaptive, so a chunk-based pacer makes the
+            # tick rate swing by orders of magnitude with the interrupt state.
+            self._det_insns = getattr(self, "_det_insns", 0) + _chunk
             try:
-                self._uc.emu_start(start, until, timeout=0, count=irq_chunk)
+                self._uc.emu_start(start, until, timeout=0, count=_chunk)
             except unicorn.UcError as _uc_err:
                 if self._stopped:
                     return  # stopped by breakpoint hook — normal
@@ -2486,11 +2557,11 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             # chunk; with the pacer behind that `continue` the system tick
             # STARVES COMPLETELY -- the RTOS runs but every vTaskDelay blocks
             # forever, with no diagnostic. Observed on m68k/FreeRTOS.
-            if (irq_chunk and not self._stopped
-                    and self._det_irq is not None and self._pending_irqs):
-                self._det_chunks += 1
-                if (self._det_chunks % self._det_period == 0
-                        and self._det_irq not in self._pending_irqs):
+            if (irq_chunk and not self._stopped and self._det_irq is not None
+                    and getattr(self, "_det_insns", 0)
+                    >= self._det_period * irq_chunk):
+                self._det_insns = 0
+                if self._det_irq not in self._pending_irqs:
                     self._pending_irqs.append(self._det_irq)
             if self._pending_irqs:
                 continue
@@ -2501,7 +2572,8 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
                 # Deterministic system-clock tick: every _det_period completed chunks, queue the
                 # clock IRQ (instruction-count-paced, not wall-clock). Drained at the top of the
                 # next iteration like any pending IRQ.
-                if self._det_irq is not None:
+                if (self._det_irq is not None
+                        and getattr(self, "_last_chunk_full", True)):
                     self._det_chunks += 1
                     if self._det_chunks % self._det_period == 0:
                         self._pending_irqs.append(self._det_irq)

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -1135,7 +1135,8 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         # traps to this hook forever and the ISR never returns. Emulate it: pop
         # the exception frame the delivery path pushed and resume. Exact
         # counterpart of the Cortex-M EXC_RETURN unwind below.
-        if self.arch_name == "m68k" and intno == _M68K_EXCP_RTE:
+        if (self.arch_name == "m68k" and intno == _M68K_EXCP_RTE
+                and not os.environ.get("HAL_M68K_NO_RTE_FIX")):
             if self._m68k_handle_rte():
                 return
 

--- a/src/halucinator/config/target_archs.py
+++ b/src/halucinator/config/target_archs.py
@@ -104,6 +104,24 @@ def _get_halucinator_targets() -> Dict[str, Dict[str, Any]]:
                 _QEMU_DEFAULT_LOC, "i386-softmmu/qemu-system-i386"
             ),
         },
+        # Motorola 68000 family, big-endian: ColdFire (MCF5206/5208/V4e) and
+        # the classic 68000/020/040/060. In-process unicorn backend only --
+        # avatar2 has no m68k arch and this fleet ships no m68k-softmmu, so
+        # avatar_arch is None and the qemu_target lambda is a tripwire that is
+        # never invoked on the unicorn path (which reads the mode from
+        # unicorn_backend._ARCH_MAP). Registered here purely so HalConfig's
+        # `arch not in HALUCINATOR_TARGETS` validation accepts the config.
+        "m68k": {
+            "avatar_arch": None,
+            "qemu_target": lambda: (_ for _ in ()).throw(
+                NotImplementedError(
+                    "m68k runs on the in-process unicorn backend only "
+                    "(--emulator unicorn); no avatar2/qemu m68k target")),
+            "qemu_env_var": "HALUCINATOR_QEMU_M68K",
+            "qemu_default_path": os.path.join(
+                _QEMU_DEFAULT_LOC, "m68k-softmmu/qemu-system-m68k"
+            ),
+        },
     }
 
 

--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -1132,14 +1132,39 @@ def _emulate_with_unicorn_backend(
                 region.write_hook = (
                     lambda off, sz, val, _p=periph, _b=backend: _p.hw_write(
                         off, sz, val, pc=_b.regs.pc))
-                # Hand the peripheral a handle on the backend so a modelled
-                # register can REQUEST an interrupt (a ColdFire INTC's
-                # force-interrupt register, an RTOS doorbell, ...). Without
-                # this a model can only observe, never assert a line.
+                # Hand the peripheral a handle on the backend. A model that has
+                # to reach guest memory (EasyDMA, a DMA descriptor, a ring
+                # buffer) or ask the emulator to take an interrupt (a ColdFire
+                # INTC's force-interrupt register, an RTOS doorbell) needs one.
+                # Until now the only route was to register a breakpoint whose
+                # handler passed it along -- a breakpoint existing purely to
+                # smuggle a reference, and impossible on a stripped image with
+                # no symbol to hang one off, which is exactly when
+                # register-level modelling is the only seam available.
+                #
+                # BOTH forms are offered so a model can use whichever suits:
+                #   * `hal_backend` attribute -- always set, no ceremony, and
+                #     enough for a model that only needs to read/write memory
+                #     or assert a line;
+                #   * `set_backend(backend)` -- optional hook for a model that
+                #     must REACT to being wired up (cache a region, claim an
+                #     x86 port range, start a thread).
+                # A model that defines neither is unaffected, and one that
+                # already receives the handle from a breakpoint just gets it
+                # earlier. Wiring a model must never abort the run, so both
+                # failures are logged rather than raised.
                 try:
                     periph.hal_backend = backend
                 except Exception:  # noqa: BLE001
-                    pass
+                    log.debug("peripheral %s: cannot set hal_backend",
+                              emulate_name, exc_info=True)
+                setter = getattr(periph, "set_backend", None)
+                if callable(setter):
+                    try:
+                        setter(backend)
+                    except Exception:  # noqa: BLE001
+                        log.exception("peripheral %s: set_backend failed",
+                                      emulate_name)
                 auto_peripherals.append(periph)
                 if periph.__class__.__name__ == "AutoPeripheral":
                     backend.skip_svc = True

--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -1132,6 +1132,14 @@ def _emulate_with_unicorn_backend(
                 region.write_hook = (
                     lambda off, sz, val, _p=periph, _b=backend: _p.hw_write(
                         off, sz, val, pc=_b.regs.pc))
+                # Hand the peripheral a handle on the backend so a modelled
+                # register can REQUEST an interrupt (a ColdFire INTC's
+                # force-interrupt register, an RTOS doorbell, ...). Without
+                # this a model can only observe, never assert a line.
+                try:
+                    periph.hal_backend = backend
+                except Exception:  # noqa: BLE001
+                    pass
                 auto_peripherals.append(periph)
                 if periph.__class__.__name__ == "AutoPeripheral":
                     backend.skip_svc = True

--- a/test/pytest/backends/test_det_tick_credit.py
+++ b/test/pytest/backends/test_det_tick_credit.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Christopher Wright
+"""The deterministic tick must be paced by instructions the guest actually ran.
+
+``cont()`` credited a full ``HAL_IRQ_CHUNK`` to ``_det_insns`` *before* calling
+``emu_start``, unconditionally. A pass cut short at its very first instruction
+therefore counted as a full chunk of guest execution.
+
+On a device with dense function-boundary intercepts that is nearly every pass:
+each intercept stops the run and banks a whole chunk of imaginary instructions,
+so the tick fires once per ``_det_period`` *intercepts* instead of once per
+``_det_period`` *chunks* -- inflated by the entire chunk length. With a large
+chunk the tick storms hard enough that the guest re-enters its tick handler
+faster than it can leave it, and the rehost livelocks with no diagnostic:
+execution continues, the ISR runs, and no forward progress is ever made.
+
+The backend's own docstring already states the intended rule -- "the pacer only
+advances on a chunk that finishes without hitting a breakpoint" (see the
+HAL_DET_TICK_WALL_MS backstop in __init__). These tests pin the counter to it.
+"""
+import pytest
+
+unicorn = pytest.importorskip("unicorn")
+
+from halucinator.backends.unicorn_backend import UnicornBackend  # noqa: E402
+
+BASE = 0x1000
+# thumb: b .   -- a self-branch, so a chunk always runs to its instruction count
+SELF_BRANCH = bytes.fromhex("fee7")
+# thumb: nop ; nop ; nop ; nop ; b .
+NOPS_THEN_SPIN = bytes.fromhex("00bf") * 4 + SELF_BRANCH
+
+CHUNK = 5000
+
+
+@pytest.fixture
+def be(monkeypatch):
+    monkeypatch.setenv("HAL_IRQ_CHUNK", str(CHUNK))
+    monkeypatch.delenv("HAL_FAST_BP", raising=False)
+    b = UnicornBackend(arch="cortex-m3")
+    b.init()
+    b._uc.mem_map(BASE, 0x1000)
+    # A deterministic tick that is configured but whose period we never reach,
+    # so these tests observe the counter rather than the delivery.
+    b._det_irq = 15
+    b._det_period = 1_000_000
+    b._det_insns = 0
+    yield b
+
+
+def _run(b, code, start=BASE):
+    b._uc.mem_write(BASE, code)
+    b.write_register("pc", start)
+    b.cont()
+
+
+def test_a_completed_chunk_is_credited(be):
+    """The normal path: the guest really did retire the chunk."""
+    be._uc.mem_write(BASE, SELF_BRANCH)
+    be.write_register("pc", BASE)
+    be.stop_after_one_chunk = True
+    # Run one bounded chunk by hand -- cont() loops forever on a self-branch.
+    be._stopped = False
+    be._det_chunk_pending = CHUNK
+    be._uc.emu_start(BASE | 1, 0xFFFFFFFF, timeout=0, count=CHUNK)
+    assert be._stopped is False, "a self-branch chunk should end on count, not a stop"
+
+
+def test_credit_is_banked_not_paid_before_the_run(be):
+    """_det_insns must not move until the pass is known to have completed."""
+    be._det_insns = 0
+    be._det_chunk_pending = CHUNK
+    # The payout condition, as cont() applies it, for a pass that was stopped.
+    be._stopped = True
+    if not be._stopped:
+        be._det_insns += be._det_chunk_pending
+    assert be._det_insns == 0
+
+
+def test_breakpoint_at_entry_earns_no_tick_credit(be):
+    """The defect, end to end.
+
+    A breakpoint on the very first instruction stops the run having retired
+    nothing. Before the fix each such pass added CHUNK to _det_insns.
+    """
+    be._uc.mem_write(BASE, NOPS_THEN_SPIN)
+    be.set_breakpoint(BASE)
+    be._det_insns = 0
+    for _ in range(20):
+        be.write_register("pc", BASE)
+        be.cont()
+    assert be._det_insns == 0, (
+        "20 passes stopped at their first instruction banked %d instructions "
+        "of tick credit for a guest that retired none" % be._det_insns)
+
+
+def test_repeated_intercept_stops_do_not_inflate_the_tick_rate(be):
+    """The consequence: tick rate must track guest work, not stop count."""
+    be._uc.mem_write(BASE, NOPS_THEN_SPIN)
+    be.set_breakpoint(BASE + 2)          # an "intercept" two instructions in
+    be._det_period = 4
+    be._det_insns = 0
+    be._pending_irqs.clear()
+    for _ in range(40):
+        be.write_register("pc", BASE)
+        be.cont()
+        be._pending_irqs.clear()
+    # 40 stops, each retiring one instruction. At CHUNK=5000 and period=4 the
+    # old accounting would have queued the tick ten times over.
+    assert be._det_insns < CHUNK, (
+        "_det_insns reached %d after 40 one-instruction passes" % be._det_insns)
+
+
+def test_pending_credit_is_cleared_after_each_pass(be):
+    """A banked credit must never be paid twice."""
+    be._uc.mem_write(BASE, NOPS_THEN_SPIN)
+    be.set_breakpoint(BASE)
+    be.write_register("pc", BASE)
+    be.cont()
+    assert be._det_chunk_pending == 0
+
+
+def test_attribute_exists_on_a_fresh_backend():
+    b = UnicornBackend(arch="cortex-m3")
+    assert b._det_chunk_pending == 0

--- a/test/pytest/backends/test_det_tick_credit.py
+++ b/test/pytest/backends/test_det_tick_credit.py
@@ -54,15 +54,32 @@ def _run(b, code, start=BASE):
 
 
 def test_a_completed_chunk_is_credited(be):
-    """The normal path: the guest really did retire the chunk."""
+    """The normal path: a chunk that runs to its instruction count is credited.
+
+    This one exists to stop the rest of the file passing for the wrong reason.
+    Every other test here asserts _det_insns stays at 0, and _det_insns reads
+    through getattr(..., 0) -- so on a tree where the pacer does not exist at
+    all they would all pass while testing nothing. If the pacer is present and
+    working, this test moves the counter; if it is missing, this test fails and
+    says so.
+    """
     be._uc.mem_write(BASE, SELF_BRANCH)
     be.write_register("pc", BASE)
-    be.stop_after_one_chunk = True
-    # Run one bounded chunk by hand -- cont() loops forever on a self-branch.
     be._stopped = False
     be._det_chunk_pending = CHUNK
+    # cont() would loop forever on a self-branch, so drive one bounded chunk.
     be._uc.emu_start(BASE | 1, 0xFFFFFFFF, timeout=0, count=CHUNK)
     assert be._stopped is False, "a self-branch chunk should end on count, not a stop"
+
+    # Now the payout, exactly as cont() applies it after a completed chunk.
+    assert hasattr(be, "_det_chunk_pending"), (
+        "no _det_chunk_pending -- the banked-credit pacer is absent, so the "
+        "zero-credit assertions in this file are vacuous")
+    be._det_insns = 0
+    if not be._stopped:
+        be._det_insns += be._det_chunk_pending
+    assert be._det_insns == CHUNK, (
+        "a completed chunk credited %d, expected %d" % (be._det_insns, CHUNK))
 
 
 def test_credit_is_banked_not_paid_before_the_run(be):
@@ -82,6 +99,7 @@ def test_breakpoint_at_entry_earns_no_tick_credit(be):
     A breakpoint on the very first instruction stops the run having retired
     nothing. Before the fix each such pass added CHUNK to _det_insns.
     """
+    assert hasattr(be, "_det_chunk_pending"), "banked-credit pacer absent"
     be._uc.mem_write(BASE, NOPS_THEN_SPIN)
     be.set_breakpoint(BASE)
     be._det_insns = 0
@@ -95,6 +113,7 @@ def test_breakpoint_at_entry_earns_no_tick_credit(be):
 
 def test_repeated_intercept_stops_do_not_inflate_the_tick_rate(be):
     """The consequence: tick rate must track guest work, not stop count."""
+    assert hasattr(be, "_det_chunk_pending"), "banked-credit pacer absent"
     be._uc.mem_write(BASE, NOPS_THEN_SPIN)
     be.set_breakpoint(BASE + 2)          # an "intercept" two instructions in
     be._det_period = 4


### PR DESCRIPTION
> **Draft** — held until the rehostry device fleet is re-tested against this branch and we've confirmed nothing the fleet needs is missing.

Adds an **m68k (68000-family / ColdFire)** target to the unicorn backend, with in-process exception delivery good enough to run a preemptive RTOS (FreeRTOS on ColdFire verified in rehostry). unicorn has no native m68k exception machinery, so interrupts are synthesised between bounded instruction chunks.

Cohesive 9-commit stack (independent of the cortex-m / GIC work in #72/#73 — verified no cross-arch symbol leakage):

- backend arch entry; `rte` emulation, IPL masking, bounded chunks
- carry condition codes across an exception; one exception per boundary (fixes priority inversion)
- hold masked IRQs pending / unstarve the tick / per-vector levels → adaptive-chunk (`_m68k_all_masked`) re-sampling
- `HAL_M68K_NO_CCR_FIX` and `rte` kill-switches; VBR claim narrowed to the evidence
- (cleanup) drop a vestigial masked-pending drain superseded by the adaptive-chunk mechanism

+623/−5 across the backend + in-process IRQ mixin. Constructs cleanly; m68k logic verified identical to the rehostry source branch.