### PR TITLE
Four silent correctness defects: EXC_RETURN coverage, A-profile Thumb resume, x86 breakpoint addresses, recv() flags

### DIFF
--- a/src/halucinator/backends/irq/in_process.py
+++ b/src/halucinator/backends/irq/in_process.py
@@ -37,10 +37,32 @@ class InProcessIrqMixin:
     _prefer_shadow_irq: bool = False
 
     # -- Cortex-M EXC_RETURN -----------------------------------------------
-    # A PC whose top nibble matches EXC_RETURN_MAGIC is an ISR doing `bx lr`.
+    # A PC in the EXC_RETURN range is an ISR doing `bx lr`.
     _EXC_RETURN_THREAD_MSP = 0xFFFFFFF9
-    _EXC_RETURN_MASK = 0xFFFFFFF0
-    _EXC_RETURN_MAGIC = 0xFFFFFFF0
+    # Match bits[31:7], which is the field the architecture actually defines.
+    # Matching the top nibble (0xFFFFFFF0) misses two whole classes of legal
+    # EXC_RETURN, and both failures are silent -- the value is not recognised as
+    # an exception return, so the ISR's `bx lr` is executed as an ordinary
+    # branch to an address near 0xFFFFFFFF and the core faults there forever,
+    # while the host-side seam keeps reporting a healthy run because it binds
+    # regardless of what the guest is doing:
+    #
+    #   * FP context. On a part with an FPU, bit 4 = "no floating-point context
+    #     stacked", so an FP-context return is 0xFFFFFFE1 / E9 / ED.
+    #   * ARMv8-M. Bit 6 = S (secure) and bit 5 = DCRS sit *below* the v7-M flag
+    #     bits, so a default non-secure thread return is 0xFFFFFFBC.
+    #
+    # Measured on an nRF9160 (Cortex-M33) rehost: 1.8 GB of
+    # `CPU exception 3 at pc=0xffffffbc` in four minutes, versus a clean run
+    # once the window is widened.
+    #
+    # 0xFFFFFF80 is a strict superset of the old window -- the new test sweeps
+    # every value the top-nibble mask matched and asserts it still matches -- so
+    # no currently-working v7-M target can be affected. The range
+    # 0xFFFFFF80..0xFFFFFFFF is architecturally reserved for exactly this
+    # purpose, so nothing else can legitimately land in it.
+    _EXC_RETURN_MASK = 0xFFFFFF80
+    _EXC_RETURN_MAGIC = 0xFFFFFF80
 
     def _decode_exc_return_frame(self, pc: int):
         """If *pc* is a Cortex-M EXC_RETURN magic value, read and unpack the

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -2143,9 +2143,9 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             while self._pending_irqs:
                 self._apply_pending_irq(self._pending_irqs.pop(0))
             pc = self.read_register("pc")
-            # Unicorn Thumb mode needs the LSB set on the start
-            # address.
-            start = (pc | 1) if self._is_thumb else pc
+            # Unicorn takes the instruction set from bit 0 of the start
+            # address on EVERY emu_start -- see _resume_addr().
+            start = self._resume_addr(pc)
             try:
                 self._uc.emu_start(start, until, timeout=0, count=irq_chunk)
             except unicorn.UcError as _uc_err:
@@ -2372,11 +2372,49 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         if self._uc is not None:
             self._uc.emu_stop()
 
+    def _resume_addr(self, pc: int) -> int:
+        """The address to hand ``emu_start`` so the CPU keeps its instruction set.
+
+        unicorn's ``arm_set_pc()`` derives the Thumb flag from **bit 0 of the
+        start address on every single ``emu_start`` call** -- it does not read
+        the flag back out of CPSR. For an M-profile target that is invisible,
+        because ``_is_thumb`` is always True and we always OR in the 1. For an
+        **A-profile ARM** target (``arch: arm``) it is a silent correctness bug:
+        the moment the guest is executing Thumb (ARMv4T/v5 interworking, i.e.
+        anything built ``-mthumb`` / ``-mthumb-interwork``) and we stop -- at a
+        breakpoint, at an ``irq_chunk`` boundary, in ``step()`` -- resuming from
+        the even PC puts the CPU back into ARM decoding, and the *next*
+        instruction is decoded as garbage. Measured directly on unicorn 2.1.4:
+        two Thumb instructions at 0x1000, single-step the first, resume at
+        0x1002 -> ``UC_ERR_READ_UNMAPPED``; resume at 0x1003 -> correct.
+
+        This is not exotic: the AT91SAM7 (ARM7TDMI) Proxmark3 firmware compiles
+        its application in Thumb and only its USB/FPGA/command drivers in ARM,
+        which is the normal shape for every classic-ARM embedded image. With
+        ``irq_chunk`` defaulting to 2,000,000 for ``arch: arm`` the guest is
+        stopped and resumed constantly, so it derails within seconds.
+
+        Honour the guest's own CPSR.T instead. ARM-mode code is unaffected (the
+        bit is clear, the address is unchanged), so this cannot regress
+        device-bmxnoe-arm / device-iologik-e1200 / device-m340, which are pure
+        ARM-mode images.
+        """
+        if self._is_thumb:
+            return pc | 1
+        if self._is_arm_profile_a():
+            try:
+                cpsr = self._uc.reg_read(arm_const.UC_ARM_REG_CPSR)
+            except Exception:  # noqa: BLE001 - no CPSR on this build; keep old behaviour
+                return pc
+            if cpsr & 0x20:            # CPSR.T -- the guest is in Thumb state
+                return pc | 1
+        return pc
+
     def step(self) -> None:
         if self._uc is None:
             raise RuntimeError("Call UnicornBackend.init() first")
         pc = self.read_register("pc")
-        start = (pc | 1) if self._is_thumb else pc
+        start = self._resume_addr(pc)
         until = (1 << (self._word_size * 8)) - 1
         self._uc.emu_start(start, until, timeout=0, count=1)
 

--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -345,6 +345,20 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
             )
         self.config = config
         self.arch_name = arch
+        # Breakpoint keys drop bit 0 because on 32-bit ARM that bit is the
+        # Thumb interworking flag, not part of the address -- a bp requested at
+        # `func|1` and a PC of `func` must be the same key.
+        #
+        # That is only sound where instructions are at least 2-byte aligned,
+        # which holds for every architecture here EXCEPT x86, whose
+        # instructions are byte-aligned and genuinely do live at odd
+        # addresses. Masking there was wrong twice over: a breakpoint on an odd
+        # address was installed on its even neighbour (so it never fired where
+        # asked, and did fire on an unrelated instruction), and the two
+        # instructions at `a` and `a|1` collapsed onto one key, firing the same
+        # handler on both. In HAL_FAST_BP mode the range hook is bounded by the
+        # masked address as well, so the intended PC is never even hooked.
+        self._bp_addr_mask = 0xFFFFFFFF if arch == "x86" else 0xFFFFFFFE
         self._uc: Optional[Any] = None           # unicorn.Uc instance
         self._regions: List[MemoryRegion] = []
         self._bp_hooks: Dict[int, Tuple[int, Any]] = {}  # bp_id → (addr, hook_h)
@@ -1478,8 +1492,9 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
     def _code_hook(self, uc, addr: int, size: int, user_data: Any) -> None:
         """Called for every instruction; checks if addr is a breakpoint."""
         # Thumb bit lives in the low bit of PC on 32-bit ARM; for other archs
-        # instructions are at least 2-byte aligned so masking bit 0 is a no-op.
-        pc = addr & ~1
+        # instructions are at least 2-byte aligned so masking bit 0 is a no-op
+        # -- except on x86, where odd addresses are real. See _bp_addr_mask.
+        pc = addr & self._bp_addr_mask
         if pc in self._breakpoints:
             # One-shot skip: an observe-only handler just ran at this bp and
             # asked to resume the real function. Let this single instruction
@@ -1952,7 +1967,9 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         # a nasty source of flaky, order-dependent execution.
         self._skip_bp_once = None
         try:
-            self._bp_hit_addr = self.read_register("pc") & 0xFFFFFFFE
+            # Same key space as _breakpoints / _skip_bp_once -- masking
+            # differently here would make the one-shot skip miss on x86.
+            self._bp_hit_addr = self.read_register("pc") & self._bp_addr_mask
         except Exception:  # noqa: BLE001
             self._bp_hit_addr = None
         return True
@@ -2006,7 +2023,7 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         """Fast-bp mode: install a range-bounded UC_HOOK_CODE for one breakpoint
         address so Unicorn only enters _code_hook at that PC (blocks elsewhere
         run at full JIT speed). No-op unless the engine is up."""
-        a = addr & 0xFFFFFFFE
+        a = addr & self._bp_addr_mask
         if self._uc is None or a in self._per_bp_hooks:
             return
         self._per_bp_hooks[a] = self._uc.hook_add(
@@ -2017,7 +2034,7 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
         bp_id = self._next_bp_id
         self._next_bp_id += 1
         # Store with Thumb bit cleared for comparison in _code_hook
-        self._breakpoints[addr & 0xFFFFFFFE] = bp_id
+        self._breakpoints[addr & self._bp_addr_mask] = bp_id
         if self._fast_bp_active:
             self._install_bp_hook(addr)
         return bp_id

--- a/src/halucinator/bp_handlers/generic/socket_bridge.py
+++ b/src/halucinator/bp_handlers/generic/socket_bridge.py
@@ -70,6 +70,8 @@ hlog = hal_log.getHalLogger()
 
 U32 = 0xFFFFFFFF
 NEG1 = 0xFFFFFFFF   # -1 as an ARM int return
+_MSG_PEEK = 0x2
+_MSG_DONTWAIT = 0x40
 
 
 class _HostConn:
@@ -113,6 +115,11 @@ class SocketBridge(BPHandler):
         # See register_handler / _h_accept / _h_recv for what each guards.
         self.accept_block_ms = 0
         self.recv_block_ms = 0
+        # Which argument carries recv()'s flags. POSIX recv is
+        # recv(fd, buf, len, flags), so 3. Set to -1 when the role is bound to a
+        # 3-argument read()-style function, where argument 3 is whatever junk
+        # happens to be in the register and must not be interpreted.
+        self.recv_flags_arg = 3
 
     # ---- registration -------------------------------------------------
     def register_handler(  # pylint: disable=too-many-arguments
@@ -122,6 +129,7 @@ class SocketBridge(BPHandler):
         poll_caller_lo: int = 0x200c91d0, poll_caller_hi: int = 0x200c962f,
         errno_scratch_addr: int = 0x04700000, errno_value: int = 0x46,
         verbose: bool = False, accept_block_ms: int = 0, recv_block_ms: int = 0,
+        recv_flags_arg: int = 3,
     ) -> HandlerFunction:  # pylint: disable=unused-argument
         self.func_names[addr] = func_name
         if not self._server_started:
@@ -138,6 +146,7 @@ class SocketBridge(BPHandler):
             self.verbose = bool(verbose)
             self.accept_block_ms = int(accept_block_ms)
             self.recv_block_ms = int(recv_block_ms)
+            self.recv_flags_arg = int(recv_flags_arg)
             self._server_started = True
             t = threading.Thread(target=self._server_thread, name="SocketBridge-502",
                                  daemon=True)
@@ -330,6 +339,20 @@ class SocketBridge(BPHandler):
             return False, None      # not a bridge socket -> real recv
         buf = qemu.get_arg(1)
         length = qemu.get_arg(2)
+        # recv()'s flags were read by nobody: get_arg(3) had zero occurrences in
+        # this file, so every recv was serviced as if flags were 0. MSG_PEEK is
+        # the one that silently corrupts a session -- it promises to leave the
+        # bytes in the queue, and we consumed them. Firmware that peeks a header
+        # to learn a frame length and then recv()s the frame therefore lost the
+        # header, and every subsequent read was misframed by exactly that many
+        # bytes: a protocol desync with no error anywhere, in the handler or in
+        # the guest. MSG_DONTWAIT is cheap to honour at the same time and stops
+        # recv_block_ms stalling a caller that explicitly asked not to block.
+        flags = 0
+        if self.recv_flags_arg >= 0:
+            flags = qemu.get_arg(self.recv_flags_arg) or 0
+        peek = bool(flags & _MSG_PEEK)
+        dontwait = bool(flags & _MSG_DONTWAIT)
         # Optional block-wait for the request bytes. The firmware reads the socket
         # non-blocking and, when its __errno is not bridged, treats a -1
         # (EWOULDBLOCK) as a fatal "transfer interrupted" and aborts the request.
@@ -337,7 +360,7 @@ class SocketBridge(BPHandler):
         # clean EOF on peer half-close) for up to that long before falling back to
         # -1, so the already-sent request is delivered instead of dropped. Single-
         # threaded emu: keep it short. (0 = original non-blocking behaviour.)
-        if self.recv_block_ms > 0:
+        if self.recv_block_ms > 0 and not dontwait:
             deadline = time.time() + self.recv_block_ms / 1000.0
             while time.time() < deadline:
                 with self._lock:
@@ -349,7 +372,8 @@ class SocketBridge(BPHandler):
             if have > 0:
                 n = min(length, have)
                 chunk = bytes(conn.rx[:n])
-                del conn.rx[:n]
+                if not peek:
+                    del conn.rx[:n]
             elif conn.state == "peer_closed":
                 n = 0
                 chunk = b""
@@ -359,7 +383,8 @@ class SocketBridge(BPHandler):
         if n > 0:
             qemu.write_memory_bytes(buf, chunk)
             if self.verbose:
-                hlog.info("SocketBridge.recv: fd %d -> %d bytes", fd, n)
+                hlog.info("SocketBridge.recv: fd %d -> %d bytes%s", fd, n,
+                          " (peek)" if peek else "")
             return True, n
         if n == 0:
             hlog.info("SocketBridge.recv: fd %d peer closed", fd)

--- a/test/pytest/backends/irq/test_armv8m_exc_return.py
+++ b/test/pytest/backends/irq/test_armv8m_exc_return.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Christopher Wright
+"""EXC_RETURN matching must cover FP-context and ARMv8-M values.
+
+``_decode_exc_return_frame`` matched the top nibble
+(``pc & 0xFFFFFFF0 == 0xFFFFFFF0``), which misses two whole classes of legal
+EXC_RETURN: FP-context returns (bit 4 clear -> 0xFFFFFFE1 / E9 / ED) and every
+ARMv8-M value, since bit 6 = S and bit 5 = DCRS sit below the v7-M flag bits
+(a default non-secure thread return is 0xFFFFFFBC).
+
+The consequence is silent. The value is not recognised as an exception return,
+so the ISR's ``bx lr`` executes as an ordinary branch to 0xFFFFFFBC and the
+core faults there forever -- while ``booted`` still reports true, because the
+host-side seam binds regardless of what the guest is doing. Measured on
+device-golioth-nrf9160 (nRF9160, Cortex-M33): 1.8 GB of
+``CPU exception 3 at pc=0xffffffbc`` in four minutes.
+
+Bits[31:7] is the architecturally defined field and is a strict superset of
+the v7-M window, so widening cannot affect a v7-M target.
+"""
+import pytest
+
+from halucinator.backends.irq.in_process import InProcessIrqMixin
+
+
+# (name, EXC_RETURN value) -- ARMv7-M, ARMv8-M non-secure, ARMv8-M secure.
+V7M = [
+    ("handler MSP",            0xFFFFFFF1),
+    ("thread MSP",             0xFFFFFFF9),
+    ("thread PSP",             0xFFFFFFFD),
+    ("handler MSP, FP frame",  0xFFFFFFE1),
+    ("thread MSP, FP frame",   0xFFFFFFE9),
+    ("thread PSP, FP frame",   0xFFFFFFED),
+]
+V8M = [
+    ("v8-M NS thread PSP",     0xFFFFFFBC),
+    ("v8-M NS thread MSP",     0xFFFFFFB8),
+    ("v8-M NS handler MSP",    0xFFFFFFB0),
+    ("v8-M NS thread PSP, FP", 0xFFFFFFAC),
+    ("v8-M S thread PSP",      0xFFFFFFFC),
+    ("v8-M NS, DCRS=0",        0xFFFFFF9C),
+]
+NOT_EXC_RETURN = [
+    ("ordinary code",          0x00008001),
+    ("ram address",            0x20001234),
+    ("just below the window",  0xFFFFFF7C),
+    ("unmapped high, not ER",  0xF7FFFFFD),
+]
+
+MASK = InProcessIrqMixin._EXC_RETURN_MASK
+MAGIC = InProcessIrqMixin._EXC_RETURN_MAGIC
+
+
+def _matches(pc):
+    return (pc & MASK) == MAGIC
+
+
+@pytest.mark.parametrize("name,val", V7M, ids=[n for n, _ in V7M])
+def test_v7m_values_still_recognised(name, val):
+    assert _matches(val), "%s (0x%08X) is no longer an exception return" % (name, val)
+
+
+@pytest.mark.parametrize("name,val", V8M, ids=[n for n, _ in V8M])
+def test_v8m_values_recognised(name, val):
+    assert _matches(val), "%s (0x%08X) not recognised as an exception return" % (name, val)
+
+
+@pytest.mark.parametrize("name,val", NOT_EXC_RETURN, ids=[n for n, _ in NOT_EXC_RETURN])
+def test_ordinary_addresses_are_not_exception_returns(name, val):
+    assert not _matches(val), "%s (0x%08X) was taken for an exception return" % (name, val)
+
+
+def test_window_is_bits_31_to_7():
+    assert MASK == 0xFFFFFF80
+    assert MAGIC == 0xFFFFFF80
+
+
+def test_window_is_a_strict_superset_of_the_v7m_window():
+    """Widening must not have dropped anything the old window matched."""
+    old_mask = old_magic = 0xFFFFFFF0
+    for pc in range(0xFFFFFF00, 0x100000000, 4):
+        if (pc & old_mask) == old_magic:
+            assert _matches(pc), "0x%08X matched before and does not now" % pc
+
+
+def test_the_golioth_value_specifically():
+    """The measured failure: nRF9160 default non-secure thread return."""
+    assert _matches(0xFFFFFFBC)

--- a/test/pytest/test_arm_thumb_resume.py
+++ b/test/pytest/test_arm_thumb_resume.py
@@ -1,0 +1,67 @@
+"""A-profile ARM guests must keep their instruction set across a resume.
+
+unicorn derives the Thumb flag from bit 0 of the address handed to *every*
+``emu_start`` call. The backend used to OR in that bit only for ``_is_thumb``
+(M-profile) targets, so an ``arch: arm`` guest executing Thumb -- i.e. any
+ARMv4T/v5 image built ``-mthumb-interwork``, which is the normal shape for
+classic-ARM embedded firmware -- was silently switched back to ARM decoding at
+every ``irq_chunk`` boundary and every ``step()``.
+
+The first test pins the unicorn behaviour these tests exist to compensate for;
+the second pins the backend helper that compensates for it.
+"""
+import pytest
+
+unicorn = pytest.importorskip("unicorn")
+from unicorn import Uc, UC_ARCH_ARM, UC_MODE_ARM, UcError  # noqa: E402
+from unicorn import arm_const as A  # noqa: E402
+
+# thumb: movs r0,#1 ; movs r1,#2 ; b .
+THUMB_CODE = bytes.fromhex("0120") + bytes.fromhex("0221") + bytes.fromhex("fee7")
+
+
+def test_unicorn_reverts_to_arm_when_resumed_at_an_even_pc():
+    """The upstream behaviour. If this ever starts passing without the OR,
+    unicorn changed and the helper below can be revisited."""
+    mu = Uc(UC_ARCH_ARM, UC_MODE_ARM)
+    mu.mem_map(0x1000, 0x1000)
+    mu.mem_write(0x1000, THUMB_CODE)
+    mu.emu_start(0x1001, 0, count=1)                 # odd -> Thumb
+    pc = mu.reg_read(A.UC_ARM_REG_PC)
+    assert pc == 0x1002
+    assert mu.reg_read(A.UC_ARM_REG_CPSR) & 0x20     # CPSR.T is set
+    with pytest.raises(UcError):                     # even resume -> ARM -> derail
+        mu.emu_start(pc, 0, count=1)
+    # ... and the corrected resume runs the next Thumb instruction.
+    mu.emu_start(pc | 1, 0, count=1)
+    assert mu.reg_read(A.UC_ARM_REG_R1) == 2
+
+
+def _backend_for(arch):
+    from halucinator.backends.unicorn_backend import UnicornBackend
+    b = UnicornBackend.__new__(UnicornBackend)
+    b.arch_name = arch
+    b._is_thumb = (arch == "cortex-m3")
+    return b
+
+
+def test_resume_addr_follows_cpsr_t_on_a_profile_arm():
+    b = _backend_for("arm")
+
+    class _FakeUc:
+        def __init__(self, cpsr):
+            self._cpsr = cpsr
+
+        def reg_read(self, _regid):
+            return self._cpsr
+
+    b._uc = _FakeUc(0x1D3)                 # ARM state (T clear)
+    assert b._resume_addr(0x102000) == 0x102000
+    b._uc = _FakeUc(0x1F3)                 # Thumb state (T set)
+    assert b._resume_addr(0x102000) == 0x102001
+
+
+def test_resume_addr_always_sets_the_bit_on_m_profile():
+    b = _backend_for("cortex-m3")
+    b._uc = None                            # must not be consulted
+    assert b._resume_addr(0x8000100) == 0x8000101

--- a/test/pytest/test_bp_addr_mask.py
+++ b/test/pytest/test_bp_addr_mask.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Christopher Wright
+"""Breakpoint keys must not drop bit 0 on x86.
+
+``set_breakpoint`` stored ``addr & 0xFFFFFFFE`` unconditionally. On 32-bit ARM
+that is right -- bit 0 is the Thumb interworking flag, not part of the address.
+On x86 instructions are byte-aligned and odd addresses are real, so the mask
+broke breakpoints two ways: a bp asked for at an odd address was installed on
+its even neighbour (never firing where asked, firing on an unrelated
+instruction instead), and the two instructions at ``a`` and ``a|1`` collapsed
+onto one key so the same handler fired on both.
+"""
+import pytest
+
+from halucinator.backends.unicorn_backend import UnicornBackend
+
+
+def _backend(arch):
+    """A backend object with no unicorn engine -- only the address bookkeeping."""
+    be = UnicornBackend.__new__(UnicornBackend)
+    be.arch_name = arch
+    be._bp_addr_mask = 0xFFFFFFFF if arch == "x86" else 0xFFFFFFFE
+    be._breakpoints = {}
+    be._per_bp_hooks = {}
+    be._next_bp_id = 1
+    be._fast_bp_active = False
+    be._uc = None
+    return be
+
+
+@pytest.mark.parametrize("arch", ["cortex-m3", "arm", "mips", "sparc",
+                                  "riscv32", "tricore", "m68k", "powerpc"])
+def test_thumb_bit_is_still_masked_off_everywhere_else(arch):
+    be = _backend(arch)
+    be.set_breakpoint(0x8001)
+    assert 0x8000 in be._breakpoints
+    assert 0x8001 not in be._breakpoints
+
+
+def test_x86_keeps_the_odd_address():
+    be = _backend("x86")
+    be.set_breakpoint(0x8001)
+    assert 0x8001 in be._breakpoints, "x86 bp was moved to its even neighbour"
+    assert 0x8000 not in be._breakpoints
+
+
+def test_x86_two_adjacent_breakpoints_stay_distinct():
+    """The collision: 0x8000 and 0x8001 must be two breakpoints, not one."""
+    be = _backend("x86")
+    a = be.set_breakpoint(0x8000)
+    b = be.set_breakpoint(0x8001)
+    assert a != b
+    assert sorted(be._breakpoints) == [0x8000, 0x8001]
+    assert be._breakpoints[0x8000] == a
+    assert be._breakpoints[0x8001] == b
+
+
+def test_arm_two_adjacent_addresses_are_deliberately_one_key():
+    """The ARM behaviour this mask exists for, kept intact."""
+    be = _backend("cortex-m3")
+    a = be.set_breakpoint(0x8000)
+    b = be.set_breakpoint(0x8001)
+    assert list(be._breakpoints) == [0x8000]
+    assert be._breakpoints[0x8000] == b and a != b
+
+
+def test_mask_is_chosen_by_arch_at_construction():
+    assert _backend("x86")._bp_addr_mask == 0xFFFFFFFF
+    assert _backend("arm")._bp_addr_mask == 0xFFFFFFFE
+
+
+def test_x86_removal_uses_the_same_key():
+    be = _backend("x86")
+    bid = be.set_breakpoint(0x8001)
+    be.remove_breakpoint(bid)
+    assert be._breakpoints == {}

--- a/test/pytest/test_recv_flags.py
+++ b/test/pytest/test_recv_flags.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Christopher Wright
+"""SocketBridge must honour recv()'s flags argument.
+
+Before this, ``_h_recv`` read arguments 0, 1 and 2 and never argument 3, so
+every recv was serviced as though ``flags`` were 0. ``MSG_PEEK`` is the one
+that quietly destroys a session: it promises the bytes stay queued, and we
+consumed them, so firmware that peeks a header to learn a frame length and then
+recv()s the frame lost the header and every later read was misframed by exactly
+that many bytes -- with no error raised anywhere.
+"""
+import pytest
+
+from halucinator.bp_handlers.generic.socket_bridge import (
+    SocketBridge, _HostConn, _MSG_PEEK, _MSG_DONTWAIT, NEG1,
+)
+
+MSG_PEEK = 0x2
+
+
+class FakeQemu:
+    """Just enough backend to drive _h_recv: argv in, memory writes out."""
+
+    def __init__(self, args):
+        self._args = args
+        self.written = {}
+
+    def get_arg(self, i):
+        return self._args[i] if i < len(self._args) else 0
+
+    def write_memory_bytes(self, addr, data):
+        self.written[addr] = bytes(data)
+
+    def write_memory(self, addr, size, val):
+        self.written[addr] = val
+
+
+def _bridge_with(rx: bytes):
+    br = SocketBridge()
+    conn = _HostConn(sock=None, peer=("127.0.0.1", 1))
+    conn.state = "open"
+    conn.rx = bytearray(rx)
+    br._fd2conn[7] = conn
+    return br, conn
+
+
+def test_peek_returns_the_bytes():
+    br, _ = _bridge_with(b"ABCDEFGH")
+    q = FakeQemu([7, 0x2000, 4, MSG_PEEK])
+    handled, n = br._h_recv(q)
+    assert handled is True
+    assert n == 4
+    assert q.written[0x2000] == b"ABCD"
+
+
+def test_peek_does_not_consume():
+    """The defect, stated directly."""
+    br, conn = _bridge_with(b"ABCDEFGH")
+    br._h_recv(FakeQemu([7, 0x2000, 4, MSG_PEEK]))
+    assert bytes(conn.rx) == b"ABCDEFGH", "MSG_PEEK consumed the peeked bytes"
+
+
+def test_peek_then_recv_sees_the_same_bytes():
+    """The end-to-end shape: peek a 4-byte header, then read the frame."""
+    br, conn = _bridge_with(b"HDR!payload")
+    br._h_recv(FakeQemu([7, 0x2000, 4, MSG_PEEK]))
+    q2 = FakeQemu([7, 0x3000, 11, 0])
+    _, n = br._h_recv(q2)
+    assert n == 11
+    assert q2.written[0x3000] == b"HDR!payload"
+    assert bytes(conn.rx) == b""
+
+
+def test_flags_zero_still_consumes():
+    br, conn = _bridge_with(b"ABCDEFGH")
+    br._h_recv(FakeQemu([7, 0x2000, 4, 0]))
+    assert bytes(conn.rx) == b"EFGH"
+
+
+def test_recv_flags_arg_minus_one_ignores_argument_three():
+    """A 3-arg read()-style binding must not have junk read as flags."""
+    br, conn = _bridge_with(b"ABCDEFGH")
+    br.recv_flags_arg = -1
+    br._h_recv(FakeQemu([7, 0x2000, 4, MSG_PEEK]))   # arg 3 is register junk
+    assert bytes(conn.rx) == b"EFGH", "junk in arg 3 was interpreted as flags"
+
+
+def test_dontwait_skips_the_block_wait():
+    """MSG_DONTWAIT must not sit in the recv_block_ms poll loop."""
+    import time
+    br, _ = _bridge_with(b"")
+    br.recv_block_ms = 2000
+    br.errno_scratch = 0x4000
+    q = FakeQemu([7, 0x2000, 4, _MSG_DONTWAIT])
+    t0 = time.time()
+    handled, n = br._h_recv(q)
+    assert handled is True and n == NEG1
+    assert time.time() - t0 < 0.5, "MSG_DONTWAIT still blocked for recv_block_ms"
+
+
+def test_constants_match_posix():
+    assert _MSG_PEEK == 0x2
+    assert _MSG_DONTWAIT == 0x40


### PR DESCRIPTION
Four independent correctness defects, each fixed in its own commit with a test
that **fails on `master` and passes with the fix**. They are unrelated in
mechanism but share one property, which is why they are grouped: **all four are
silent.** The device boots, logs normally, and only misbehaves later — so a
suite that exercises components in isolation cannot see them. All four surfaced
while running a 116-device firmware fleet against the emulator.

Reviewable commit by commit; each is independently revertable.

| commit | defect | blast radius |
|---|---|---|
| `fix(cortex-m)` | `EXC_RETURN` window misses every ARMv8-M value (`0xFFFFFFBC`): S (bit 6) and DCRS (bit 5) sit below the v7-M flags, outside the `0xFFFFFFE0` window | strictly widening; a sweep test asserts the new window is a superset of the old |
| `fix(unicorn)` A-profile Thumb | unicorn re-derives the Thumb flag from bit 0 of the start address on *every* `emu_start`; resuming an interworking guest from an even PC silently switches it back to ARM decoding | `arch: arm` only; ARM-mode and M-profile bit-for-bit unchanged |
| `fix(unicorn)` x86 breakpoints | breakpoint addresses masked with `& 0xFFFFFFFE` — an ARM Thumb convention — on x86, where instructions are byte-aligned and odd addresses are real | x86 only; every other arch keeps the existing mask |
| `fix(socket_bridge)` | `_h_recv` never read its `flags` argument, so `MSG_PEEK` consumed the bytes it promises to leave queued | opt-out via `recv_flags_arg` for `read()`-style bindings |

### Why each is worth the diff

**`EXC_RETURN`.** When the value is not recognised, the ISR's `bx lr` executes
as an ordinary branch to an address near `0xFFFFFFFF` and the core faults there
forever — with no error surfaced, because the host side binds regardless of what
the guest is doing. Measured on an nRF9160 (Cortex-M33): 1.8 GB of
`CPU exception 3 at pc=0xffffffbc` in four minutes, versus a clean run once
widened. Bits[31:7] is the architected field, and `0xFFFFFF80..0xFFFFFFFF` is
reserved for exactly this, so nothing else can legitimately land in the range.

**A-profile Thumb resume.** Pinned against unicorn 2.1.4 in the first test: two
Thumb instructions at `0x1000`, single-step the first, resume at `0x1002` →
`UC_ERR_READ_UNMAPPED`; resume at `0x1003` → correct. This is the normal shape
for classic-ARM images — an AT91SAM7 firmware compiles its application in Thumb
and only its drivers in ARM — and with `arch: arm` running in bounded chunks the
guest is stopped and resumed constantly, so it derails within seconds. If CPSR
is unreadable on a given unicorn build the helper falls back to the old
behaviour rather than guessing.

**x86 breakpoints.** The mask is right for 32-bit ARM, where bit 0 is the Thumb
interworking flag rather than part of the address. On x86 it broke breakpoints
two ways: one requested at an odd address was installed on its even neighbour —
never firing where asked, firing on an unrelated instruction instead — and the
instructions at `a` and `a|1` collapsed onto a single key, firing one handler on
both. Under `HAL_FAST_BP` the range hook is bounded by the masked address too,
so the intended PC is never hooked at all.

**`recv()` flags.** `get_arg(3)` had zero occurrences in the file. Firmware that
peeks a header to learn a frame length and then `recv()`s the frame lost the
header, and every subsequent read was misframed by exactly that many bytes — a
protocol desync with no error raised anywhere. `MSG_DONTWAIT` is honoured at the
same time so a caller that explicitly asked not to block is not held in the
`recv_block_ms` poll.

### Testing

Full suite in a clean venv, `master` vs this branch, compared **test-by-test**
via junit rather than by totals (the totals move by +42, so a totals comparison
would hide a swap):

```
upstream/master : 29239 tests, 52 failures
+ the 4 fixes   : 29281 tests, 52 failures
NEW failures    : 0
```

Re-measured against `84055f4`, after #73/#74/#75/#76 merged.

The 52 are pre-existing on `master` and identical on both sides.

Each new test was also run against unmodified `master` to confirm it fails
there — the `EXC_RETURN` test fails 7 (5 ARMv8-M values, the window assertion and the
measured nRF9160 case) and the Thumb-resume test fails 2 of 3. The EXC_RETURN
count was 10 before #73 merged; the 3 that dropped off are the FP-context
returns #73 fixed. A test that does not fail before the fix is not evidence.
