### PR TITLE
main: actually persist the MMIO trace (forward db_path, flush at shutdown)

### DIFF
--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -7,6 +7,7 @@ This is the halucinator entry point
 from __future__ import annotations
 
 from argparse import ArgumentParser
+import inspect
 import logging
 from multiprocessing import Lock
 import threading
@@ -1045,8 +1046,22 @@ def _instantiate_peripheral(name: str, memory: Any, db_path: str) -> Any:
                     name, memory.name)
         return None
     kwargs: Dict[str, Any] = {}
+    # Forward the run's MMIO-trace path to any peripheral that accepts one.
+    # This argument was accepted here but never passed on, so the recording
+    # peripherals were always built with their default db_path=None and no
+    # trace was ever persisted. Gated on the signature: most peripherals take
+    # no db_path and would raise TypeError.
+    try:
+        params = inspect.signature(cls).parameters
+        takes_db = "db_path" in params or any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+    except (TypeError, ValueError):  # pragma: no cover
+        takes_db = False
+    if takes_db and db_path is not None:
+        kwargs["db_path"] = db_path
     # Pull peripheral-specific kwargs from the YAML `properties` block
     # (HalMemConfig.properties is the generic per-peripheral dict slot).
+    # Applied last so a device can override the default path.
     extra = getattr(memory, "properties", None)
     if isinstance(extra, dict):
         kwargs.update(extra)
@@ -1177,6 +1192,21 @@ def _emulate_with_unicorn_backend(
     periph_thread.start()
 
     def _shutdown() -> None:
+        # Persist any buffered MMIO trace BEFORE tearing the backend down.
+        # The recording peripherals only evaluate their flush condition inside
+        # an access, so a run that issues fewer than FLUSH_EVERY accesses --
+        # or that simply stops touching MMIO after early boot -- never writes
+        # its tail, and killing the process loses the trace entirely. That is
+        # most of a short bring-up run, which is exactly when the trace is
+        # wanted.
+        for _p in auto_peripherals:
+            _flush = getattr(_p, "flush", None)
+            if callable(_flush):
+                try:
+                    _flush()
+                except Exception:  # noqa: BLE001 - never block shutdown
+                    log.exception("peripheral %s: trace flush failed",
+                                  getattr(_p, "name", _p))
         try:
             backend.shutdown()
         except Exception:  # noqa: BLE001

--- a/test/pytest/test_mmio_trace_recording.py
+++ b/test/pytest/test_mmio_trace_recording.py
@@ -1,0 +1,140 @@
+"""The MMIO trace has to actually reach disk.
+
+`emulate: RecordingPeripheral` is the *record* half of the
+record -> infer -> synthesize loop that peripheral-model generation consumes.
+Two independent defects meant it wrote nothing:
+
+1. `_instantiate_peripheral` accepted a `db_path` argument and never forwarded
+   it, so the recording peripherals were always constructed with their default
+   `db_path=None`. The failure is silent: the peripheral loads, the log says it
+   is active, the run works, and only the trace is missing.
+
+2. The flush condition is evaluated *inside an access*, by count or elapsed
+   time. A run that issues fewer than `FLUSH_EVERY` accesses -- or that stops
+   touching MMIO after early boot -- never wrote its tail. That is most of a
+   short bring-up run, which is exactly when the trace is wanted.
+
+These tests avoid constructing a real `GenericPeripheral` subclass, which needs
+avatar2's interval-tree handler maps. The forwarding logic is exercised through
+the fully-qualified `module.Class` branch with the stand-ins below, so the tests
+run with or without avatar2 installed.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import types
+
+import pytest
+
+from halucinator import main as M
+
+
+# --- stand-ins, addressed via the fully-qualified `emulate:` branch ---------
+
+class TakesDbPath:
+    """A peripheral whose constructor accepts db_path."""
+
+    def __init__(self, name, address, size, db_path=None, **kwargs):
+        self.name, self.address, self.size = name, address, size
+        self.db_path = db_path
+        self.kwargs = kwargs
+
+
+class TakesKwargsOnly:
+    """Accepts **kwargs — must be treated as accepting db_path."""
+
+    def __init__(self, name, address, size, **kwargs):
+        self.name, self.address, self.size = name, address, size
+        self.kwargs = kwargs
+
+
+class TakesNoDbPath:
+    """Like GenericPeripheral: passing db_path would be a TypeError."""
+
+    def __init__(self, name, address, size):
+        self.name, self.address, self.size = name, address, size
+
+
+_HERE = __name__  # this test module, importable by _instantiate_peripheral
+
+
+def _mem(properties=None):
+    return types.SimpleNamespace(name="mmio", base_addr=0x40000000,
+                                 size=0x1000, properties=properties)
+
+
+def test_db_path_is_forwarded(tmp_path):
+    db = str(tmp_path / "trace.sqlite")
+    inst = M._instantiate_peripheral(f"{_HERE}.TakesDbPath", _mem(), db)
+    assert inst is not None
+    assert inst.db_path == db, "db_path was accepted but not passed through"
+
+
+def test_kwargs_constructor_also_receives_it(tmp_path):
+    db = str(tmp_path / "trace.sqlite")
+    inst = M._instantiate_peripheral(f"{_HERE}.TakesKwargsOnly", _mem(), db)
+    assert inst.kwargs.get("db_path") == db
+
+
+def test_peripheral_without_db_path_is_not_broken(tmp_path):
+    """The forwarding must be gated on the signature: most peripherals take no
+    db_path and would raise TypeError."""
+    inst = M._instantiate_peripheral(f"{_HERE}.TakesNoDbPath", _mem(),
+                                     str(tmp_path / "trace.sqlite"))
+    assert inst is not None and inst.size == 0x1000
+
+
+def test_yaml_properties_win_over_the_run_default(tmp_path):
+    """A device that sets its own db_path in `properties:` keeps it."""
+    chosen = str(tmp_path / "device-chosen.sqlite")
+    inst = M._instantiate_peripheral(
+        f"{_HERE}.TakesDbPath", _mem(properties={"db_path": chosen}),
+        str(tmp_path / "run-default.sqlite"))
+    assert inst.db_path == chosen
+
+
+def test_no_db_path_available_means_none_is_passed():
+    inst = M._instantiate_peripheral(f"{_HERE}.TakesDbPath", _mem(), None)
+    assert inst.db_path is None
+
+
+# --- persistence -----------------------------------------------------------
+
+def _recording(tmp_path):
+    """A RecordingPeripheral, skipping if this environment cannot build one
+    (GenericPeripheral needs avatar2's handler maps)."""
+    from halucinator.peripheral_models.auto_model import RecordingPeripheral
+    db = str(tmp_path / "trace.sqlite")
+    try:
+        return RecordingPeripheral("mmio", 0x40000000, 0x1000, db_path=db), db
+    except AttributeError as exc:      # no avatar2 handler maps here
+        pytest.skip(f"cannot construct GenericPeripheral: {exc}")
+
+
+def test_short_run_persists_its_trace_on_flush(tmp_path):
+    """Fewer accesses than FLUSH_EVERY: the tail only reaches disk on flush."""
+    from halucinator.peripheral_models.auto_model import RecordingPeripheral
+    p, db = _recording(tmp_path)
+    n = 10
+    assert n < RecordingPeripheral.FLUSH_EVERY
+    for _ in range(n):
+        p.hw_read(0x10, 4, pc=0x8000)
+    p.flush()
+    assert os.path.exists(db), "flush() did not create the trace database"
+    rows = sqlite3.connect(db).execute(
+        "select count(*) from mmio_trace").fetchone()[0]
+    assert rows == n, f"expected {n} recorded accesses, got {rows}"
+
+
+def test_flush_is_idempotent(tmp_path):
+    p, db = _recording(tmp_path)
+    for _ in range(5):
+        p.hw_read(0x10, 4, pc=0x8000)
+    p.flush()
+    first = sqlite3.connect(db).execute(
+        "select count(*) from mmio_trace").fetchone()[0]
+    p.flush()
+    second = sqlite3.connect(db).execute(
+        "select count(*) from mmio_trace").fetchone()[0]
+    assert first == second == 5


### PR DESCRIPTION
`emulate: RecordingPeripheral` / `AutoPeripheral` is the *record* half of the record → infer → synthesize loop that peripheral-model generation reads. It wrote nothing, for two independent reasons.

### 1. `db_path` was never forwarded

`_instantiate_peripheral` takes a `db_path` argument, documents it, and then builds the peripheral from `memory.properties` alone — so the recording peripherals were always constructed with their default `db_path=None`. Dead since the function was introduced in #32, and no device works around it (none sets `db_path` in YAML).

The failure is **silent**, which is why it lasted: the peripheral loads, the log reports it active (`Adding Memory: … (emulate=AutoPeripheral)`), the run behaves normally, and only the trace is missing.

Forwarding is gated on the constructor signature — most peripherals (`GenericPeripheral`, `HaltPeripheral`, the At91 family) take no `db_path` and would raise `TypeError`. A `**kwargs` constructor counts as accepting it. YAML `properties:` is applied last, so a device can still choose its own path.

### 2. A short run lost its trace

The flush condition is only evaluated *inside an access*, by count (`FLUSH_EVERY`) or elapsed time. Firmware that issues fewer than 4096 accesses, or that stops touching MMIO after early boot, never wrote its tail — and since the `emu_start` loop does not return, killing the process lost everything. That is precisely a short bring-up run, which is when the trace is most wanted.

`_shutdown` now flushes the collected peripherals before tearing the backend down. `auto_peripherals` was already being collected and never used; this is what it is for.

### Measured

On `device-heatpress-sam3x`: before, a 60 s run wrote **no database at all**; after, the same run persists **567 accesses over 56 registers** through the SIGINT path, with `FLUSH_EVERY` unchanged at 4096.

### Tests

`test/pytest/test_mmio_trace_recording.py` reaches the forwarding logic through the fully-qualified `module.Class` branch using local stand-ins, so it runs with or without avatar2 installed. Reverting the fix fails 2 of the 7.