### PR TITLE
test: two guards that assert stale facts about their subjects

### DIFF
--- a/src/halucinator/backends/unicorn_backend.py
+++ b/src/halucinator/backends/unicorn_backend.py
@@ -3697,6 +3697,7 @@ class UnicornBackend(InProcessIrqMixin, ARMHalMixin, HalBackend):
                               begin=_ISEN0, end=_ISEN0 + 0x10 - 1)
             self._uc.hook_add(unicorn.UC_HOOK_MEM_WRITE, _icenabler_write,
                               begin=_ICEN0, end=_ICEN0 + 0x10 - 1)
+
     def _effective_vtor(self) -> int:
         """The vector base the firmware is actually using, if discoverable.
 

--- a/test/pytest/backends/test_ghidra_backend.py
+++ b/test/pytest/backends/test_ghidra_backend.py
@@ -73,15 +73,16 @@ def test_exc_return_magic_matches_arm_v7m():
     specifically thread-mode + MSP. inject_irq relies on these exact values
     so the emulator never needs to talk to a real NVIC model.
 
-    The mask is bits 31:5 (0xFFFFFFE0), not the top nibble: on an FPU part
+    The mask is bits 31:7 (0xFFFFFF80), not the top nibble: on an FPU part
     bit 4 carries "no floating-point context stacked", so an FP-context
-    return is 0xFFFFFFE1/E9/ED. Matching only 0xFFFFFFFx would fail to
-    recognise those and the ISR's `bx lr` would branch to an unmapped
-    address."""
+    return is 0xFFFFFFE1/E9/ED, and ARMv8-M adds bit 6 (S) and bit 5 (DCRS)
+    below those, so a non-secure thread return is 0xFFFFFFBC. Matching only
+    0xFFFFFFFx -- or only bits 31:5 -- would fail to recognise those and the
+    ISR's `bx lr` would branch to an unmapped address."""
     from halucinator.backends.ghidra_backend import GhidraBackend
     assert GhidraBackend._EXC_RETURN_THREAD_MSP == 0xFFFFFFF9
-    assert GhidraBackend._EXC_RETURN_MASK == 0xFFFFFFE0
-    assert GhidraBackend._EXC_RETURN_MAGIC == 0xFFFFFFE0
+    assert GhidraBackend._EXC_RETURN_MASK == 0xFFFFFF80
+    assert GhidraBackend._EXC_RETURN_MAGIC == 0xFFFFFF80
     # Sanity-check the mask-match logic — non-FP frames...
     assert (0xFFFFFFF9 & GhidraBackend._EXC_RETURN_MASK) == \
            GhidraBackend._EXC_RETURN_MAGIC
@@ -91,6 +92,9 @@ def test_exc_return_magic_matches_arm_v7m():
     assert (0xFFFFFFE9 & GhidraBackend._EXC_RETURN_MASK) == \
            GhidraBackend._EXC_RETURN_MAGIC
     assert (0xFFFFFFED & GhidraBackend._EXC_RETURN_MASK) == \
+           GhidraBackend._EXC_RETURN_MAGIC
+    # ...and ARMv8-M non-secure returns, which a bits-31:5 window missed.
+    assert (0xFFFFFFBC & GhidraBackend._EXC_RETURN_MASK) == \
            GhidraBackend._EXC_RETURN_MAGIC
     # A normal code address must NOT match
     assert (0x08001234 & GhidraBackend._EXC_RETURN_MASK) != \

--- a/test/pytest/peripheral_models/test_gpio.py
+++ b/test/pytest/peripheral_models/test_gpio.py
@@ -79,7 +79,11 @@ def test_update_gpio_does_not_depend_on_python2_builtins():
         "test harness leaked a raw_input shim into builtins")
     import inspect
     src = inspect.getsource(gpio.update_gpio)
-    assert "raw_input" not in src
+    # Comments are stripped first: the fixed code names the builtin it
+    # replaced, and that prose must not trip the guard.
+    code = "\n".join(line for line in src.splitlines()
+                     if not line.lstrip().startswith("#"))
+    assert "raw_input" not in code
     assert "send_string" in src, (
         "encode_zmq_msg returns str; plain send() raises TypeError on it")
 


### PR DESCRIPTION
Two test guards on `master` assert things that are no longer true of the code they guard. Both are silent in CI — one is skipped without an optional dependency, the other only trips once the bug it guards is actually fixed — so neither has ever failed a run, and both fail locally today.

### 1. `test_exc_return_magic_matches_arm_v7m`

Pins `_EXC_RETURN_MASK` to the v7-M window, bits 31:5 (`0xFFFFFFE0`). `InProcessIrqMixin` widened it to bits 31:7 (`0xFFFFFF80`) so ARMv8-M non-secure returns are recognised: v8-M puts two more flags below the v7-M ones (bit 6 = S, bit 5 = DCRS), so a plain non-secure thread return is `0xFFFFFFBC`, which a `0xFFFFFFE0` window misses. Nothing complains when that happens — the value is not taken for an exception return, the ISR's `bx lr` branches to `0xFFFFFFBC` as if it were an address, and the core faults there for the rest of the run while the host side carries on reporting a healthy boot.

The test is `skipif not _HAVE_PYGHIDRA`, so CI never runs it. With pyghidra installed it fails:

```
assert GhidraBackend._EXC_RETURN_MASK == 0xFFFFFFE0
E  AssertionError: assert 4294967168 == 4294967264
```

Updated to pin the widened value, and the sweep now covers the v8-M encoding alongside the existing non-FP and FP frames.

### 2. `test_update_gpio_does_not_depend_on_python2_builtins`

Greps the entire source of `update_gpio` for `raw_input`. The fix for that bug left a comment naming the builtin it replaced (`# \`input\`, not Python 2's \`raw_input\` — this loop used to raise NameError on its first iteration`), which trips the guard on prose rather than code. Comment lines are now stripped before the check; `send_string` still checks the full source.

### Also

Restores the blank line between `_init_gic_hooks`'s last `hook_add` and `def _effective_vtor`.

### Testing

Full suite on macOS/py3.9: `29261 passed, 43 skipped, 28 xfailed, 27 xpassed`. The one remaining failure, `test_rx_from_emulator_bug_fixed`, is a pre-existing macOS-only flake documented in its own docstring (passes in isolation and in every directory subset; a `peripheral_server` singleton not fully reset across a full run's setup/teardown cycles) and is untouched here.