### PR TITLE
Add Ubuntu 26.04 (Resolute Raccoon) to CI and install docs

### DIFF
--- a/.github/workflows/virtual-environment-tests.yml
+++ b/.github/workflows/virtual-environment-tests.yml
@@ -13,12 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         include:
           - os: ubuntu-22.04
             codename: jammy
           - os: ubuntu-24.04
             codename: noble
+          - os: ubuntu-26.04
+            codename: resolute
     env:
       HALUCINATOR_QEMU_ARM: "${{ github.workspace }}/deps/build-qemu/arm-softmmu/qemu-system-arm"
       HALUCINATOR_QEMU_ARM64: "${{ github.workspace }}/deps/build-qemu/aarch64-softmmu/qemu-system-aarch64"
@@ -146,8 +148,9 @@ jobs:
         pip install -r src/requirements.txt
         pip install -e .
         # MCP server extra (mcp[cli] + capstone). The CI runners are Python
-        # 3.10 (jammy) / 3.12 (noble), both >= the SDK's 3.10 floor, so the
-        # MCP tests under test/pytest/mcp_server/ run on both.
+        # 3.10 (jammy) / 3.12 (noble) / 3.13 (resolute), all >= the SDK's
+        # 3.10 floor, so the MCP tests under test/pytest/mcp_server/ run on
+        # all three.
         pip install -e '.[mcp]'
         pip install pytest-cov pytest-timeout
 
@@ -537,10 +540,11 @@ jobs:
   # unicorn-backend regression rather than a toolchain problem. It is also the
   # matrix that validates the declared `requires-python = ">=3.10"`.
   pip-install-unicorn:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-24.04, ubuntu-26.04]
         python: ['3.10', '3.11', '3.13']
 
     steps:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To clean up: `docker rm halucinator`
 
 ## Setup in Virtual Environment
 
-Tested on Ubuntu 22.04 and 24.04.
+Tested on Ubuntu 22.04, 24.04, and 26.04.
 
 ### 1. Clone the repo and submodules
 
@@ -109,7 +109,22 @@ sudo apt-get install -y \
     clang-format ethtool tcpdump
 ```
 
-> **Note:** On Ubuntu 24.04, pip refuses to install packages outside a
+**Ubuntu 26.04 (Resolute):**
+```bash
+sudo apt-get update
+echo "deb-src http://archive.ubuntu.com/ubuntu/ resolute main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+echo "deb-src http://archive.ubuntu.com/ubuntu/ resolute-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+sudo apt-get update
+sudo apt-get build-dep -y qemu
+sudo apt-get install -y \
+    build-essential ca-certificates cmake ninja-build g++ git vim wget \
+    python3 python3-pip python3-venv python3-tk \
+    gdb-multiarch gcc-arm-none-eabi binutils-arm-none-eabi \
+    libaio-dev libglib2.0-dev libpixman-1-dev pkg-config \
+    clang-format ethtool tcpdump
+```
+
+> **Note:** On Ubuntu 24.04+, pip refuses to install packages outside a
 > virtual environment (PEP 668). Always use a venv as shown below.
 > The package `python-tk` was renamed to `python3-tk` starting in 22.04.
 
@@ -523,8 +538,8 @@ Tests are categorized with pytest markers defined in `conftest.py`:
 ### CI/CD
 
 The GitHub Actions workflow (`.github/workflows/virtual-environment-tests.yml`)
-runs on every push and pull request to master. It tests on both Ubuntu 22.04
-and 24.04 in parallel, builds QEMU for all architectures (cached per OS),
+runs on every push and pull request to master. It tests on Ubuntu 22.04,
+24.04, and 26.04 in parallel, builds QEMU for all architectures (cached per OS),
 runs QEMU smoke tests, all e2e firmware tests (STM32, Zephyr, multi-arch),
 and the full pytest suite with coverage reporting.
 

--- a/doc/tutorial/0_Preqs.md
+++ b/doc/tutorial/0_Preqs.md
@@ -1,7 +1,7 @@
 # Prerequisites
 
 This tutorial assumes you have HALucinator installed on Ubuntu 22.04 (also tested
-on 20.04) in a virtual environment named `halucinator`, and that the source is
+on 24.04 and 26.04) in a virtual environment named `halucinator`, and that the source is
 located in your home directory (e.g. ~/).  See the main repo README for setup
 instructions.
 


### PR DESCRIPTION
Adds ubuntu-26.04 to the test-env matrix (editable installs, full QEMU build) and as an os dimension in pip-install-unicorn (regular wheel/sdist installs), and documents the new release alongside 22.04/24.04.