### PR TITLE
unicorn/arm32: write stack arguments in AAPCS order, not reversed

### DIFF
--- a/src/halucinator/backends/hal_backend.py
+++ b/src/halucinator/backends/hal_backend.py
@@ -445,6 +445,11 @@ class ARM32HalMixin(_ABIBase):
     """
     ARM32 / Cortex-M ABI: args in r0–r3 then stack, return addr in lr,
     return value in r0.
+
+    AAPCS reserves no home space for the register-passed arguments, so at the
+    callee's entry the fifth argument is the word AT the stack pointer, the
+    sixth is at sp+4, and so on — ascending. ``get_arg`` and ``set_args`` below
+    both index from that base.
     """
     WORD_SIZE = 4
     REGISTERS = tuple(f"r{i}" for i in range(13)) + ("sp", "lr", "pc", "cpsr")
@@ -461,10 +466,24 @@ class ARM32HalMixin(_ABIBase):
         for i, v in enumerate(args[:4]):
             self.write_register(f"r{i}", v)
         if len(args) > 4:
-            sp = self.read_register("sp")
-            for i, v in enumerate(args[4:]):
-                sp -= 4
-                self.write_memory(sp, 4, v)
+            extra = args[4:]
+            # Allocate the whole outgoing block, then fill it ASCENDING so the
+            # fifth argument lands at the FINAL sp — which is where get_arg
+            # looks for it.
+            #
+            # This used to push one word at a time (`sp -= 4` then write), which
+            # placed the fifth argument at the HIGHEST address and the last at
+            # the lowest. The pair therefore round-tripped reversed: set_args
+            # [a,b,c,d,e,f] then get_arg(4) returned f, not e. Silent, and only
+            # visible on a call with more than four arguments.
+            #
+            # The block is rounded up to 8 bytes because AAPCS requires SP to be
+            # 8-byte aligned at a public interface; the padding sits ABOVE the
+            # arguments so the fifth stays at sp+0.
+            size = ((4 * len(extra)) + 7) & ~7
+            sp = (self.read_register("sp") - size) & 0xFFFFFFFF
+            for i, v in enumerate(extra):
+                self.write_memory(sp + i * 4, 4, v)
             self.write_register("sp", sp)
 
     def get_ret_addr(self) -> int:

--- a/test/pytest/backends/test_arm32_abi.py
+++ b/test/pytest/backends/test_arm32_abi.py
@@ -1,0 +1,84 @@
+"""ARM32/AAPCS calling-convention tests for ARM32HalMixin.
+
+ARM32 is the default ABI — `_bind_abi` falls back to this mixin for any arch
+missing from `ABI_MIXINS` — so a defect here is the widest-reach ABI defect in
+the tree.
+
+The bug these pin down: `set_args` pushed stack arguments one word at a time,
+placing the FIFTH argument at the highest address and the last at the lowest,
+while `get_arg` reads ascending from sp. A round-trip therefore came back
+reversed, silently, and only on a call with more than four arguments.
+"""
+from __future__ import annotations
+
+import pytest
+
+from halucinator.backends.hal_backend import ARM32HalMixin
+
+_SP0 = 0x20008000
+
+
+class _Fake(ARM32HalMixin):
+    """Register/memory model just big enough to exercise the ABI methods."""
+
+    def __init__(self, sp: int = _SP0):
+        self.regs = {f"r{i}": 0 for i in range(13)}
+        self.regs.update({"sp": sp, "lr": 0, "pc": 0, "cpsr": 0})
+        self.mem: dict[int, int] = {}
+
+    def read_register(self, name):
+        return self.regs[name]
+
+    def write_register(self, name, value):
+        self.regs[name] = value
+
+    def read_memory(self, addr, size, num):
+        return self.mem.get(addr, 0)
+
+    def write_memory(self, addr, size, value, num=1, raw=False):
+        self.mem[addr] = value
+
+
+def test_register_args_use_r0_r3():
+    f = _Fake()
+    f.set_args([1, 2, 3, 4])
+    assert [f.regs[f"r{i}"] for i in range(4)] == [1, 2, 3, 4]
+    assert [f.get_arg(i) for i in range(4)] == [1, 2, 3, 4]
+    assert f.regs["sp"] == _SP0, "no stack args — sp must not move"
+
+
+@pytest.mark.parametrize("n_extra", [1, 2, 3, 5])
+def test_stack_args_round_trip_in_order(n_extra):
+    """THE REGRESSION: set_args then get_arg must return what was set, in
+    order. The old push-one-word-at-a-time loop returned them reversed."""
+    f = _Fake()
+    args = [0xA0 + i for i in range(4 + n_extra)]
+    f.set_args(args)
+    assert [f.get_arg(i) for i in range(len(args))] == args
+
+
+def test_fifth_argument_is_at_the_final_sp():
+    """AAPCS puts the fifth argument AT sp (no home space), ascending from
+    there — assert the absolute placement, since a reader and writer that are
+    both wrong in the same direction would still agree with each other."""
+    f = _Fake()
+    f.set_args([1, 2, 3, 4, 0x55, 0x66])
+    sp = f.regs["sp"]
+    assert f.mem[sp] == 0x55
+    assert f.mem[sp + 4] == 0x66
+
+
+def test_stack_stays_eight_byte_aligned():
+    """AAPCS requires an 8-byte-aligned SP at a public interface. An odd number
+    of stack words must round the allocation up, with the padding ABOVE the
+    arguments so the fifth stays at sp+0."""
+    for n_extra in (1, 2, 3, 4, 5):
+        f = _Fake()
+        f.set_args(list(range(4 + n_extra)))
+        assert f.regs["sp"] % 8 == 0, f"sp misaligned with {n_extra} stack args"
+        assert f.regs["sp"] <= _SP0 - 4 * n_extra, "allocated too little space"
+
+
+def test_get_arg_rejects_a_negative_index():
+    with pytest.raises(ValueError):
+        _Fake().get_arg(-1)


### PR DESCRIPTION
`ARM32HalMixin.set_args` pushed stack arguments one word at a time — decrement `sp`, store — so the **fifth** argument landed at the highest address and the last at the lowest. `get_arg` reads ascending from `sp`, per AAPCS, where the fifth argument is the word *at* `sp`. The pair round-tripped reversed:

```
set_args([a, b, c, d, e, f]); get_arg(4)  ->  f   (should be e)
set_args([a, b, c, d, e, f]); get_arg(5)  ->  e   (should be f)
```

Silent, and only reachable on a call with more than four arguments — r0–r3 cover the common case, which is why it survived.

This is the widest-reach ABI defect in the tree: `_bind_abi` resolves with `ABI_MIXINS.get(arch, ARM32HalMixin)`, so ARM32 is what every arch missing from the table falls back to.

### Fix

`set_args` allocates the whole outgoing block and fills it ascending, so the fifth argument is at the final `sp`. The block is rounded up to 8 bytes — AAPCS requires an 8-byte-aligned SP at a public interface, and an odd number of stack words would otherwise leave it 4-byte aligned. Padding sits above the arguments so the fifth stays at `sp+0`.

### Tests

`test/pytest/backends/test_arm32_abi.py` asserts the **absolute placement** as well as the round-trip: a reader and writer that are wrong in the same direction still agree with each other, so a round-trip alone would not catch this. Verified by reverting `set_args` — 5 of the 8 tests fail.