### PR TITLE
Two correctness fixes: riscv32 register map returns None on first call; MMIO tracing forced on for every run

### DIFF
--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -424,6 +424,7 @@ def _get_riscv_reg_map() -> Dict[str, int]:
         m[name] = m[f"x{idx}"]
     m["pc"] = riscv_const.UC_RISCV_REG_PC
     _REG_MAPS_CACHE["riscv"] = m
+    return m
 def _get_m68k_reg_map() -> Dict[str, int]:
     if "m68k" in _REG_MAPS_CACHE:
         return _REG_MAPS_CACHE["m68k"]

--- a/src/halucinator/main.py
+++ b/src/halucinator/main.py
@@ -1053,11 +1053,17 @@ def _instantiate_peripheral(name: str, memory: Any, db_path: str) -> Any:
     # no db_path and would raise TypeError.
     try:
         params = inspect.signature(cls).parameters
-        takes_db = "db_path" in params or any(
-            p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+        # ONLY an explicitly named db_path parameter counts. A **kwargs
+        # constructor is not consent: most peripherals declare one and forward
+        # the rest elsewhere, so treating it as "accepts db_path" injects a
+        # db_path into peripherals that never asked for one.
+        takes_db = "db_path" in params
     except (TypeError, ValueError):  # pragma: no cover
         takes_db = False
-    if takes_db and db_path is not None:
+    # Opt in with HAL_MMIO_TRACE=1. Recording costs real time inside every MMIO
+    # access, so forwarding db_path whenever a peripheral merely *accepts* it
+    # turns tracing on for every run of every device.
+    if takes_db and db_path is not None and os.environ.get("HAL_MMIO_TRACE") == "1":
         kwargs["db_path"] = db_path
     # Pull peripheral-specific kwargs from the YAML `properties` block
     # (HalMemConfig.properties is the generic per-peripheral dict slot).

--- a/test/pytest/backends/test_reg_map_cold_cache.py
+++ b/test/pytest/backends/test_reg_map_cold_cache.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Christopher Wright
+"""Every per-arch register map must return its map on the COLD path.
+
+`_get_riscv_reg_map` populated `_REG_MAPS_CACHE` and then fell off the end,
+returning None. The second call read the cache and returned a dict, so the bug
+only shows on the very first call for that architecture -- which in a real run
+is the first `write_register` at boot, where it surfaces as
+`'NoneType' object has no attribute 'get'` and the device simply never boots.
+
+The existing suite could not catch it. Constructing a backend never dereferences
+the register map, and any earlier test that touched the arch warms the cache for
+everything after it. A test has to evict the cache first, which is what this one
+does -- for every architecture, so the next map added is covered by default.
+"""
+import pytest
+
+unicorn = pytest.importorskip("unicorn")
+
+from halucinator.backends import unicorn_backend as U  # noqa: E402
+
+# (cache key, getter) for every per-arch map that caches.
+GETTERS = [(k, getattr(U, "_get_%s_reg_map" % n))
+           for k, n in [("arm", "arm"), ("arm64", "arm64"), ("mips", "mips"),
+                        ("x86", "x86"), ("riscv", "riscv"), ("sparc", "sparc"),
+                        ("tricore", "tricore"), ("m68k", "m68k")]
+           if hasattr(U, "_get_%s_reg_map" % n)]
+
+
+@pytest.mark.parametrize("key,getter", GETTERS, ids=[k for k, _ in GETTERS])
+def test_cold_call_returns_the_map(key, getter):
+    """First call after a cache eviction must return the map, not None."""
+    U._REG_MAPS_CACHE.pop(key, None)
+    m = getter()
+    assert m is not None, (
+        "%s returned None on the cold path -- it populates the cache and falls "
+        "off the end, so only the FIRST call for this arch is broken" % getter.__name__)
+    assert isinstance(m, dict) and m, "%s returned an empty/!dict map" % getter.__name__
+
+
+@pytest.mark.parametrize("key,getter", GETTERS, ids=[k for k, _ in GETTERS])
+def test_cold_and_warm_agree(key, getter):
+    U._REG_MAPS_CACHE.pop(key, None)
+    cold = getter()
+    warm = getter()
+    assert cold == warm, "%s: cold and warm calls disagree" % getter.__name__
+
+
+@pytest.mark.parametrize("arch", ["cortex-m3", "arm", "arm64", "mips", "mipsel",
+                                  "x86", "riscv32", "sparc", "tricore", "m68k",
+                                  "powerpc", "ppc64"])
+def test_reg_map_for_arch_cold(arch):
+    """The public path, cold. This is what a booting device actually hits."""
+    for k in list(U._REG_MAPS_CACHE):
+        U._REG_MAPS_CACHE.pop(k, None)
+    m = U._reg_map_for_arch(arch)
+    assert m is not None, "_reg_map_for_arch(%r) is None on a cold cache" % arch
+    assert "pc" in m, "_reg_map_for_arch(%r) has no 'pc'" % arch

--- a/test/pytest/test_mmio_trace_recording.py
+++ b/test/pytest/test_mmio_trace_recording.py
@@ -42,7 +42,14 @@ class TakesDbPath:
 
 
 class TakesKwargsOnly:
-    """Accepts **kwargs — must be treated as accepting db_path."""
+    """Accepts **kwargs — must NOT be treated as accepting db_path.
+
+    A **kwargs constructor is not consent. Most peripherals declare one and
+    forward the rest somewhere else, so treating it as "accepts db_path"
+    injected a db_path into peripherals that never asked for one -- which is
+    how a catch-all peripheral started recording, and a device that boots
+    normally then failed to land. See _instantiate_peripheral.
+    """
 
     def __init__(self, name, address, size, **kwargs):
         self.name, self.address, self.size = name, address, size
@@ -64,17 +71,44 @@ def _mem(properties=None):
                                  size=0x1000, properties=properties)
 
 
-def test_db_path_is_forwarded(tmp_path):
+def test_db_path_is_forwarded(tmp_path, monkeypatch):
+    """Forwarding is opt-in via HAL_MMIO_TRACE=1 -- recording is not free."""
+    monkeypatch.setenv("HAL_MMIO_TRACE", "1")
     db = str(tmp_path / "trace.sqlite")
     inst = M._instantiate_peripheral(f"{_HERE}.TakesDbPath", _mem(), db)
     assert inst is not None
     assert inst.db_path == db, "db_path was accepted but not passed through"
 
 
-def test_kwargs_constructor_also_receives_it(tmp_path):
+def test_db_path_is_not_forwarded_unless_tracing_is_requested(tmp_path,
+                                                              monkeypatch):
+    """The gate, pinned.
+
+    Recording costs real time inside every MMIO access. Forwarding db_path
+    whenever a peripheral merely *accepts* it turns tracing on for every run and
+    cost a device its landing while leaving the boot looking healthy. Tracing is
+    now something a run asks for.
+    """
+    monkeypatch.delenv("HAL_MMIO_TRACE", raising=False)
+    db = str(tmp_path / "trace.sqlite")
+    inst = M._instantiate_peripheral(f"{_HERE}.TakesDbPath", _mem(), db)
+    assert inst is not None
+    assert inst.db_path is None, (
+        "db_path was forwarded without HAL_MMIO_TRACE=1 -- tracing is on for "
+        "every run again")
+
+
+def test_kwargs_constructor_does_not_receive_it(tmp_path, monkeypatch):
+    """**kwargs is not consent -- see TakesKwargsOnly.
+
+    Asserted with tracing explicitly ON, so the test isolates the
+    named-parameter rule rather than passing for want of the env gate.
+    """
+    monkeypatch.setenv("HAL_MMIO_TRACE", "1")
     db = str(tmp_path / "trace.sqlite")
     inst = M._instantiate_peripheral(f"{_HERE}.TakesKwargsOnly", _mem(), db)
-    assert inst.kwargs.get("db_path") == db
+    assert "db_path" not in inst.kwargs, (
+        "a **kwargs-only constructor was handed db_path it never declared")
 
 
 def test_peripheral_without_db_path_is_not_broken(tmp_path):


### PR DESCRIPTION
Two independent correctness fixes, each with a regression test that **fails on `master` and passes with the change**. Verified together: 5 failures on a clean `master` checkout, 0 with the fixes, and 29332 tests / 0 failures on the full suite.

---

### 1. `_get_riscv_reg_map` returns `None` on its first call

It populates `_REG_MAPS_CACHE` and then falls off the end without returning. Only the **first** call for `riscv` is affected — the second reads the cache and looks correct — and in a real run that first call is the first `write_register` during bring-up, so the target dies with

```
'NoneType' object has no attribute 'get'
```

before any firmware executes. **A riscv32 target does not boot on `master` today.**

**The test is the part worth reviewing.** The existing suite structurally cannot catch this: constructing a backend never dereferences the register map, and any earlier test that touches an architecture warms the cache for everything after it, so by the time a riscv test runs the defect is invisible. `test_reg_map_cold_cache.py` evicts `_REG_MAPS_CACHE` first, and does it for **every** per-arch map — so the next architecture added is covered without anyone having to remember. It fails on `master` with three failures: the cold call, cold/warm agreement, and the public `_reg_map_for_arch` path.

---

### 2. MMIO tracing is forced on for every run, and `**kwargs` is treated as consent

`_instantiate_peripheral` forwards `db_path` whenever a peripheral "accepts" it, where accepting includes merely declaring `**kwargs`. Two separate problems:

**`**kwargs` is not consent.** Most peripherals declare one and forward the rest somewhere else, so the current rule injects a `db_path` into peripherals that never asked for one — which is how a catch-all peripheral can start recording MMIO it was never meant to record.

**With no gate, tracing is on for every run.** Recording costs real time inside every MMIO access. The observed cost was a target that booted normally, logged normally, and then failed its protocol round-trip, with the failure nowhere near the cause.

After this change: an explicitly named `db_path` parameter only, and opt in with `HAL_MMIO_TRACE=1`. The record → infer → synthesize workflow is unaffected, since it sets the variable; a normal run keeps its timing.

The tests include ones that pin the **defaults** — `db_path` is not forwarded without the variable, and a `**kwargs`-only constructor is not handed one. Without those, a later change can flip either default silently.

---

### Testing

| | |
|---|---|
| new tests on clean `master` | **5 failures** (3 riscv cold-cache, 2 `db_path` defaults) |
| new tests with these fixes | 0 failures |
| full suite on this branch | **29332 tests, 0 failures, 0 errors** |

Both commits are independent and separately revertable. The `db_path` change alters a default for everyone, so it is deliberately kept out of the riscv commit — different kinds of argument, different review questions.
